### PR TITLE
Feature/widget editor manage errors

### DIFF
--- a/components/widgets/MapEditor.js
+++ b/components/widgets/MapEditor.js
@@ -10,37 +10,7 @@ import { showLayer } from 'redactions/widgetEditor';
 // Components
 import Select from 'components/form/SelectInput';
 
-// Services
-import DatasetService from 'services/DatasetService';
-
 class MapEditor extends React.Component {
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      layers: []
-    };
-
-    this.datasetService = new DatasetService(props.dataset, { apiURL: process.env.WRI_API_URL });
-  }
-
-  componentWillMount() {
-    this.datasetService.getLayers().then((response) => {
-      this.setState({
-        layers: response.map(val => ({
-          id: val.id,
-          name: val.attributes.name,
-          subtitle: val.attributes.subtitle,
-          ...val.attributes,
-          order: 1,
-          hidden: false
-        }))
-      });
-    }).catch((err) => {
-      console.log(err);
-    });
-  }
 
   @Autobind
   handleLayerChange(layerID) {
@@ -48,8 +18,7 @@ class MapEditor extends React.Component {
   }
 
   render() {
-    const { layers } = this.state;
-    const { widgetEditor } = this.props;
+    const { widgetEditor, layers } = this.props;
     const { layer } = widgetEditor;
 
     return (
@@ -79,7 +48,7 @@ class MapEditor extends React.Component {
 
 
 MapEditor.propTypes = {
-  dataset: PropTypes.string.isRequired, // Dataset ID
+  layers: PropTypes.array.isRequired, // Dataset ID
   // Store
   showLayer: PropTypes.func.isRequired,
   widgetEditor: PropTypes.object.isRequired


### PR DESCRIPTION
![screen shot 2017-07-07 at 3 38 59 pm](https://user-images.githubusercontent.com/545342/27960143-73e183c4-632a-11e7-8b0d-4d3f7c08a5a1.png)

This pull request includes a few changes in Explore Detail + Widget Editor that makes the page to hide the component in the case where neither fields nor layers are present. 
Also chart + table view are deactivated when fields cannot be retrieved but the dataset has layers associated to it.