### PR TITLE
Feature/bar chart changes

### DIFF
--- a/components/widgets/VegaChart.js
+++ b/components/widgets/VegaChart.js
@@ -111,8 +111,11 @@ class VegaChart extends React.Component {
   getVegaConfig() {
     const padding = this.props.data.padding || { top: 20, right: 20, bottom: 20, left: 20 };
     const size = {
-      width: this.width - padding.left - padding.right,
-      height: this.height - padding.top - padding.bottom
+      // Please don't change these conditions, the bar chart
+      // needs its height and width to not be overriden to display
+      // properly
+      width: this.props.data.width || (this.width - padding.left - padding.right),
+      height: this.props.data.height || (this.height - padding.top - padding.bottom)
     };
 
     // This signal is used for the tooltip

--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -37,7 +37,9 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    flex-grow: 1;
+    flex-shrink: 1;
+    flex-basis: 100%;
+    overflow-x: auto;
 
     &.-chart {
       margin-left: 20px;

--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -51,7 +51,16 @@
       height: 100%;
 
       .chart {
-        height: calc(100% - 100px);
+        // The height will be set either by VegaChart or Vega itself
+        height: auto;
+
+        .vega {
+          // We can't use display: flex; here otherwise
+          // the user won't be able to see all of the
+          // widgets with scrolling (especially the left
+          // hand side which will be cut)
+          text-align: center;
+        }
       }
     }
   }

--- a/utils/widgets/pie.js
+++ b/utils/widgets/pie.js
@@ -2,6 +2,8 @@ import deepClone from 'lodash/cloneDeep';
 
 /* eslint-disable */
 const defaultChart = {
+  "width": 1,
+  "height": 1,
   "data": [
     {
       "name": "table"

--- a/utils/widgets/theme.js
+++ b/utils/widgets/theme.js
@@ -1,11 +1,12 @@
 import deepClone from 'lodash/cloneDeep';
 
 const defaultTheme = {
-  height: 0,
-  padding: 'strict', // Do not set something different than 'strict'
-                     // or the autopadInset property because it will cause the
-                     // graph to increase its size each time it is rendered
-                     // again
+  height: 0, // Don't touch this without testing all the charts
+             // and particularly the bar chart with or without
+             // scrolling and its vertical alignment
+  padding: 'auto', // Do not set something different than 'auto'
+                   // because it will break several graphs
+                   // (primarly the bar and pie ones)
   marks: {
     color: '#3BB2D0'
   },
@@ -19,7 +20,6 @@ const defaultTheme = {
     tickLabelFontSize: 13
   },
   axis_y: {
-    orient: 'right',
     axisWidth: 0,
     tickSize: 0,
     ticks: 5,


### PR DESCRIPTION
This PR mainly changes the layout of the bar chart.

<img width="636" alt="Screenshot of a bar chart with horizontal scrolling" src="https://user-images.githubusercontent.com/6073968/28174036-3aef40de-67e8-11e7-8ed5-2f229c529241.png">

The changes include the y axis to be positioned on the left, the ticks to be vertical, the bars to have a fixed width and the possibility to have horizontal scrolling if too much bars have to be displayed.

## Warnings

Because of the requested changes, the charts _could_ break the layout of other pages or not being visually centred.

#### Beware of the overflow

You must understand that previously, the component `VegaChart` would compute the available space available for the chart, and the chart would adapt. **This is not the case anymore for the bar and line charts.** Instead, they take as much space as they want.

The pie chart shouldn't give any issue because it should respect the provided space and its size is determined by it

The bar chart is different. Horizontally, it will take the space it needs. **This means that its container should have an horizontal overflow set to `auto`.** Vertically, its size will be **at least 300px** but generally it will be between 350 and 450. If you use `VegaChart` somewhere with a container of smaller height, the bar chart will probably overflow.

#### Visually center the charts

As said previously, all the charts except the bar and pie ones will take all the space they are given. This means that they will be automatically centred both vertically and horizontally.

The pie and bar charts are different: they take all the space they want. This means that if they just need a small amount of space and the container is bigger, the chart won't be centred nor vertically nor horizontally. **You then have to take care to centre them.** **Be careful, you won't be always able to use a flex container:** if you use it with the property `justify-content: center;`, you'll probably cut the graph on the sides when it has an horizontal overflow. Prefer `text-align: center;`. Check [this comment](https://github.com/resource-watch/resource-watch/compare/feature/bar-chart-changes?expand=1#diff-d49891f3649d1a4dd8c2031c01ea6d5dR57) for more information.

#### Bar chart with a few columns

With the new changes, the bars of the bar charts won't have dynamic width anymore. Nothing can be done about it.


