### PR TITLE
Fix/tooltip value

### DIFF
--- a/components/widgets/VegaChart.js
+++ b/components/widgets/VegaChart.js
@@ -54,7 +54,9 @@ class VegaChart extends React.Component {
   onMousemove(vegaConfig, visData, x, item) {
     // If the cursor is on top of a mark, we display the data
     // associated to that mark
-    if (!isEmpty(item) && item.datum.x) {
+    // The only exception is for the lines because the data
+    // they own is always the first one (first point)
+    if (!isEmpty(item) && item.datum.x && item.mark.marktype !== 'line') {
       return this.props.toggleTooltip(true, {
         follow: true,
         children: VegaChartTooltip,

--- a/components/widgets/VegaChart.js
+++ b/components/widgets/VegaChart.js
@@ -88,6 +88,13 @@ class VegaChart extends React.Component {
       const d1 = visData[i];
       data = (d0 && d1 && (x - d0.x > d1.x - x)) ? d1 : d0;
     }
+    if (x instanceof Date) {
+      const bisectDate = bisector(d => d.x).left;
+      const i = bisectDate(sortedVisData, x.getTime(), 1);
+      const d0 = visData[i - 1];
+      const d1 = visData[i];
+      data = (d0 && d1 && (x.getTime() - d0.x > d1.x - x.getTime())) ? d1 : d0;
+    }
 
     if (data) {
       return this.props.toggleTooltip(true, {


### PR DESCRIPTION
This PR fixes two issues related with the tooltip of the Vega charts:
* The tooltip wouldn't show the data of charts using a temporal x axis
* When the user would hover the line of a line chart, the data shown in the tooltip would be the data of the first point

[Pivotal task](https://www.pivotaltracker.com/story/show/148814199)