### PR TITLE
Published dataset

### DIFF
--- a/components/admin/dataset/form/constants.js
+++ b/components/admin/dataset/form/constants.js
@@ -69,6 +69,7 @@ export const STATE_DEFAULT = {
     provider: '',
     connectorType: '',
     connectorUrlHint: '',
+    published: false,
 
     // STEP 2
     connectorUrl: '',

--- a/components/admin/dataset/form/steps/Step1.js
+++ b/components/admin/dataset/form/steps/Step1.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-// Utils
-import { substitution } from 'utils/utils';
+// Redux
+import withRedux from 'next-redux-wrapper';
+import { initStore } from 'store';
 
 // Constants
 import { PROVIDER_TYPES_DICTIONARY, FORM_ELEMENTS } from 'components/admin/dataset/form/constants';
@@ -12,6 +14,7 @@ import Input from 'components/form/Input';
 import File from 'components/form/File';
 import Select from 'components/form/SelectInput';
 import Title from 'components/ui/Title';
+import Checkbox from 'components/form/Checkbox';
 
 class Step1 extends React.Component {
   constructor(props) {
@@ -59,6 +62,7 @@ class Step1 extends React.Component {
 
 
   render() {
+    const { user } = this.props;
     const { dataset } = this.state;
     const { provider } = this.state.form;
 
@@ -81,6 +85,24 @@ class Step1 extends React.Component {
           <Title className="form-title -big -secondary">
             Edit dataset
           </Title>
+        }
+
+        {user.role === 'ADMIN' &&
+          <Field
+            ref={(c) => { if (c) FORM_ELEMENTS.elements.published = c; }}
+            onChange={value => this.props.onChange({ published: value.checked })}
+            validations={['required']}
+            properties={{
+              name: 'published',
+              label: 'Do you want to set this dataset as published?',
+              value: 'published',
+              title: 'Published',
+              defaultChecked: (!dataset) ? user.role === 'ADMIN' : this.props.form.published,
+              checked: this.props.form.published
+            }}
+          >
+            {Checkbox}
+          </Field>
         }
 
         <Field
@@ -466,9 +488,16 @@ class Step1 extends React.Component {
 }
 
 Step1.propTypes = {
-  dataset: React.PropTypes.string,
-  form: React.PropTypes.object,
-  onChange: React.PropTypes.func
+  dataset: PropTypes.string,
+  form: PropTypes.object,
+  onChange: PropTypes.func,
+
+  // Store
+  user: PropTypes.object.isRequired
 };
 
-export default Step1;
+const mapStateToProps = state => ({
+  user: state.user
+});
+
+export default withRedux(initStore, mapStateToProps, null)(Step1);

--- a/components/admin/dataset/pages/index.js
+++ b/components/admin/dataset/pages/index.js
@@ -65,6 +65,7 @@ class DatasetIndex extends React.Component {
 }
 
 DatasetIndex.propTypes = {
+  user: PropTypes.object.isRequired,
   datasets: PropTypes.array.isRequired,
   // Redux
   setFilters: PropTypes.func.isRequired

--- a/components/admin/dataset/table/DatasetTable.js
+++ b/components/admin/dataset/table/DatasetTable.js
@@ -19,6 +19,7 @@ import DeleteAction from './actions/DeleteAction';
 
 // TDs
 import NameTD from './td/NameTD';
+import PublishedTD from './td/PublishedTD';
 import StatusTD from './td/StatusTD';
 import RelatedContentTD from './td/RelatedContentTD';
 
@@ -47,6 +48,7 @@ class DatasetTable extends React.Component {
             columns={[
               { label: 'Name', value: 'name', td: NameTD },
               { label: 'Status', value: 'status', td: StatusTD },
+              { label: 'Published', value: 'published', td: PublishedTD },
               { label: 'Provider', value: 'provider' },
               { label: 'Related content', value: 'status', td: RelatedContentTD }
             ]}
@@ -56,6 +58,10 @@ class DatasetTable extends React.Component {
                 { name: 'Edit', route: 'admin_data_detail', params: { tab: 'datasets', subtab: 'edit', id: '{{id}}' }, show: true, component: EditAction },
                 { name: 'Remove', route: 'admin_data_detail', params: { tab: 'datasets', subtab: 'remove', id: '{{id}}' }, component: DeleteAction, componentProps: { authorization: this.props.authorization } }
               ]
+            }}
+            sort={{
+              field: 'name',
+              value: 1
             }}
             filters={false}
             data={this.getDatasets()}

--- a/components/admin/dataset/table/td/PublishedTD.js
+++ b/components/admin/dataset/table/td/PublishedTD.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function PublishedTD(props) {
+  const { value, index } = props;
+
+  return (
+    <td key={index}>
+      {(value) ? 'true' : 'false' }
+    </td>
+  );
+}
+
+PublishedTD.propTypes = {
+  value: PropTypes.string,
+  index: PropTypes.string
+};
+
+export default PublishedTD;

--- a/components/admin/dataset/table/td/PublishedTD.js
+++ b/components/admin/dataset/table/td/PublishedTD.js
@@ -12,7 +12,7 @@ function PublishedTD(props) {
 }
 
 PublishedTD.propTypes = {
-  value: PropTypes.string,
+  value: PropTypes.bool,
   index: PropTypes.string
 };
 

--- a/components/admin/widget/table/WidgetTable.js
+++ b/components/admin/widget/table/WidgetTable.js
@@ -103,6 +103,10 @@ class WidgetTable extends React.Component {
             pageSize: 20,
             page: 0
           }}
+          sort={{
+            field: 'name',
+            value: 1
+          }}
           onToggleSelectedRow={(ids) => {
             console.info(ids);
           }}

--- a/components/ui/customtable/CustomTable.js
+++ b/components/ui/customtable/CustomTable.js
@@ -85,12 +85,16 @@ export default class CustomTable extends React.Component {
     const nextLength = nextProps.data.length;
     const nextColumnsKeys = CustomTable.getColumnKeys(nextProps.data).sort();
 
-    if (currentLength !== nextLength) {
-      // TODO: check if the data has changed to reload all the data or only to filter it
-      this.setState(CustomTable.setTableData(nextProps), () => {
-        this.filter();
-      });
-    }
+
+    // TODO: check if the data has changed to reload all the data or only to filter it
+    // if you only check the length, sometimes you have only edited one dataset,
+    // so the table will not render the new values
+
+    // if (currentLength !== nextLength) {
+    this.setState(CustomTable.setTableData(nextProps), () => {
+      this.filter();
+    });
+    // }
 
     if (!isEqual(currentColumnsKeys, nextColumnsKeys)) {
       this.setState({

--- a/components/ui/customtable/CustomTable.js
+++ b/components/ui/customtable/CustomTable.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import uniq from 'lodash/uniq';
 import flatten from 'lodash/flatten';
 import isEqual from 'lodash/isEqual';
@@ -49,7 +50,7 @@ export default class CustomTable extends React.Component {
     this.state = {
       pagination: props.pagination,
       // Sort
-      sort: {},
+      sort: props.sort,
       // Search
       search: {},
       // Columns
@@ -95,7 +96,7 @@ export default class CustomTable extends React.Component {
       this.setState({
         ...CustomTable.setTableData(nextProps),
         // Sort
-        sort: {},
+        sort: nextProps.sort,
         // Search
         search: {},
         // Columns
@@ -273,13 +274,14 @@ export default class CustomTable extends React.Component {
 
 /* Property typing */
 CustomTable.propTypes = {
-  actions: React.PropTypes.object,
-  columns: React.PropTypes.array,
-  data: React.PropTypes.array,
-  pagination: React.PropTypes.object,
-  filters: React.PropTypes.bool,
-  onToggleSelectedRow: React.PropTypes.func,
-  onRowDelete: React.PropTypes.func
+  actions: PropTypes.object,
+  columns: PropTypes.array,
+  data: PropTypes.array,
+  pagination: PropTypes.object,
+  filters: PropTypes.bool,
+  sort: PropTypes.object,
+  onToggleSelectedRow: PropTypes.func,
+  onRowDelete: PropTypes.func
 };
 
 /* Property default values */
@@ -292,6 +294,7 @@ CustomTable.defaultProps = {
     page: 0,
     total: null
   },
+  sort: {},
   actions: {
     show: true,
     list: [

--- a/css/components/form/checkbox.scss
+++ b/css/components/form/checkbox.scss
@@ -56,8 +56,6 @@
   }
 
   input[type=checkbox]:checked + label {
-    font-weight: 700;
-
     .checkbox-icon {
       &:after {
         transform: translate(-50%,-50%) rotate(-40deg) scale(1);

--- a/pages/admin/pages/edit.js
+++ b/pages/admin/pages/edit.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Router } from '../../../routes';
+import { Router } from 'routes';
 
 // Redux
 import withRedux from 'next-redux-wrapper';
@@ -9,7 +9,7 @@ import { initStore } from 'store';
 // Components
 import Title from 'components/ui/Title';
 import Layout from 'components/admin/layout/Layout';
-import PageForm from 'components/admin/pages/PageForm';
+import PageForm from 'components/admin/pages/form/PageForm';
 
 class PageEdit extends React.Component {
 

--- a/redactions/admin/datasets.js
+++ b/redactions/admin/datasets.js
@@ -78,11 +78,10 @@ export function getDatasets(applications = ['rw']) {
   return (dispatch) => {
     dispatch({ type: GET_DATASETS_LOADING });
 
-    console.log('load datasets!!');
     // TODO: remove the date now
     // ⬆️ Copied from redations/explore.js, no idea what
     // the date is used for
-    fetch(new Request(`${process.env.WRI_API_URL}/dataset?application=${applications.join(',')}&status=saved&includes=widget,layer,metadata,vocabulary&page[size]=${Date.now() / 100000}`))
+    fetch(new Request(`${process.env.WRI_API_URL}/dataset?application=${applications.join(',')}&includes=widget,layer,metadata,vocabulary&page[size]=${Date.now() / 100000}`))
       .then((response) => {
         if (response.ok) return response.json();
         throw new Error(response.statusText);

--- a/redactions/admin/datasets.js
+++ b/redactions/admin/datasets.js
@@ -78,6 +78,7 @@ export function getDatasets(applications = ['rw']) {
   return (dispatch) => {
     dispatch({ type: GET_DATASETS_LOADING });
 
+    console.log('load datasets!!');
     // TODO: remove the date now
     // ⬆️ Copied from redations/explore.js, no idea what
     // the date is used for

--- a/redactions/explore.js
+++ b/redactions/explore.js
@@ -157,7 +157,7 @@ export function getDatasets() {
     // Waiting for fetch from server -> Dispatch loading
     dispatch({ type: GET_DATASETS_LOADING });
     // TODO: remove the date now
-    fetch(new Request(`${process.env.WRI_API_URL}/dataset?application=rw&status=saved&includes=widget,layer,metadata,vocabulary&page[size]=${Date.now() / 100000}`))
+    fetch(new Request(`${process.env.WRI_API_URL}/dataset?application=rw&status=saved&published=true&includes=widget,layer,metadata,vocabulary&page[size]=${Date.now() / 100000}`))
       .then((response) => {
         if (response.ok) return response.json();
         throw new Error(response.statusText);

--- a/redactions/user.js
+++ b/redactions/user.js
@@ -1,5 +1,6 @@
 /* global config */
 import 'isomorphic-fetch';
+import isEmpty from 'lodash/isEmpty';
 
 /**
  * CONSTANTS
@@ -33,5 +34,14 @@ export default function (state = initialState, action) {
  * - setUser
 */
 export function setUser(user) {
-  return dispatch => dispatch({ type: SET_USER, payload: user });
+  let userObj = user;
+
+  // Add 'Bearer' to token
+  if (!isEmpty(user)) {
+    userObj = {
+      ...userObj,
+      token: `Bearer ${userObj.token}`
+    };
+  }
+  return dispatch => dispatch({ type: SET_USER, payload: userObj });
 }

--- a/routes.js
+++ b/routes.js
@@ -13,8 +13,6 @@ routes.add('admin_partners', '/admin/partners/:tab?/:subtab?', 'admin/partners')
 routes.add('admin_pages', '/admin/pages/:tab?/:subtab?', 'admin/pages');
 // USERS
 routes.add('admin_users', '/admin/users/:tab?/:subtab?', 'admin/users');
-// LOGOUT
-routes.add('logout', '/admin/logout', '/');
 
 // ========================= APP ROUTES =====================
 routes.add('home', '/home', 'app/Home');


### PR DESCRIPTION
This PR adds:
- Published dataset checkbox
- Published dataset column
- Filter in explore page

**IMPORTANT!!!!**
I just discovered that the API is not filtering by published. I mean, it does, but it does it wrong. It only sends 30 datasets, but we have 116 datasets published. I already told them that they need to check it out

**UPDATE**
It seems that is working now