### PR TITLE
Fix/hide show save widget editor

### DIFF
--- a/components/admin/widget/form/steps/Step2.js
+++ b/components/admin/widget/form/steps/Step2.js
@@ -121,6 +121,7 @@ class Step2 extends React.Component {
         <WidgetEditor
           dataset={dataset}
           mode="dataset"
+          showSaveButton={false}
         />
 
         <Field

--- a/components/app/myrw/widgets/MyRWWidgetsEdit.js
+++ b/components/app/myrw/widgets/MyRWWidgetsEdit.js
@@ -103,6 +103,7 @@ class MyRWWidgetsEdit extends React.Component {
           dataset={widget.attributes.dataset}
           availableVisualizations={['chart', 'table']}
           mode="widget"
+          showSaveButton
         />
         }
       </div>

--- a/components/widgets/ChartEditor.js
+++ b/components/widgets/ChartEditor.js
@@ -59,11 +59,21 @@ class ChartEditor extends React.Component {
   }
 
   render() {
-    const { dataset, tableName, jiminy, widgetEditor, tableViewMode, user, mode } = this.props;
+    const {
+      dataset,
+      tableName,
+      jiminy,
+      widgetEditor,
+      tableViewMode,
+      user,
+      mode,
+      showSaveButton
+     } = this.props;
     const { chartType, fields, category, value } = widgetEditor;
 
-    const showSaveButton = chartType && category && value && user && user.token;
-    const showUpdateButton = showSaveButton;
+    const showSaveButtonFlag =
+      chartType && category && value && user && user.token && showSaveButton;
+    const showUpdateButton = showSaveButtonFlag;
 
     const chartOptions = (
         jiminy
@@ -110,7 +120,7 @@ class ChartEditor extends React.Component {
           >
             Need help?
           </button>
-          {showSaveButton && mode === 'save' &&
+          {showSaveButtonFlag && mode === 'save' &&
           <a
             onClick={this.handleSaveWidget}
           >
@@ -137,6 +147,7 @@ ChartEditor.propTypes = {
   jiminy: PropTypes.object,
   dataset: PropTypes.string.isRequired, // Dataset ID
   tableViewMode: PropTypes.bool.isRequired,
+  showSaveButton: PropTypes.bool.isRequired,
   // Store
   widgetEditor: PropTypes.object.isRequired,
   user: PropTypes.object.isRequired,

--- a/components/widgets/WidgetEditor.js
+++ b/components/widgets/WidgetEditor.js
@@ -76,7 +76,7 @@ class WidgetEditor extends React.Component {
       chartConfig: null, // Vega chart configuration
       chartConfigError: null, // Error message when fetching the chart configuration
       chartConfigLoading: false, // Whether we're loading the config
-      
+
       // Jiminy
       jiminy: {},
       jiminyLoaded: false,
@@ -453,7 +453,7 @@ class WidgetEditor extends React.Component {
       updating
     } = this.state;
     let { jiminy } = this.state;
-    const { dataset, mode } = this.props;
+    const { dataset, mode, showSaveButton } = this.props;
 
     // Whether we're still waiting for some data
     const loading = (mode === 'dataset' && !layersLoaded)
@@ -526,6 +526,7 @@ class WidgetEditor extends React.Component {
                     tableViewMode={selectedVisualizationType === 'table'}
                     mode={chartEditorMode}
                     onUpdateWidget={this.handleUpdateWidget}
+                    showSaveButton
                   />
                 }
                 {
@@ -555,6 +556,7 @@ const mapDispatchToProps = dispatch => ({
 
 WidgetEditor.propTypes = {
   mode: PropTypes.oneOf(['dataset', 'widget']),
+  showSaveButton: PropTypes.bool.isRequired, // Show save button in chart editor or not
   dataset: PropTypes.string, // Dataset ID
   widget: PropTypes.object, // Widget object
   availableVisualizations: PropTypes.arrayOf(

--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -217,6 +217,7 @@ class ExploreDetail extends Page {
             <WidgetEditor
               dataset={dataset.id}
               mode="dataset"
+              showSaveButton
             />
           }
 

--- a/utils/layers/pulse_layers.js
+++ b/utils/layers/pulse_layers.js
@@ -33,7 +33,7 @@ export const LAYERS_PLANET_PULSE = [
       },
       {
         label: 'Landslide Risk Locations (NASA)',
-        id: '3a6c18d8-bc56-418f-a390-e559f269d9c5',
+        id: '64f78c2e-2692-4842-b904-bf6aeb3d9c68',
         '3d': true,
         markerType: 'bar'
       }


### PR DESCRIPTION
Only show the 'Save widget' button as part of the Widget Editor in sections of the app.
It was also showed in the CMS before this pull request.