### PR TITLE
Forbid the Annoying Sticky Tooltip ™ from showing up unexpectedly once and for all

### DIFF
--- a/components/admin/layout/Layout.js
+++ b/components/admin/layout/Layout.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Router } from 'routes';
 
 // Redux
 import withRedux from 'next-redux-wrapper';
 import { initStore } from 'store';
 import { toggleModal, setModalOptions } from 'redactions/modal';
+import { toggleTooltip } from 'redactions/tooltip';
 import { setUser } from 'redactions/user';
 
 // Components
@@ -14,6 +16,23 @@ import Icons from 'components/admin/layout/icons';
 import Tooltip from 'components/ui/Tooltip';
 
 class Layout extends React.Component {
+
+  componentWillMount() {
+    // When a tooltip is shown and the router navigates to a
+    // another page, the tooltip stays in place because it is
+    // managed in Redux
+    // The way we prevent this is by listening to the router
+    // and whenever we navigate, we hide the tooltip
+    // NOTE: we can't just call this.props.toggleTooltip here
+    // because for some pages, we don't re-mount the Layout
+    // component. If we listen for events from the router,
+    // we're sure to not miss any page.
+    if (!Router.onRouteChangeStart) {
+      Router.onRouteChangeStart = () => {
+        this.props.toggleTooltip(false);
+      };
+    }
+  }
 
   componentDidMount() {
     this.props.setUser(this.props.user);
@@ -51,10 +70,12 @@ Layout.propTypes = {
   description: PropTypes.string.isRequired,
 
   // Store
-  setUser: PropTypes.func.isRequired
+  setUser: PropTypes.func.isRequired,
+  toggleTooltip: PropTypes.func
 };
 
 const mapDispatchToProps = dispatch => ({
+  toggleTooltip: () => dispatch(toggleTooltip()),
   toggleModal: () => {
     dispatch(toggleModal());
   },

--- a/components/app/layout/Layout.js
+++ b/components/app/layout/Layout.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Router } from 'routes';
 
 // Redux
 import withRedux from 'next-redux-wrapper';
@@ -35,9 +36,17 @@ class Layout extends React.Component {
     // When a tooltip is shown and the router navigates to a
     // another page, the tooltip stays in place because it is
     // managed in Redux
-    // In order to hide it every time a new page is loaded,
-    // we toggle it off each the Layout component is mounted
-    this.props.toggleTooltip(false);
+    // The way we prevent this is by listening to the router
+    // and whenever we navigate, we hide the tooltip
+    // NOTE: we can't just call this.props.toggleTooltip here
+    // because for some pages, we don't re-mount the Layout
+    // component. If we listen for events from the router,
+    // we're sure to not miss any page.
+    if (!Router.onRouteChangeStart) {
+      Router.onRouteChangeStart = () => {
+        this.props.toggleTooltip(false);
+      };
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
Even with [the previous fix](https://github.com/resource-watch/resource-watch/pull/63), the Annoying Sticky Tooltip ™ would invite itself on some pages. This PR forbids it from showing up unexpectedly once and for all ⚔️.

In detail, the previous solution was to toggle off the tooltip every time the `Layout` component would mount. This had two flaws:
1. Only the `Layout` component of the public site had been updated, not the one of the CMS.
2. Some pages don't re-mount the component because they are sub-pages (basically the pages which are tabs).

To prevent the Annoying Sticky Tooltip ™ to come back, this PR toggles off the tooltip _each time_ some navigation occurs. The listener is registered once in both `Layout` components if not previously defined. Because each page extends the `Page` component which uses one of the two `Layout`, the Annoying Sticky Tooltip ™ won't surprise us anymore.

[Pivotal task](https://www.pivotaltracker.com/story/show/149150695)