### PR TITLE
CMS - Search for a dataset on the listing page

### DIFF
--- a/components/admin/dataset/pages/index.js
+++ b/components/admin/dataset/pages/index.js
@@ -1,23 +1,84 @@
 import React from 'react';
-import DatasetTable from 'components/admin/dataset/table/DatasetTable';
-import ButtonContainer from 'components/ui/ButtonContainer';
+import PropTypes from 'prop-types';
+import { Autobind } from 'es-decorators';
 
-export default function DatasetIndex() {
-  return (
-    <div className="c-datasets-index">
-      <ButtonContainer
-        className="-j-end"
-        buttons={[{
-          label: 'New Dataset',
-          route: 'admin_data_detail',
-          params: { tab: 'datasets', id: 'new' },
-          className: 'c-button -secondary'
-        }]}
-      />
-      <DatasetTable
-        application={['rw']}
-        authorization={process.env.TEMP_TOKEN}
-      />
-    </div>
-  );
+// Next
+import { Link } from 'routes';
+
+// Redux
+import withRedux from 'next-redux-wrapper';
+import { initStore } from 'store';
+import { setFilters } from 'redactions/admin/datasets';
+
+// Components
+import DatasetTable from 'components/admin/dataset/table/DatasetTable';
+import CustomSelect from 'components/ui/CustomSelect';
+
+class DatasetIndex extends React.Component {
+  /**
+   * Event handler executed when the user search for a dataset
+   * @param {string} { value } Search keywords
+   */
+  @Autobind
+  onSearch({ value }) {
+    if (!value.length) {
+      this.props.setFilters([]);
+    } else {
+      this.props.setFilters([{ key: 'name', value }]);
+    }
+  }
+
+  /**
+   * Return the dataset options for the search input
+   * @returns {{ label: string, value: string }}
+   */
+  getSelectOptions() {
+    return this.props.datasets.map(dataset => ({
+      label: dataset.attributes.name,
+      value: dataset.id
+    }));
+  }
+
+  render() {
+    return (
+      <div className="c-datasets-index">
+        <div className="actions">
+          <CustomSelect
+            options={this.getSelectOptions()}
+            onKeyPressed={this.onSearch}
+            search
+            placeholder="Search dataset"
+            hideList
+          />
+          <Link route="admin_data_detail" params={{ tab: 'datasets', id: 'new' }}>
+            <a className="c-button -secondary">New Dataset</a>
+          </Link>
+        </div>
+        <DatasetTable
+          application={['rw']}
+          authorization={process.env.TEMP_TOKEN}
+        />
+      </div>
+    );
+  }
 }
+
+DatasetIndex.propTypes = {
+  datasets: PropTypes.array.isRequired,
+  // Redux
+  setFilters: PropTypes.func.isRequired
+};
+
+DatasetIndex.defaultProps = {
+  datasets: []
+};
+
+const mapStateToProps = ({ datasets }) => ({
+  datasets: datasets.datasets.list
+});
+
+const mapDispatchToProps = dispatch => ({
+  setFilters: filters => dispatch(setFilters(filters))
+});
+
+export default withRedux(initStore, mapStateToProps, mapDispatchToProps)(DatasetIndex);

--- a/components/admin/dataset/table/DatasetTable.js
+++ b/components/admin/dataset/table/DatasetTable.js
@@ -6,6 +6,9 @@ import withRedux from 'next-redux-wrapper';
 import { initStore } from 'store';
 import { getDatasets } from 'redactions/admin/datasets';
 
+// Selectors
+import getFilteredDatasets from 'selectors/admin/datasets';
+
 // Components
 import Spinner from 'components/ui/Spinner';
 import CustomTable from 'components/ui/customtable/CustomTable';
@@ -89,10 +92,10 @@ DatasetTable.propTypes = {
   getDatasets: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ datasets }) => ({
-  loading: datasets.datasets.loading,
-  datasets: datasets.datasets.list,
-  error: datasets.datasets.error
+const mapStateToProps = state => ({
+  loading: state.datasets.datasets.loading,
+  datasets: getFilteredDatasets(state),
+  error: state.datasets.datasets.error
 });
 const mapDispatchToProps = dispatch => ({
   getDatasets: () => dispatch(getDatasets())

--- a/css/components/admin/dataset/datasets_index.scss
+++ b/css/components/admin/dataset/datasets_index.scss
@@ -1,0 +1,17 @@
+.c-datasets-index {
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+
+    > .c-custom-select {
+      margin-right: 20px;
+    }
+
+    > .c-button {
+      flex-basis: 140px;
+      flex-shrink: 0;
+    }
+  }
+}

--- a/css/components/ui/custom_select.scss
+++ b/css/components/ui/custom_select.scss
@@ -77,7 +77,6 @@
     font-size: $font-size-big;
     font-weight: normal;
     line-height: 2;
-    color: palette(white);
     display: block;
     width: 100%;
     position: relative;
@@ -172,7 +171,7 @@
   .custom-select-search {
     background-color: transparent;
     cursor: pointer;
-    color: $color-white;
+    color: $base-font-color;
     outline: none;
     border: none;
     position: absolute;

--- a/css/index.scss
+++ b/css/index.scss
@@ -80,6 +80,7 @@
 // ================== ADMIN ======================
 
 // Datasets
+@import "./components/admin/dataset/datasets_index";
 @import "./components/admin/dataset/card";
 @import "./components/admin/dataset/filter";
 @import "./components/admin/dataset/filter-item";

--- a/redactions/admin/datasets.js
+++ b/redactions/admin/datasets.js
@@ -6,16 +6,19 @@ import 'isomorphic-fetch';
 const GET_DATASETS_SUCCESS = 'datasets/GET_DATASETS_SUCCESS';
 const GET_DATASETS_ERROR = 'datasets/GET_DATASETS_ERROR';
 const GET_DATASETS_LOADING = 'datasets/GET_DATASETS_LOADING';
+const SET_DATASETS_FILTERS = 'datasets/SET_DATASETS_FILTERS';
 
 /**
  * STORE
- * @property {?string} datasets.error
+ * @property {string} datasets.error
+ * @property {{ key: string, value: string|number }[]} datasets.filters
  */
 const initialState = {
   datasets: {
     list: [],       // Actual list of datasets
     loading: false, // Are we loading the data?
-    error: null     // An error was produced while loading the data
+    error: null,    // An error was produced while loading the data
+    filters: []     // Filters for the list of datasets
   }
 };
 
@@ -52,6 +55,11 @@ export default function (state = initialState, action) {
       return Object.assign({}, state, { datasets });
     }
 
+    case SET_DATASETS_FILTERS: {
+      const datasets = Object.assign({}, state.datasets, { filters: action.payload });
+      return Object.assign({}, state, { datasets });
+    }
+
     default:
       return state;
   }
@@ -81,4 +89,16 @@ export function getDatasets(applications = ['rw']) {
       .then(({ data }) => dispatch({ type: GET_DATASETS_SUCCESS, payload: data }))
       .catch(err => dispatch({ type: GET_DATASETS_ERROR, payload: err.message }));
   };
+}
+
+/**
+ * Set the filters for the list of datasets
+ * @export
+ * @param {{ key: string, value: string|number }[]} filters List of filters
+ */
+export function setFilters(filters) {
+  return dispatch => dispatch({
+    type: SET_DATASETS_FILTERS,
+    payload: filters
+  });
 }

--- a/redactions/admin/datasets.js
+++ b/redactions/admin/datasets.js
@@ -1,0 +1,84 @@
+import 'isomorphic-fetch';
+
+/**
+ * CONSTANTS
+*/
+const GET_DATASETS_SUCCESS = 'datasets/GET_DATASETS_SUCCESS';
+const GET_DATASETS_ERROR = 'datasets/GET_DATASETS_ERROR';
+const GET_DATASETS_LOADING = 'datasets/GET_DATASETS_LOADING';
+
+/**
+ * STORE
+ * @property {?string} datasets.error
+ */
+const initialState = {
+  datasets: {
+    list: [],       // Actual list of datasets
+    loading: false, // Are we loading the data?
+    error: null     // An error was produced while loading the data
+  }
+};
+
+/**
+ * REDUCER
+ * @export
+ * @param {initialState} state
+ * @param {{ type: string, payload: any }} action
+ */
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case GET_DATASETS_LOADING: {
+      const datasets = Object.assign({}, state.datasets, {
+        loading: true,
+        error: null
+      });
+      return Object.assign({}, state, { datasets });
+    }
+
+    case GET_DATASETS_SUCCESS: {
+      const datasets = Object.assign({}, state.datasets, {
+        list: action.payload,
+        loading: false,
+        error: null
+      });
+      return Object.assign({}, state, { datasets });
+    }
+
+    case GET_DATASETS_ERROR: {
+      const datasets = Object.assign({}, state.datasets, {
+        loading: false,
+        error: action.payload
+      });
+      return Object.assign({}, state, { datasets });
+    }
+
+    default:
+      return state;
+  }
+}
+
+/**
+ * ACTIONS
+ */
+
+/**
+ * Retrieve the list of datasets
+ * @export
+ * @param {string[]} applications Name of the applications to load the datasets from
+ */
+export function getDatasets(applications = ['rw']) {
+  return (dispatch) => {
+    dispatch({ type: GET_DATASETS_LOADING });
+
+    // TODO: remove the date now
+    // ⬆️ Copied from redations/explore.js, no idea what
+    // the date is used for
+    fetch(new Request(`${process.env.WRI_API_URL}/dataset?application=${applications.join(',')}&status=saved&includes=widget,layer,metadata,vocabulary&page[size]=${Date.now() / 100000}`))
+      .then((response) => {
+        if (response.ok) return response.json();
+        throw new Error(response.statusText);
+      })
+      .then(({ data }) => dispatch({ type: GET_DATASETS_SUCCESS, payload: data }))
+      .catch(err => dispatch({ type: GET_DATASETS_ERROR, payload: err.message }));
+  };
+}

