### PR TITLE
Feature/custom select input

### DIFF
--- a/components/ui/SearchSelect.js
+++ b/components/ui/SearchSelect.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 
 export default class SearchSelect extends React.Component {
@@ -78,7 +79,7 @@ export default class SearchSelect extends React.Component {
         const filteredOptions = this.props.options.filter(item => item.label
           .toLowerCase().match(value.toLowerCase()));
         this.setState({ filteredOptions }, () => {
-          this.props.onKeyPressed && this.props.onKeyPressed({ value }, [], 'name');
+          if (this.props.onKeyPressed) this.props.onKeyPressed({ value }, [], 'name');
         });
         break;
       }
@@ -109,7 +110,7 @@ export default class SearchSelect extends React.Component {
   selectItem(item) {
     this.setState({ selectedItem: item });
     this.close();
-    this.props.onValueChange && this.props.onValueChange(item);
+    if (this.props.onValueChange) this.props.onValueChange(item);
   }
 
   toggle() {
@@ -122,7 +123,7 @@ export default class SearchSelect extends React.Component {
     window.addEventListener('click', this.onScreenClick);
 
     this.setState({ closed: false }, () => {
-      this.input && this.input.focus();
+      if (this.input) this.input.focus();
     });
   }
 
@@ -140,8 +141,8 @@ export default class SearchSelect extends React.Component {
   render() {
     // Class names
     const cNames = ['c-custom-select -search'];
-    this.props.className && cNames.push(this.props.className);
-    this.state.closed && cNames.push('-closed');
+    if (this.props.className) cNames.push(this.props.className);
+    if (this.state.closed) cNames.push('-closed');
 
     const noResults = !!(this.props.options.length && !this.state.filteredOptions.length);
 
@@ -173,7 +174,7 @@ export default class SearchSelect extends React.Component {
               return (
                 <li
                   className={cName}
-                  key={index}
+                  key={item.label}
                   onMouseEnter={() => { this.setSelectedIndex(index); }}
                   onMouseDown={() => this.selectItem(item)}
                 >
@@ -189,11 +190,11 @@ export default class SearchSelect extends React.Component {
 }
 
 SearchSelect.propTypes = {
-  options: React.PropTypes.array,
-  hideList: React.PropTypes.bool,
-  value: React.PropTypes.string,
-  className: React.PropTypes.string,
-  placeholder: React.PropTypes.string,
-  onValueChange: React.PropTypes.func,
-  onKeyPressed: React.PropTypes.func
+  options: PropTypes.array,
+  hideList: PropTypes.bool,
+  value: PropTypes.string,
+  className: PropTypes.string,
+  placeholder: PropTypes.string,
+  onValueChange: PropTypes.func,
+  onKeyPressed: PropTypes.func
 };

--- a/components/ui/SearchSelect.js
+++ b/components/ui/SearchSelect.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 
+// Components
+import Icon from 'components/ui/Icon';
+
 export default class SearchSelect extends React.Component {
   constructor(props) {
     super(props);
@@ -150,10 +153,10 @@ export default class SearchSelect extends React.Component {
       <div ref={(node) => { this.el = node; }} className={cNames.join(' ')}>
         <span className="custom-select-text" onClick={this.toggle}>
           <div>
-            <span>{this.state.value ?
-              this.state.value :
-              this.props.placeholder}
-            </span>
+            <span>{ this.state.value ? this.state.value : this.props.placeholder }</span>
+            <button className="icon-btn" onClick={this.toggle}>
+              <Icon name="icon-search" className="-small" />
+            </button>
           </div>
           <input
             ref={(node) => { this.input = node; }}

--- a/css/components/ui/custom_select.scss
+++ b/css/components/ui/custom_select.scss
@@ -49,6 +49,7 @@
   }
 
   .icon-btn {
+    display: flex; // Vertically align the icon
     border: 0;
     background: none;
     cursor: pointer;

--- a/css/components/ui/custom_select.scss
+++ b/css/components/ui/custom_select.scss
@@ -42,9 +42,9 @@
     }
   }
 
-  &:not(.-closed).-search {
-    .custom-select-text span {
-      opacity: 0;
+  &.-search:not(.-closed) {
+    .custom-select-text > div {
+      display: none;
     }
   }
 
@@ -93,7 +93,9 @@
       white-space: nowrap;
       line-height: 17px;
       align-items: center;
-      text-transform: capitalize;
+      // Don't capitalise the text here because the case of the
+      // content of the input won't match the case of the text
+      // when the focus is somewhere else
     }
   }
 
@@ -180,5 +182,6 @@
     // padding-bottom: 2px;
     z-index: 10;
     padding: 10px 20px;
+    font-family: $base-font-family;
   }
 }


### PR DESCRIPTION
<p align="center">
<img width="403" alt="Search input on the explore page" src="https://user-images.githubusercontent.com/6073968/27783841-bbf6dc94-5fcf-11e7-8ba3-eee43b0179e5.png">
</p>

This PR improves the search input component, `CustomSelect`, notably on the explore page:
* The input now has a small icon on its right side (1)
* The placeholder doesn't overlap the input's content anymore (2)
* Some eslint errors have been removed

[Pivotal task 1](https://www.pivotaltracker.com/story/show/148062407)
[Pivotal task 2](https://www.pivotaltracker.com/story/show/148062335)