### PR TITLE
Feature/manual chart data fetching

### DIFF
--- a/components/modal/SaveWidgetModal.js
+++ b/components/modal/SaveWidgetModal.js
@@ -69,7 +69,7 @@ class SaveWidgetModal extends React.Component {
   }
 
   @Autobind
-  onSubmit(event) {
+  async onSubmit(event) {
     event.preventDefault();
 
     this.setState({
@@ -78,22 +78,39 @@ class SaveWidgetModal extends React.Component {
     const { widgetEditor, tableName, dataset } = this.props;
     const { limit, value, category, color, size, orderBy, aggregateFunction, chartType, filters } = widgetEditor;
 
-    const widgetConfig = { widgetConfig: Object.assign(
-      {},
-      { paramsConfig: {
-        limit,
-        value,
-        category,
-        color,
-        size,
-        orderBy,
-        aggregateFunction,
-        chartType,
-        filters
-      }
-      },
-      getChartConfig(widgetEditor, tableName, dataset)
-    ) };
+    let chartConfig;
+    try {
+      chartConfig = await getChartConfig(widgetEditor, tableName, dataset);
+    } catch (err) {
+      this.setState({
+        saved: false,
+        error: true,
+        errorMessage: 'Unable to generate the configuration of the chart'
+      });
+
+      return;
+    }
+
+    const widgetConfig = {
+      widgetConfig: Object.assign(
+        {},
+        {
+          paramsConfig: {
+            limit,
+            value,
+            category,
+            color,
+            size,
+            orderBy,
+            aggregateFunction,
+            chartType,
+            filters
+          }
+        },
+        chartConfig
+      )
+    };
+
     const widgetObj = Object.assign({}, this.state.widget, widgetConfig);
 
     this.widgetService.saveUserWidget(widgetObj, this.props.dataset, this.props.user.token)

--- a/components/widgets/WidgetEditor.js
+++ b/components/widgets/WidgetEditor.js
@@ -349,6 +349,8 @@ class WidgetEditor extends React.Component {
   /**
    * Fetch the Vega chart configuration and store it in
    * the state
+   * NOTE: the vega chart *will* contain the whole dataset
+   * inside and not the URL of the data
    */
   fetchChartConfig() {
     const { widgetEditor, dataset } = this.props;
@@ -356,7 +358,7 @@ class WidgetEditor extends React.Component {
 
     this.setState({ chartConfigLoading: true });
 
-    getChartConfig(widgetEditor, tableName, dataset)
+    getChartConfig(widgetEditor, tableName, dataset, true)
       .then(chartConfig => this.setState({ chartConfig, chartConfigError: null }))
       .catch(({ message }) => this.setState({ chartConfig: null, chartConfigError: message }))
       .then(() => this.setState({ chartConfigLoading: false }));

--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -41,6 +41,17 @@
     flex-basis: 100%;
     overflow-x: auto;
 
+    &.-error {
+      text-align: center;
+
+      span {
+        display: block;
+        margin-top: 10px;
+        font-size: $font-size-small;
+        font-weight: $font-weight-bold;
+      }
+    }
+
     &.-chart {
       margin-left: 20px;
       // This padding avoids the chart to touch the top and

--- a/utils/widgets/1d_scatter.js
+++ b/utils/widgets/1d_scatter.js
@@ -1,4 +1,5 @@
 import deepClone from 'lodash/cloneDeep';
+import isArray from 'lodash/isArray';
 
 /* eslint-disable */
 const defaultChart = {
@@ -50,13 +51,21 @@ const defaultChart = {
  */
 export default function ({ columns, data }) {
   const config = deepClone(defaultChart);
+  // Whether we have access to the data instead
+  // of having its URL
+  const hasAccessToData = isArray(data);
 
-  // We set the URL of the dataset
-  config.data[0].url = data.url;
-  config.data[0].format = {
-    "type": "json",
-    "property": data.property
-  };
+  if (hasAccessToData) {
+    // We directly set the data
+    config.data[0].values = data;
+  } else {
+    // We set the URL of the dataset
+    config.data[0].url = data.url;
+    config.data[0].format = {
+      "type": "json",
+      "property": data.property
+    };
+  }
 
   if (columns.color.present) {
     // We add the color scale

--- a/utils/widgets/1d_tick.js
+++ b/utils/widgets/1d_tick.js
@@ -1,4 +1,5 @@
 import deepClone from 'lodash/cloneDeep';
+import isArray from 'lodash/isArray';
 
 /* eslint-disable */
 const defaultChart = {
@@ -51,13 +52,21 @@ const defaultChart = {
  */
 export default function ({ columns, data }) {
   const config = deepClone(defaultChart);
+  // Whether we have access to the data instead
+  // of having its URL
+  const hasAccessToData = isArray(data);
 
-  // We set the URL of the dataset
-  config.data[0].url = data.url;
-  config.data[0].format = {
-    "type": "json",
-    "property": data.property
-  };
+  if (hasAccessToData) {
+    // We directly set the data
+    config.data[0].values = data;
+  } else {
+    // We set the URL of the dataset
+    config.data[0].url = data.url;
+    config.data[0].format = {
+      "type": "json",
+      "property": data.property
+    };
+  }
 
   if (columns.color.present) {
     // We add the color scale

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -78,6 +78,14 @@ export function canRenderChart(widgetEditor) {
     );
 }
 
+/**
+ * Return the URL of the data needed for the Vega chart
+ * @export
+ * @param {object} widgetEditor Configuration of the widget editor from the store
+ * @param {string} tableName Name of dataset's table
+ * @param {string} dataset ID of the dataset
+ * @returns {string} URL of the data
+ */
 export function getDataURL(widgetEditor, tableName, dataset) {
   const {
     category,
@@ -149,8 +157,39 @@ export function getDataURL(widgetEditor, tableName, dataset) {
   return `${process.env.WRI_API_URL}/query/${dataset}?sql=${query}`;
 }
 
-export function getChartConfig(widgetEditor, tableName, dataset) {
+/**
+ * Fetch the data of the chart
+ * @export
+ * @param {string} url URL of the data
+ * @returns {object[]}
+ */
+export async function fetchData(url) { // eslint-disable-line no-unused-vars
+  // TODO: implement this
+  return setTimeout(() => ({}), 100);
+}
+
+/**
+ * Generate the chart configuration (Vega's) according to the
+ * current state of the store
+ * @export
+ * @param {any} widgetEditor State of the editor (coming from the store)
+ * @param {string} tableName Name of the dataset's table
+ * @param {string} dataset ID of the dataset
+ * @param {boolean} [mustFetchData=false] Whether the the configuration
+ * should store the URL of the raw data (might be needed for smarter
+ * charts)
+ * @returns {object} JSON object
+ */
+export async function getChartConfig(widgetEditor, tableName, dataset, mustFetchData = false) {
   const { category, value, size, color, chartType } = widgetEditor;
+
+  // URL of the data needed to display the chart
+  const url = getDataURL(widgetEditor, tableName, dataset);
+
+  // In case we must fetch the data, we save it in this variable
+  // TODO: conditionally use the data var
+  // eslint-disable-next-line no-unused-vars
+  const data = mustFetchData && fetchData(url);
 
   return CHART_TYPES[chartType]({
     // In the future, we could pass the type of the columns so the chart
@@ -162,7 +201,7 @@ export function getChartConfig(widgetEditor, tableName, dataset) {
       size: { present: !!size }
     },
     data: {
-      url: getDataURL(widgetEditor, tableName, dataset),
+      url,
       property: 'data'
     }
   });

--- a/utils/widgets/bar.js
+++ b/utils/widgets/bar.js
@@ -1,4 +1,5 @@
 import deepClone from 'lodash/cloneDeep';
+import isArray from 'lodash/isArray';
 
 /* eslint-disable */
 const defaultChart = {
@@ -136,13 +137,21 @@ const defaultChart = {
  */
 export default function ({ columns, data }) {
   const config = deepClone(defaultChart);
+  // Whether we have access to the data instead
+  // of having its URL
+  const hasAccessToData = isArray(data);
 
-  // We set the URL of the dataset
-  config.data[0].url = data.url;
-  config.data[0].format = {
-    "type": "json",
-    "property": data.property
-  };
+  if (hasAccessToData) {
+    // We directly set the data
+    config.data[0].values = data;
+  } else {
+    // We set the URL of the dataset
+    config.data[0].url = data.url;
+    config.data[0].format = {
+      "type": "json",
+      "property": data.property
+    };
+  }
 
   if (columns.color.present) {
     // We add the color scale

--- a/utils/widgets/line.js
+++ b/utils/widgets/line.js
@@ -1,4 +1,5 @@
 import deepClone from 'lodash/cloneDeep';
+import isArray from 'lodash/isArray';
 
 /* eslint-disable */
 const defaultChart = {
@@ -53,13 +54,21 @@ const defaultChart = {
  */
 export default function ({ columns, data }) {
   const config = deepClone(defaultChart);
+  // Whether we have access to the data instead
+  // of having its URL
+  const hasAccessToData = isArray(data);
 
-  // We set the URL of the dataset
-  config.data[0].url = data.url;
-  config.data[0].format = {
-    "type": "json",
-    "property": data.property
-  };
+  if (hasAccessToData) {
+    // We directly set the data
+    config.data[0].values = data;
+  } else {
+    // We set the URL of the dataset
+    config.data[0].url = data.url;
+    config.data[0].format = {
+      "type": "json",
+      "property": data.property
+    };
+  }
 
   // If the x column is a date, we need to use a
   // temporal x scale and parse the x column as a date

--- a/utils/widgets/pie.js
+++ b/utils/widgets/pie.js
@@ -1,4 +1,5 @@
 import deepClone from 'lodash/cloneDeep';
+import isArray from 'lodash/isArray';
 
 /* eslint-disable */
 const defaultChart = {
@@ -67,13 +68,22 @@ const defaultChart = {
  */
 export default function ({ columns, data }) {
   const config = deepClone(defaultChart);
+  // Whether we have access to the data instead
+  // of having its URL
+  const hasAccessToData = isArray(data);
 
-  // We set the URL of the dataset
-  config.data[0].url = data.url;
-  config.data[0].format = {
-    "type": "json",
-    "property": data.property,
-  };
+  if (hasAccessToData) {
+    // We directly set the data
+    config.data[0].values = data;
+  } else {
+    // We set the URL of the dataset
+    config.data[0].url = data.url;
+    config.data[0].format = {
+      "type": "json",
+      "property": data.property
+    };
+  }
+
   config.data[0].transform = [{
     "type": "pie", "field": "y"
   }];

--- a/utils/widgets/scatter.js
+++ b/utils/widgets/scatter.js
@@ -1,4 +1,5 @@
 import deepClone from 'lodash/cloneDeep';
+import isArray from 'lodash/isArray';
 
 /* eslint-disable */
 const defaultChart = {
@@ -53,14 +54,21 @@ const defaultChart = {
  */
 export default function ({ columns, data }) {
   const config = deepClone(defaultChart);
+  // Whether we have access to the data instead
+  // of having its URL
+  const hasAccessToData = isArray(data);
 
-  // We set the URL of the dataset
-  config.data[0].url = data.url;
-  config.data[0].format = {
-    "type": "json",
-    "property": data.property
-  };
-
+  if (hasAccessToData) {
+    // We directly set the data
+    config.data[0].values = data;
+  } else {
+    // We set the URL of the dataset
+    config.data[0].url = data.url;
+    config.data[0].format = {
+      "type": "json",
+      "property": data.property
+    };
+  }
   if (columns.color.present) {
     // We add the color scale
     config.scales.push({


### PR DESCRIPTION
This PR changes the way the data of the charts is handled.

Previously, we would generate a Vega configuration with the URL of the data in it. Vega would be then responsible for fetching and handling the data.

Nevertheless, several functionalities such as having smarter temporal ticks force us to have access to the data. The decision was thus taken to manually fetch the data and then handle it to Vega. With the data on hand, we'll be able to have better charts in the future.

For now, the changes only make the app manually fetch the data for the `WidgetEditor` component. No visual change should be visible because the changes are architectural.