--- a/redactions/index.js
+++ b/redactions/index.js
@@ -8,3 +8,4 @@ export { default as tooltip } from './tooltip';
 export { default as staticPages } from './static_pages';
 export { default as modal } from './modal';
 export { default as widgetEditor } from './widgetEditor';
+export { default as datasets } from './admin/datasets';

--- a/selectors/admin/datasets.js
+++ b/selectors/admin/datasets.js
@@ -1,0 +1,28 @@
+import { createSelector } from 'reselect';
+
+const datasets = state => state.datasets.datasets.list;
+const filters = state => state.datasets.datasets.filters;
+
+/**
+ * Return the datasets that comply with the filters
+ * @param {object[]} datasets Datasets to filter
+ * @param {{ key: string, value: string|number }[]} filters Filters to apply to the datasets
+ */
+const getFilteredDatasets = (datasets, filters) => { // eslint-disable-line no-shadow
+  if (!filters.length) return datasets;
+
+  return datasets.filter((dataset) => { // eslint-disable-line arrow-body-style
+    return filters.every((filter) => {
+      if (filter.key === 'id') return dataset.id === filter.value;
+      if (!dataset.attributes[filter.key]) return false;
+
+      if (typeof filter.value === 'string') {
+        return dataset.attributes[filter.key].toLowerCase().match(filter.value.toLowerCase());
+      }
+
+      return dataset.attributes[filter.key] === filter.value;
+    });
+  });
+};
+
+export default createSelector(datasets, filters, getFilteredDatasets);


### PR DESCRIPTION
This PR lets the user filter the datasets by name on the listing page of the CMS.

<p align="center">
<img width="1124" alt="Screenshot of the listing page with the search input" src="https://user-images.githubusercontent.com/6073968/27826844-9adf4eaa-60ac-11e7-9b46-d7ef25c2fc6b.png">
</p>

In order to bring the functionality, a numerous number of changes have been necessary. Here are the main changes:
* `DatasetTable` doesn't store the list of datasets anymore, Redux's store does
* A new selector (from `reselect`) has been created to filter the datasets

[Pivotal task](https://www.pivotaltracker.com/story/show/144274023)