### PR TITLE
Feature/widget editor cms

### DIFF
--- a/components/admin/widget/form/steps/Step1.js
+++ b/components/admin/widget/form/steps/Step1.js
@@ -118,6 +118,7 @@ class Step1 extends React.Component {
 
         <WidgetEditor
           dataset={dataset}
+          availableVisualizations={['chart']}
         />
 
         <Field

--- a/components/widgets/ChartEditor.js
+++ b/components/widgets/ChartEditor.js
@@ -29,28 +29,25 @@ class ChartEditor extends React.Component {
     const { dataset, tableName, jiminy, fields, widgetEditor } = this.props;
     const { chartType } = widgetEditor;
 
+    const chartOptions = (
+        jiminy
+        && jiminy.general
+        && jiminy.general.map(val => ({ label: val, value: val }))
+      ) || [];
+
     return (
       <div className="c-chart-editor">
         <div className="chart-type">
           <h5>Chart type</h5>
-          {
-              jiminy && jiminy.general &&
-              <Select
-                properties={{
-                  className: 'chart-type-selector',
-                  name: 'chart-type',
-                  value: chartType
-                }}
-                options={jiminy.general.map(val => (
-                  {
-                    label: val,
-                    value: val
-                  }
-                ))}
-                onChange={this.handleChartTypeChange}
-
-              />
-          }
+          <Select
+            properties={{
+              className: 'chart-type-selector',
+              name: 'chart-type',
+              value: chartType
+            }}
+            options={chartOptions}
+            onChange={this.handleChartTypeChange}
+          />
         </div>
         <div className="actions-div">
           <div className="fields">
@@ -87,7 +84,7 @@ class ChartEditor extends React.Component {
 
 ChartEditor.propTypes = {
   tableName: PropTypes.string.isRequired,
-  jiminy: PropTypes.object.isRequired,
+  jiminy: PropTypes.object,
   fields: PropTypes.object.isRequired,
   dataset: PropTypes.string.isRequired, // Dataset ID
   // Store

--- a/components/widgets/WidgetEditor.js
+++ b/components/widgets/WidgetEditor.js
@@ -220,21 +220,14 @@ class WidgetEditor extends React.Component {
     });
   }
 
-  render() {
-    const {
-      loading,
-      tableName,
-      selectedVisualizationType,
-      jiminy,
-      fields,
-      chartLoading
-    } = this.state;
-    const { dataset, widgetEditor } = this.props;
+  getVisualization() {
+    const { tableName, selectedVisualizationType, chartLoading } = this.state;
+    const { widgetEditor } = this.props;
     const { chartType, layer } = widgetEditor;
 
     let visualization = null;
-
     switch (selectedVisualizationType) {
+
       case 'chart':
         if (!tableName) {
           visualization = (
@@ -267,6 +260,7 @@ class WidgetEditor extends React.Component {
           );
         }
         break;
+
       case 'map':
         if (layer) {
           visualization = (
@@ -276,7 +270,7 @@ class WidgetEditor extends React.Component {
                 mapConfig={mapConfig}
                 layersActive={[layer]}
               />
-            {/*<Legend
+              {/* <Legend
                 layersActive={[layer]}
                 className={{ color: '-dark' }}
               />*/}
@@ -288,6 +282,25 @@ class WidgetEditor extends React.Component {
 
     }
 
+    return visualization;
+  }
+
+  render() {
+    const {
+      loading,
+      tableName,
+      selectedVisualizationType,
+      jiminy,
+      fields
+    } = this.state;
+    const { dataset } = this.props;
+
+    const visualization = this.getVisualization();
+
+    // We filter out the visualizations that aren't present in
+    // this.props.availableVisualizations
+    const visualizationsOptions = VISUALIZATION_TYPES
+      .filter(viz => this.props.availableVisualizations.includes(viz.value));
 
     return (
       <div className="c-widget-editor">
@@ -308,7 +321,7 @@ class WidgetEditor extends React.Component {
                     name: 'visualization-type',
                     value: selectedVisualizationType
                   }}
-                  options={VISUALIZATION_TYPES}
+                  options={visualizationsOptions}
                   onChange={this.handleVisualizationTypeChange}
                 />
               </div>
@@ -344,9 +357,16 @@ const mapDispatchToProps = dispatch => ({
 
 WidgetEditor.propTypes = {
   dataset: PropTypes.string, // Dataset ID
+  availableVisualizations: PropTypes.arrayOf(
+    PropTypes.oneOf(VISUALIZATION_TYPES.map(viz => viz.value))
+  ),
   // Store
   widgetEditor: PropTypes.object,
   resetWidgetEditor: PropTypes.func.isRequired
+};
+
+WidgetEditor.defaultProps = {
+  availableVisualizations: VISUALIZATION_TYPES.map(viz => viz.value)
 };
 
 export default withRedux(initStore, mapStateToProps, mapDispatchToProps)(WidgetEditor);


### PR DESCRIPTION
This PR makes two changes to the widget editor:

1. The chart selector is always present in the UI whether or not the fields and Jiminy's results have been loaded. By doing so, the UI stays consistent.

2. The `WidgetEditor` component can get passed a new prop, `availableVisualizations`, which consists of an array of the types of visualisation we want the user to be able to select. By default, all the options defined in  `VISUALIZATION_TYPES ` are available, but they are restricted to just `['chart']` in the back-office (via the prop).