### PR TITLE
Widget chart improvements

### DIFF
--- a/components/widgets/WidgetEditor.js
+++ b/components/widgets/WidgetEditor.js
@@ -178,14 +178,14 @@ class WidgetEditor extends React.Component {
 
   getChartConfig() {
     const { widgetEditor } = this.props;
-    const { value, size, color, chartType } = widgetEditor;
+    const { category, value, size, color, chartType } = widgetEditor;
 
     return CHART_TYPES[chartType]({
       // In the future, we could pass the type of the columns so the chart
       // could select the right scale
       columns: {
-        x: { present: true },
-        y: { present: !!value },
+        x: { present: true, type: category.type },
+        y: { present: !!value, type: value.type },
         color: { present: !!color },
         size: { present: !!size }
       },

--- a/utils/widgets/bar.js
+++ b/utils/widgets/bar.js
@@ -19,7 +19,8 @@ const defaultChart = {
       type: 'linear',
       range: 'height',
       domain: { data: 'table', field: 'y' },
-      nice: true
+      nice: true,
+      zero: false
     }
   ],
   axes: [
@@ -55,7 +56,7 @@ const defaultChart = {
           x: { scale: 'x', field: 'x' },
           width: { scale: 'x', band: true, offset: -3 },
           y: { scale: 'y', field: 'y' },
-          y2: { scale: 'y', value: 0 }
+          "y2": {"field": {"group": "height"}}
         }
       }
     }
@@ -92,6 +93,17 @@ export default function ({ columns, data }) {
       "scale": "c",
       "field": "color"
     };
+  }
+
+  // If the x column is a date, we need to use a
+  // a temporal x axis and parse the x column as a date
+  if (columns.x.type === 'date') {
+    // We update the axis
+    const xAxis = config.axes.find(axis => axis.type === 'x');
+    xAxis.formatType = 'time';
+
+    // We parse the x column as a date
+    config.data[0].format.parse = { x: 'date' };
   }
 
   return config;

--- a/utils/widgets/line.js
+++ b/utils/widgets/line.js
@@ -19,12 +19,13 @@ const defaultChart = {
       name: 'y',
       type: 'linear',
       range: 'height',
+      zero: false,
       nice: true,
       domain: { data: 'table', field: 'y' }
     }
   ],
   axes: [
-    { type: 'x', scale: 'x', ticks: 20 },
+    { type: 'x', scale: 'x', ticks: 6 },
     { type: 'y', scale: 'y' }
   ],
   marks: [
@@ -33,7 +34,7 @@ const defaultChart = {
       from: { data: 'table' },
       properties: {
         enter: {
-          interpolate: { value: 'monotone' },
+          interpolate: { value: 'linear' },
           x: { scale: 'x', field: 'x' },
           y: { scale: 'y', field: 'y' },
           y2: { scale: 'y', value: 0 },
@@ -59,6 +60,17 @@ export default function ({ columns, data }) {
     "type": "json",
     "property": data.property
   };
+
+  // If the x column is a date, we need to use a
+  // temporal x scale and parse the x column as a date
+  if (columns.x.type === 'date') {
+    // We update the scale
+    const xScale = config.scales.find(scale => scale.name === 'x');
+    xScale.type = 'utc';
+
+    // We parse the x column as a date
+    config.data[0].format.parse = { x: 'date' };
+  }
 
   return config;
 };


### PR DESCRIPTION
<p align="center">
<img width="1010" alt="Example of a line chart" src="https://user-images.githubusercontent.com/6073968/27855594-f252d736-6162-11e7-8b78-7864df1dd12d.png">
</p>

This PR brings a few improvements to the bar and line charts:
- both charts now support a temporal x axis
- both charts won't necessarily have an y axis that starts with 0
- line charts will have *approximatively* 6 ticks on the x axis
- lines of the line charts will be sharp (no interpolation)

[Pivotal task](https://www.pivotaltracker.com/story/show/148241329)