### PR TITLE
Layout issues with the widget editor

### DIFF
--- a/css/components/widgets/dimensions_container.scss
+++ b/css/components/widgets/dimensions_container.scss
@@ -1,6 +1,12 @@
 .c-dimensions-container {
   .c-column-container {
     margin-bottom: $space-1;
+    // Here we prevent the columns from growing too much
+    // This isn't an ideal solution at all, but that's the
+    // easiest that doesn't reduce the usability of the tool
+    // (i.e. the user can still see the full name of the column)
+    max-width: 172px;
+    overflow-x: scroll;
     &:last-child { margin-bottom: 0; }
   }
 }

--- a/css/components/widgets/fields_container.scss
+++ b/css/components/widgets/fields_container.scss
@@ -1,15 +1,22 @@
 .c-fields-container {
+  // We prevent the columns with long names to
+  // take too much space
+  flex-grow: 0;
+  flex-basis: 160px;
+  overflow: hidden;
 
+  // This is the direct ancestor of the columns
+  // We limit the height of it so the widget editor
+  // doesn't get too high
   .fields {
-    max-width: 150px;
-    max-height: 220px;
-    overflow-y: auto;
-    overflow-x: hidden;
-
-    float: left;
-    clear: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    overflow: auto;
+    max-height: 330px;
 
     .c-columnbox {
+      flex-shrink: 0;
       margin-bottom: $space-1;
       &:last-child { margin-bottom: 0; }
     }

--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -6,7 +6,9 @@
   .customize-visualization {
     position: relative;
     min-height: 630px;
-    max-height: 630px;
+    // We don't set a max-height because the height will be
+    // determined by the number of columns so the max-height
+    // will be defined in c-fields-container
     min-width: 430px;
     max-width: 430px;
     margin-top: -20px;


### PR DESCRIPTION
This PR fixes two issues with the layout of the widget editors:
- Several columns could be displayed on the same lines
- Columns with long names would break the layout if placed in a box container

The solution is to use overflow everywhere. It doesn't reduce the usability but that's not an ideal solution either. Here are the list of issues that haven't been addressed:
- To see the full name of the columns the user might be forced to scroll horizontally
- To access the aggregation functions, the user might have to scroll horizontally

I've created [a task on Pivotal](https://www.pivotaltracker.com/story/show/148330129) so Dani can review the design and maybe give us some solutions to the remaining issues.

[Pivotal task](https://www.pivotaltracker.com/story/show/148324491)