### PR TITLE
Brand new shiny legend

### DIFF
--- a/components/app/explore/DatasetWidgetChart.js
+++ b/components/app/explore/DatasetWidgetChart.js
@@ -8,7 +8,7 @@ import Spinner from 'components/ui/Spinner';
 
 // Themes
 import ChartTheme from 'utils/widgets/theme';
-import ThumbnailTheme from 'utils/widgets/vega-theme-thumbnails.json'
+import ThumbnailTheme from 'utils/widgets/vega-theme-thumbnails.json';
 
 class DatasetWidgetChart extends React.Component {
 
@@ -28,6 +28,18 @@ class DatasetWidgetChart extends React.Component {
     this.setState({
       widget: nextProps.widget
     });
+  }
+
+  componentDidUpdate(previousProps) {
+    // If the mode changes, we want to re-render the chart to
+    // take full advantage of the width
+    // To do so, we need to have the forceChartUpdate
+    // function available
+    // NOTE: this code should probably stay in componentDidUpdate
+    // so we're sure we can compute the new width of the charts
+    if (previousProps.mode !== this.props.mode && this.forceChartUpdate) {
+      this.forceChartUpdate();
+    }
   }
 
   triggerToggleLoading(loading) {
@@ -52,8 +64,10 @@ class DatasetWidgetChart extends React.Component {
         <VegaChart
           data={widgetConfig}
           theme={themeObj}
+          showLegend={mode !== 'thumbnail'}
           reloadOnResize={mode !== 'thumbnail'}
           toggleLoading={this.triggerToggleLoading}
+          getForceUpdate={(func) => { this.forceChartUpdate = func; }}
         />
       </div>
     );

--- a/components/widgets/VegaChart.js
+++ b/components/widgets/VegaChart.js
@@ -14,6 +14,7 @@ import { toggleTooltip } from 'redactions/tooltip';
 
 // Components
 import VegaChartTooltip from './VegaChartTooltip';
+import VegaChartLegend from './VegaChartLegend';
 
 class VegaChart extends React.Component {
 
@@ -303,6 +304,8 @@ class VegaChart extends React.Component {
   }
 
   render() {
+    const vegaConfig = this.getVegaConfig();
+
     return (
       <div
         className="c-chart"
@@ -310,6 +313,7 @@ class VegaChart extends React.Component {
         ref={(el) => { this.chartViewportContainer = el; }}
       >
         <div ref={(c) => { this.chart = c; }} className="chart" />
+        { vegaConfig.legend && <VegaChartLegend config={vegaConfig.legend} /> }
       </div>
     );
   }

--- a/components/widgets/VegaChart.js
+++ b/components/widgets/VegaChart.js
@@ -213,13 +213,15 @@ class VegaChart extends React.Component {
    * @returns {object}
    */
   getVegaConfig() {
-    const padding = this.props.data.padding || { top: 20, right: 20, bottom: 20, left: 20 };
+    const padding = this.props.data.padding || 'strict';
     const size = {
       // Please don't change these conditions, the bar chart
       // needs its height and width to not be overriden to display
       // properly
-      width: this.props.data.width || (this.width - padding.left - padding.right),
-      height: this.props.data.height || (this.height - padding.top - padding.bottom)
+      width: this.props.data.width
+        || this.width - (padding.left && padding.right ? (padding.left + padding.right) : 0),
+      height: this.props.data.height
+        || this.height - (padding.top && padding.bottom ? (padding.top + padding.bottom) : 0)
     };
 
     // This signal is used for the tooltip
@@ -233,7 +235,7 @@ class VegaChart extends React.Component {
       /* eslint-enable */
     };
 
-    const config = Object.assign({}, this.props.data, size);
+    const config = Object.assign({}, this.props.data, size, { padding });
 
     // If the configuration already has signals, we don't override it
     // but push a new one instead

--- a/components/widgets/VegaChart.js
+++ b/components/widgets/VegaChart.js
@@ -29,6 +29,18 @@ class VegaChart extends React.Component {
     this.mounted = true;
     this.renderChart();
     window.addEventListener('resize', this.triggerResize);
+
+    // We pass the callback to force the re-render of the chart
+    if (this.props.getForceUpdate) {
+      this.props.getForceUpdate(this.forceUpdate.bind(this));
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // We pass the callback to force the re-render of the chart
+    if (nextProps.getForceUpdate) {
+      nextProps.getForceUpdate(this.forceUpdate.bind(this));
+    }
   }
 
   shouldComponentUpdate(nextProps) {
@@ -36,7 +48,6 @@ class VegaChart extends React.Component {
   }
 
   componentDidUpdate() {
-    // We should check if the data has changed
     this.renderChart();
   }
 
@@ -315,7 +326,8 @@ class VegaChart extends React.Component {
         ref={(el) => { this.chartViewportContainer = el; }}
       >
         <div ref={(c) => { this.chart = c; }} className="chart" />
-        { vegaConfig.legend && <VegaChartLegend config={vegaConfig.legend} /> }
+        { this.props.showLegend && vegaConfig.legend
+          && <VegaChartLegend config={vegaConfig.legend} /> }
       </div>
     );
   }
@@ -323,12 +335,20 @@ class VegaChart extends React.Component {
 
 VegaChart.propTypes = {
   reloadOnResize: PropTypes.bool.isRequired,
+  showLegend: PropTypes.bool,
   // Define the chart data
   data: PropTypes.object,
   theme: PropTypes.object,
   // Callbacks
   toggleLoading: PropTypes.func,
-  toggleTooltip: PropTypes.func
+  toggleTooltip: PropTypes.func,
+  // This callback should be passed the function
+  // to force the re-render of the chart
+  getForceUpdate: PropTypes.func
+};
+
+VegaChart.defaultProps = {
+  showLegend: true
 };
 
 const mapStateToProps = ({ tooltip }) => ({

--- a/components/widgets/VegaChartLegend.js
+++ b/components/widgets/VegaChartLegend.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { time } from 'd3';
+import uniqBy from 'lodash/uniqBy';
 
 // Components
 import Title from 'components/ui/Title';
 
 // Helpers
-import { getSINumber } from 'utils/widgets/WidgetHelper';
+import { getSINumber, getTimeFormat } from 'utils/widgets/WidgetHelper';
 
 class VegaChartLegend extends React.Component {
 
@@ -20,17 +22,34 @@ class VegaChartLegend extends React.Component {
     // Kind of a trick, if there's something better, use it
     const uniqueId = config.values.slice(0, 5).map(v => v.label).join('');
 
+    // This is only used if the labels are dates
+    let timeFormat;
+    const formatDateLabel = (values, label) => {
+      if (!timeFormat) timeFormat = getTimeFormat(values.map(v => v.label));
+      return time.format(timeFormat)(new Date(label));
+    };
+
+    // Format the label according to its type
+    const formatLabel = (values, value) => {
+      if (value.type === 'date') return formatDateLabel(values, value.label);
+      return value.label;
+    };
+
+    // We use uniqBy to remove the duplicates in case the user
+    // hasn't use an aggregation method yet
+    const items = uniqBy(config.values, 'label');
+
     return (
       <div className="legend -color" key={uniqueId}>
         { config.label && <Title className="-default">{config.label}</Title> }
         <div className="items">
-          { config.values.map(value => (
-            <div className="item" key={value.label}>
+          { items.map((item, i, values) => (
+            <div className="item" key={item.label}>
               <span
                 className={`shape -${config.shape || 'square'}`}
-                style={{ backgroundColor: value.value }}
+                style={{ backgroundColor: item.value }}
               />
-              <span className="label">{value.label}</span>
+              <span className="label">{formatLabel(values, item)}</span>
             </div>
           ))}
         </div>

--- a/components/widgets/VegaChartLegend.js
+++ b/components/widgets/VegaChartLegend.js
@@ -4,6 +4,9 @@ import PropTypes from 'prop-types';
 // Components
 import Title from 'components/ui/Title';
 
+// Helpers
+import { getSINumber } from 'utils/widgets/WidgetHelper';
+
 class VegaChartLegend extends React.Component {
 
    /**
@@ -36,6 +39,40 @@ class VegaChartLegend extends React.Component {
   }
 
   /**
+   * Render the "size" legend corresponding to the config
+   * This legend is specific for marks which the size varies
+   * @static
+   * @param {object} config Check VegaChartLegend.propTypes.config for the types
+   * @return {JSX}
+   */
+  static renderSizeLegend(config) {
+    // Kind of a trick, if there's something better, use it
+    const uniqueId = config.values.slice(0, 5).map(v => v.label).join('');
+
+    return (
+      <div className="legend -size" key={uniqueId}>
+        { config.label && <Title className="-default">{config.label}</Title> }
+        <div className="items">
+          { config.values.map(value => (
+            <div className="item" key={value.label}>
+              <div className="shape-container">
+                <span
+                  className={`shape -${config.shape || 'square'}`}
+                  style={{
+                    width: `${2 * value.value}px`,
+                    height: `${2 * value.value}px`
+                  }}
+                />
+              </div>
+              <span className="label">{getSINumber(value.label)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  /**
    * Render the legend corresponding to the config
    * @param {object} config Check VegaChartLegend.propTypes.config for the types
    */
@@ -43,8 +80,7 @@ class VegaChartLegend extends React.Component {
     if (config.type === 'color') {
       return VegaChartLegend.renderColorLegend(config);
     } else if (config.type === 'size') {
-      // TODO
-      return null;
+      return VegaChartLegend.renderSizeLegend(config);
     }
   }
 

--- a/components/widgets/VegaChartLegend.js
+++ b/components/widgets/VegaChartLegend.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Components
+import Title from 'components/ui/Title';
+
+class VegaChartLegend extends React.Component {
+
+   /**
+   * Render the "color" legend corresponding to the config
+   * This legend is specific for marks which the color varies
+   * @static
+   * @param {object} config Check VegaChartLegend.propTypes.config for the types
+   * @return {JSX}
+   */
+  static renderColorLegend(config) {
+    // Kind of a trick, if there's something better, use it
+    const uniqueId = config.values.slice(0, 5).map(v => v.label).join('');
+
+    return (
+      <div className="legend -color" key={uniqueId}>
+        { config.label && <Title className="-default">{config.label}</Title> }
+        <div className="items">
+          { config.values.map(value => (
+            <div className="item" key={value.label}>
+              <span
+                className={`shape -${config.shape || 'square'}`}
+                style={{ backgroundColor: value.value }}
+              />
+              <span className="label">{value.label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  /**
+   * Render the legend corresponding to the config
+   * @param {object} config Check VegaChartLegend.propTypes.config for the types
+   */
+  static renderLegend(config) { // eslint-disable-line consistent-return
+    if (config.type === 'color') {
+      return VegaChartLegend.renderColorLegend(config);
+    } else if (config.type === 'size') {
+      // TODO
+      return null;
+    }
+  }
+
+  render() {
+    return (
+      <div className="c-vega-chart-legend">
+        <div className="container">
+          { this.props.config.map(config => VegaChartLegend.renderLegend(config)) }
+        </div>
+      </div>
+    );
+  }
+}
+
+VegaChartLegend.propTypes = {
+  config: PropTypes.arrayOf(PropTypes.shape({
+    type: PropTypes.oneOf(['color', 'size']),
+    label: PropTypes.string,
+    scale: PropTypes.string,
+    shape: PropTypes.oneOf(['square', 'circle', 'line']),
+    values: PropTypes.arrayOf(PropTypes.shape({
+      label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    }))
+  })).isRequired
+};
+
+export default VegaChartLegend;

--- a/components/widgets/VegaChartTooltip.js
+++ b/components/widgets/VegaChartTooltip.js
@@ -1,14 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format, time } from 'd3';
+import { time } from 'd3';
 
 // Helpers
-import { getTimeFormat } from 'utils/widgets/WidgetHelper';
-
-// Global functions
-// eslint-disable-next-line no-confusing-arrow
-const getRoundNumber = number => Math.abs(number % 1) > 0 ? format('.2f')(number) : number;
-const getSINumber = format('.2s');
+import { getTimeFormat, get2DecimalFixedNumber, getSINumber } from 'utils/widgets/WidgetHelper';
 
 class VegaChartTooltip extends React.Component {
 
@@ -19,7 +14,7 @@ class VegaChartTooltip extends React.Component {
     const { x } = item;
 
     if (x.type === 'number') {
-      return getRoundNumber(x.value);
+      return get2DecimalFixedNumber(x.value);
     } else if (x.type === 'date') {
       const date = new Date(x.value);
       return time.format(getTimeFormat(x.range))(date);

--- a/components/widgets/WidgetCard.js
+++ b/components/widgets/WidgetCard.js
@@ -132,7 +132,7 @@ class WidgetCard extends React.Component {
   }
 
   render() {
-    const { widget, showRemove, showActions, showEmbed, showStar } = this.props;
+    const { widget, showRemove, showActions, showEmbed, showStar, mode } = this.props;
 
     return (
       <div
@@ -144,7 +144,7 @@ class WidgetCard extends React.Component {
         {widget &&
           <DatasetWidgetChart
             widget={widget.attributes}
-            mode="full"
+            mode={mode}
           />
         }
 
@@ -217,6 +217,7 @@ WidgetCard.propTypes = {
   showRemove: PropTypes.bool,
   showEmbed: PropTypes.bool,
   showStar: PropTypes.bool,
+  mode: PropTypes.oneOf(['thumbnail', 'full']), // How to show the graph
   // Callbacks
   onWidgetRemove: PropTypes.func,
   onWidgetUnfavourited: PropTypes.func,

--- a/components/widgets/WidgetEditor.js
+++ b/components/widgets/WidgetEditor.js
@@ -63,14 +63,12 @@ class WidgetEditor extends React.Component {
 
     this.state = {
       selectedVisualizationType: 'chart',
-      // fields
-      fields: [],
+      // FIELDS
       fieldsLoaded: false,
       fieldsError: false,
-      // tablename
-      tableName: null,
-      // Whether the chart is loading its data/rendering
-      chartLoading: false,
+
+      tableName: null, // Name of the table
+      chartLoading: false, // Whether the chart is loading its data/rendering
 
       // CHART CONFIG
       chartConfig: null, // Vega chart configuration
@@ -106,7 +104,7 @@ class WidgetEditor extends React.Component {
     this.getFields()
       .then(() => {
         this.getJiminy();
-        this.getTableName();
+        this.getDatasetInfo();
       })
       .catch(() => console.error('Unable to retrieve the fields'));
 
@@ -115,14 +113,14 @@ class WidgetEditor extends React.Component {
     }
   }
 
-  componentDidUpdate(previousProps) {
+  componentDidUpdate(previousProps, previousState) {
     // If the configuration of the chart is updated, then we
     // fetch the Vega chart config again
     // NOTE: this can't be moved to componentWillUpdate because
     // this.fetchChartConfig uses the store
     if (canRenderChart(this.props.widgetEditor)
-      && !isEqual(previousProps.widgetEditor, this.props.widgetEditor)
-      && this.state.tableName !== null) {
+      && (!isEqual(previousProps.widgetEditor, this.props.widgetEditor)
+      || previousState.tableName !== this.state.tableName)) {
       this.fetchChartConfig();
     }
   }
@@ -148,9 +146,12 @@ class WidgetEditor extends React.Component {
         const fieldsError = !response.fields || !response.fields.length || fields.length === 0;
 
         this.setState({
-          fieldsLoaded: true,
-          fieldsError,
-          fields: response.fields
+          // We still need to fetch the aliases in getDatasetInfo
+          // so we let the loader spinning
+          // FIXME: once the fields enpoint is updated, the aliases
+          // should come with this query
+          fieldsLoaded: false,
+          fieldsError
         }, () => {
           // We wait for the state to be updated before doing anything
           // else
@@ -161,7 +162,7 @@ class WidgetEditor extends React.Component {
         });
       })
       // TODO: handle the error case in the UI
-      .catch(() => this.setState({ fieldsError: true }))
+      .catch(() => this.setState({ fieldsError: true, fieldsLoaded: true }))
       // If we reach this point, either we have already resolved the promise
       // and so rejecting it has no effect, or we haven't and so we reject it
       .then(reject);
@@ -204,8 +205,7 @@ class WidgetEditor extends React.Component {
   getJiminy() {
     // We get the name of the columns that we can use to build the
     // charts
-    const fieldsSt = this.state.fields
-      .filter(field => isFieldAllowed(field))
+    const fieldsSt = this.props.widgetEditor.fields
       .map(elem => elem.columnName);
 
     const querySt = `SELECT ${fieldsSt} FROM ${this.props.dataset} LIMIT 300`;
@@ -217,18 +217,36 @@ class WidgetEditor extends React.Component {
   }
 
   /**
-   * Fetch the name of the dataset's table and save it in the state
+   * Fetch the name of the table and the aliases and descriptions
+   * of the columns and save all of that in the store
    */
-  getTableName() {
-    this.datasetService.fetchData()
+  getDatasetInfo() {
+    this.datasetService.fetchData('metadata')
       .then(({ attributes }) => {
+        const metadata = attributes.metadata.length
+          && attributes.metadata[0]
+          && attributes.metadata[0].attributes.columns;
+
+        // Return the metadata's field for the specified column
+        const getMetadata = (column, field) => (metadata
+          && metadata[column]
+          && metadata[column][field]
+        );
+
+        // We add the aliases and descriptions to the fields
+        const fields = this.props.widgetEditor.fields.map(field => Object.assign({}, field, {
+          alias: getMetadata(field.columnName, 'alias'),
+          description: getMetadata(field.columnName, 'description')
+        }));
+
         this.setState({ tableName: attributes.tableName });
-        if (this.props.mode === 'widget') {
-          this.fetchChartConfig();
-        }
+        this.props.setFields(fields);
       })
-      // TODO: handle the error case
-      .catch(() => console.error('Unable to load the table name'));
+      // TODO: handle the error case in the UI
+      .catch(() => console.error('Unable to load the information about the dataset'))
+      // FIXME: should be removed once the getFields method can fetch the aliases
+      // and description
+      .then(() => this.setState({ fieldsLoaded: true }));
   }
 
   /**
@@ -395,6 +413,7 @@ class WidgetEditor extends React.Component {
       jiminyError,
       jiminyLoaded,
       fieldsError,
+      fieldsLoaded,
       layersError,
       layersLoaded,
       layers
@@ -404,7 +423,9 @@ class WidgetEditor extends React.Component {
 
     // Whether we're still waiting for some data
     const loading = (mode === 'dataset' && !layersLoaded)
-      || (!fieldsError && !jiminyLoaded);
+      || !fieldsLoaded
+      || !jiminyLoaded
+      || (mode === 'widget' && updating);
 
     const chartEditorMode = (mode === 'dataset') ? 'save' : 'update';
 

--- a/components/widgets/WidgetList.js
+++ b/components/widgets/WidgetList.js
@@ -66,6 +66,7 @@ export default class WidgetList extends React.Component {
                 showRemove={showRemove}
                 showEmbed={showEmbed}
                 showStar={showStar}
+                mode={mode === 'grid' ? 'thumbnail' : 'full'}
               />
             </li>)
           )}
@@ -89,7 +90,7 @@ WidgetList.propTypes = {
   showRemove: PropTypes.bool,
   showEmbed: PropTypes.bool,
   showStar: PropTypes.bool,
-  mode: PropTypes.string.isRequired, // grid|list
+  mode: PropTypes.oneOf(['grid', 'list']).isRequired,
   // Callbacks
   onWidgetRemove: PropTypes.func
 };

--- a/css/components/admin/widget/widget_chart.scss
+++ b/css/components/admin/widget/widget_chart.scss
@@ -34,26 +34,30 @@
       flex-grow: 1;
 
       .vega {
-        text-align: center;
+        display: flex;
+        justify-content: center;
+
+        canvas {
+          display: block; // Mandatory to avoid a gap below it
+        }
       }
     }
   }
 
   // These styles are used in the Explore page
-  // (the list of datasets)
+  // (the list of datasets) and My RW > Widgets
+  // when in grid mode
   &.-thumbnail {
     max-height: 180px;
 
     .c-chart {
       display: block;
-      height: 300px;
+      height: 160px;
+      min-height: 160px; // Override a rule above
 
       .chart {
         display: block;
         height: 100%;
-        // We need to set this since otherwise an horizontal scroll bar appears
-        // in the Explore cards
-        overflow-x: hidden;
       }
     }
   }

--- a/css/components/widgets/vega_chart_legend.scss
+++ b/css/components/widgets/vega_chart_legend.scss
@@ -1,110 +1,145 @@
 .c-vega-chart-legend {
   position: absolute;
-  bottom: 20px;
+  top: 20px;
   right: 20px;
-  padding: 0 15px;
-  width: 250px;
-  border: 1px solid rgba(26, 28, 34, .1);
-  border-radius: 4px;
-  background-color: $color-white;
-  box-shadow: 0 20px 30px 0 rgba(0, 0, 0, .1);
 
-  &::before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 15px;
-    background: linear-gradient(to bottom, $color-white, transparent);
-    content: '';
-  }
+  .toggle-button {
+    display: flex;
+    align-items: center;
+    font-size: $font-size-small-medium;
+    color: $color-text-3;
+    cursor: pointer;
 
-  &::after {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 15px;
-    background: linear-gradient(to top, $color-white, transparent);
-    content: '';
+    span {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      width: 15px;
+      height: 15px;
+      margin-right: 5px;
+      border: 1px solid rgba($color-text-3, .2);
+      border-radius: 100%;
+      font-family: "Georgia", serif;
+      font-style: italic;
+      color: $color-text-1;
+    }
   }
 
   .container {
-    padding: 15px 0 0; // The padding bottom won't be applicated anyway..
-    max-height: 150px;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 0 15px;
+    width: 200px;
+    border: 1px solid rgba(26, 28, 34, .1);
+    border-radius: 4px;
+    background-color: $color-white;
+    box-shadow: 0 20px 30px 0 rgba(0, 0, 0, .1);
 
-    // ... that's why we add it here
-    .legend {
-      padding-bottom: 15px;
-    }
-  }
-
-  .legend {
-    & + .legend {
-      margin-top: 10px;
-      padding-top: 10px;
-      border-top: 1px solid rgba(26, 28, 34, .1);
+    &[aria-hidden="true"] {
+      display: none;
     }
 
-    .c-title {
-      margin-bottom: 10px;
+    &::before {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 15px;
+      background: linear-gradient(to bottom, $color-white, rgba($color-white, 0));
+      content: '';
     }
 
-    .item {
-      font-size: $font-size-default;
-      color: $color-text-1;
+    &::after {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 15px;
+      background: linear-gradient(to top, $color-white, rgba($color-white, 0));
+      content: '';
     }
 
-    .shape {
-      display: inline-block;
-      // The width and the height might be overridden by some JS
-      width: 10px;
-      height: 10px;
-      border: 1px solid rgba(26, 28, 34, .1);
-      // The color might be overridden by some JS
-      background-color: $color-secondary;
+    .content {
+      padding: 15px 0 0; // The padding bottom won't be applicated anyway..
+      max-height: 120px;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
 
-      &.-circle {
-        border-radius: 100%;
+      // ... that's why we add it here
+      .legend {
+        padding-bottom: 15px;
       }
     }
 
-    &.-color {
+    .legend {
+      & + .legend {
+        margin-top: 10px;
+        padding-top: 10px;
+        border-top: 1px solid rgba(26, 28, 34, .1);
+      }
+
+      .c-title {
+        margin-bottom: 10px;
+      }
+
       .item {
-        padding: 2px 0;
+        font-size: $font-size-default;
+        color: $color-text-1;
       }
 
       .shape {
-        margin-right: 10px;
-      }
-    }
+        display: inline-block;
+        // The width and the height might be overridden by some JS
+        width: 10px;
+        height: 10px;
+        border: 1px solid rgba(26, 28, 34, .1);
+        // The color might be overridden by some JS
+        background-color: $color-secondary;
 
-    &.-size {
-      .items {
-        display: flex;
-        justify-content: flex-start;
-        align-items: stretch;
-      }
-
-      .item {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        align-items: center;
-
-        & + .item {
-          margin-left: 15px;
+        &.-circle {
+          border-radius: 100%;
         }
       }
 
-      .shape-container {
-        flex-grow: 1;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        margin-bottom: 5px;
+      &.-color {
+        .item {
+          display: flex;
+          padding: 2px 0;
+        }
+
+        .shape {
+          flex-shrink: 0;
+          margin-top: 4px;
+          margin-right: 10px;
+        }
+      }
+
+      &.-size {
+        .items {
+          display: flex;
+          justify-content: flex-start;
+          align-items: stretch;
+        }
+
+        .item {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+          align-items: center;
+
+          & + .item {
+            margin-left: 15px;
+          }
+        }
+
+        .shape-container {
+          flex-grow: 1;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          margin-bottom: 5px;
+        }
       }
     }
   }

--- a/css/components/widgets/vega_chart_legend.scss
+++ b/css/components/widgets/vega_chart_legend.scss
@@ -1,0 +1,82 @@
+.c-vega-chart-legend {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  padding: 0 15px;
+  width: 250px;
+  border: 1px solid rgba(26, 28, 34, .1);
+  border-radius: 4px;
+  background-color: $color-white;
+  box-shadow: 0 20px 30px 0 rgba(0, 0, 0, .1);
+
+  &::before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 15px;
+    background: linear-gradient(to bottom, $color-white, transparent);
+    content: '';
+  }
+
+  &::after {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 15px;
+    background: linear-gradient(to top, $color-white, transparent);
+    content: '';
+  }
+
+  .container {
+    padding: 15px 0; // The padding bottom won't be applicated...
+    max-height: 150px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+
+    // ... that's why we add it here
+    .legend {
+      padding-bottom: 15px;
+    }
+  }
+
+  .legend {
+    & + .legend {
+      margin-top: 10px;
+      padding-top: 10px;
+      border-top: 1px solid rgba(26, 28, 34, .1);
+    }
+
+    .c-title {
+      margin-bottom: 10px;
+    }
+
+    .item {
+      font-size: $font-size-default;
+      color: $color-text-1;
+    }
+
+    .shape {
+      display: inline-block;
+      // The width and the height might be overridden by some JS
+      width: 10px;
+      height: 10px;
+      border: 1px solid rgba(26, 28, 34, .1);
+
+      &.-circle {
+        border-radius: 100%;
+      }
+    }
+
+    &.-color {
+      .item {
+        padding: 2px 0;
+      }
+
+      .shape {
+        margin-right: 10px;
+      }
+    }
+  }
+}

--- a/css/components/widgets/vega_chart_legend.scss
+++ b/css/components/widgets/vega_chart_legend.scss
@@ -30,7 +30,7 @@
   }
 
   .container {
-    padding: 15px 0; // The padding bottom won't be applicated...
+    padding: 15px 0 0; // The padding bottom won't be applicated anyway..
     max-height: 150px;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
@@ -63,6 +63,8 @@
       width: 10px;
       height: 10px;
       border: 1px solid rgba(26, 28, 34, .1);
+      // The color might be overridden by some JS
+      background-color: $color-secondary;
 
       &.-circle {
         border-radius: 100%;
@@ -76,6 +78,33 @@
 
       .shape {
         margin-right: 10px;
+      }
+    }
+
+    &.-size {
+      .items {
+        display: flex;
+        justify-content: flex-start;
+        align-items: stretch;
+      }
+
+      .item {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: center;
+
+        & + .item {
+          margin-left: 15px;
+        }
+      }
+
+      .shape-container {
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        margin-bottom: 5px;
       }
     }
   }

--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -43,7 +43,7 @@
     align-items: center;
     flex-shrink: 1;
     flex-basis: 100%;
-    overflow-x: auto;
+    overflow-x: hidden;
 
     &.-error {
       text-align: center;
@@ -71,6 +71,7 @@
       .chart {
         // The height will be set either by VegaChart or Vega itself
         height: auto;
+        overflow-x: auto;
 
         .vega {
           // We can't use display: flex; here otherwise

--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -67,6 +67,7 @@
       display: flex;
       align-items: center;
       height: 100%;
+      padding-top: 20px; // Space for the legend
 
       .chart {
         // The height will be set either by VegaChart or Vega itself

--- a/css/index.scss
+++ b/css/index.scss
@@ -92,6 +92,7 @@
 @import "./components/widgets/widget_card";
 @import "./components/widgets/chart_tooltip";
 @import "./components/widgets/widget_actions_tooltip";
+@import "./components/widgets/vega_chart_legend";
 
 
 // ================== ADMIN ======================

--- a/utils/widgets/1d_scatter.js
+++ b/utils/widgets/1d_scatter.js
@@ -47,23 +47,20 @@ const defaultChart = {
  * Return the Vega chart configuration
  * 
  * @export
- * @param {any} { columns, data } 
+ * @param {any} { columns, data, url, embedData } 
  */
-export default function ({ columns, data }) {
+export default function ({ columns, data, url, embedData }) {
   const config = deepClone(defaultChart);
-  // Whether we have access to the data instead
-  // of having its URL
-  const hasAccessToData = isArray(data);
 
-  if (hasAccessToData) {
+  if (embedData) {
     // We directly set the data
     config.data[0].values = data;
   } else {
     // We set the URL of the dataset
-    config.data[0].url = data.url;
+    config.data[0].url = url;
     config.data[0].format = {
       "type": "json",
-      "property": data.property
+      "property": "data"
     };
   }
 

--- a/utils/widgets/1d_tick.js
+++ b/utils/widgets/1d_tick.js
@@ -48,23 +48,20 @@ const defaultChart = {
  * Return the Vega chart configuration
  * 
  * @export
- * @param {any} { columns, data } 
+ * @param {any} { columns, data, url, embedData } 
  */
-export default function ({ columns, data }) {
+export default function ({ columns, data, url, embedData }) {
   const config = deepClone(defaultChart);
-  // Whether we have access to the data instead
-  // of having its URL
-  const hasAccessToData = isArray(data);
 
-  if (hasAccessToData) {
+  if (embedData) {
     // We directly set the data
     config.data[0].values = data;
   } else {
     // We set the URL of the dataset
-    config.data[0].url = data.url;
+    config.data[0].url = url;
     config.data[0].format = {
       "type": "json",
-      "property": data.property
+      "property": "data"
     };
   }
 

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -1,4 +1,5 @@
 import 'isomorphic-fetch';
+import { format } from 'd3';
 
 // Components
 import BarChart from 'utils/widgets/bar';
@@ -253,7 +254,7 @@ export function getTimeFormat(data) {
  * @returns {object} JSON object
  */
 export async function getChartConfig(widgetEditor, tableName, dataset, mustFetchData = false) {
-  const { category, value, size, color, chartType, aggregateFunction } = widgetEditor;
+  const { category, value, size, color, chartType, aggregateFunction, fields } = widgetEditor;
 
   // URL of the data needed to display the chart
   const url = getDataURL(widgetEditor, tableName, dataset);
@@ -283,19 +284,55 @@ export async function getChartConfig(widgetEditor, tableName, dataset, mustFetch
       x: {
         present: true,
         type: category.type,
-        name: xLabel
+        name: xLabel,
+        alias: fields.find(f => f.columnName === category.name).alias
       },
       y: {
         present: !!value,
         type: value && value.type,
-        name: yLabel
+        name: yLabel,
+        alias: value && fields.find(f => f.columnName === value.name).alias
       },
-      color: { present: !!color },
-      size: { present: !!size }
+      color: {
+        present: !!color,
+        alias: color && fields.find(f => f.columnName === color.name).alias
+      },
+      size: {
+        present: !!size,
+        alias: size && fields.find(f => f.columnName === size.name).alias
+      }
     },
     data: data || {
       url,
       property: 'data'
     }
   });
+}
+
+// TOOLTIP & LEGEND
+
+/**
+ * Return a two-decimal fixed number (as a string) if the number
+ * isn't an integer, if it is, just return the number
+ * For example:
+ *  * 1773.38    => 1,773.38
+ *  *    2.76557 =>     2.76
+ *  *    2.7     =>     2.70
+ *  *    2       =>     2
+ * @export
+ * @param {number} number Number to format
+ * @return {string}
+ */
+export function get2DecimalFixedNumber(number) {
+  return Math.abs(number % 1) > 0 ? format(',.2f')(number) : `${number}`;
+}
+
+/**
+ * Return the number in the SI format
+ * @export
+ * @param {number} number Number to format
+ * @return {string}
+ */
+export function getSINumber(number) {
+  return format('.2s')(number);
 }

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -248,19 +248,18 @@ export function getTimeFormat(data) {
  * @param {any} widgetEditor State of the editor (coming from the store)
  * @param {string} tableName Name of the dataset's table
  * @param {string} dataset ID of the dataset
- * @param {boolean} [mustFetchData=false] Whether the the configuration
- * should store the URL of the raw data (might be needed for smarter
- * charts)
+ * @param {boolean} [embedData=false] Whether the configuration should
+ * be saved with the data in it or just its URL
  * @returns {object} JSON object
  */
-export async function getChartConfig(widgetEditor, tableName, dataset, mustFetchData = false) {
+export async function getChartConfig(widgetEditor, tableName, dataset, embedData = false) {
   const { category, value, size, color, chartType, aggregateFunction, fields } = widgetEditor;
 
   // URL of the data needed to display the chart
   const url = getDataURL(widgetEditor, tableName, dataset);
 
-  // In case we must fetch the data, we save it in this variable
-  const data = mustFetchData && await fetchData(url);
+  // We fetch the data to have clever charts
+  const data = await fetchData(url);
 
   // We compute the name of the x column
   const xLabel = category.name[0].toUpperCase() + category.name.slice(1, category.name.length);
@@ -302,10 +301,9 @@ export async function getChartConfig(widgetEditor, tableName, dataset, mustFetch
         alias: size && fields.find(f => f.columnName === size.name).alias
       }
     },
-    data: data || {
-      url,
-      property: 'data'
-    }
+    data,
+    url,
+    embedData
   });
 }
 

--- a/utils/widgets/bar.js
+++ b/utils/widgets/bar.js
@@ -157,23 +157,20 @@ const defaultChart = {
  * Return the Vega chart configuration
  * 
  * @export
- * @param {any} { columns, data } 
+ * @param {any} { columns, data, url, embedData  } 
  */
-export default function ({ columns, data }) {
+export default function ({ columns, data, url, embedData  }) {
   const config = deepClone(defaultChart);
-  // Whether we have access to the data instead
-  // of having its URL
-  const hasAccessToData = isArray(data);
 
-  if (hasAccessToData) {
+  if (embedData) {
     // We directly set the data
     config.data[0].values = data;
   } else {
     // We set the URL of the dataset
-    config.data[0].url = data.url;
+    config.data[0].url = url;
     config.data[0].format = {
       "type": "json",
-      "property": data.property
+      "property": "data"
     };
   }
 
@@ -215,13 +212,10 @@ export default function ({ columns, data }) {
     if (!config.data[0].format) config.data[0].format = {};
     config.data[0].format.parse = { x: 'date' };
 
-    // If we have access to the data, we should be able to
-    // compute an optimal format for the ticks
-    if (hasAccessToData) {
-      const temporalData = data.map(d => d.x);
-      const format = getTimeFormat(temporalData);
-      if (format) xAxis.format = format;
-    }
+    // We compute an optimal format for the ticks
+    const temporalData = data.map(d => d.x);
+    const format = getTimeFormat(temporalData);
+    if (format) xAxis.format = format;
 
     // The x axis has a template used to truncate the
     // text. Nevertheless, when using it, a date will

--- a/utils/widgets/line.js
+++ b/utils/widgets/line.js
@@ -52,23 +52,20 @@ const defaultChart = {
  * Return the Vega chart configuration
  * 
  * @export
- * @param {any} { columns, data } 
+ * @param {any} { columns, data, url, embedData } 
  */
-export default function ({ columns, data }) {
+export default function ({ columns, data, url, embedData }) {
   const config = deepClone(defaultChart);
-  // Whether we have access to the data instead
-  // of having its URL
-  const hasAccessToData = isArray(data);
 
-  if (hasAccessToData) {
+  if (embedData) {
     // We directly set the data
     config.data[0].values = data;
   } else {
     // We set the URL of the dataset
-    config.data[0].url = data.url;
+    config.data[0].url = url;
     config.data[0].format = {
       "type": "json",
-      "property": data.property
+      "property": "data"
     };
   }
 
@@ -92,13 +89,10 @@ export default function ({ columns, data }) {
     // We make the axis use temporal ticks
     xAxis.formatType = 'time';
 
-    // If we have access to the data, we should be able to
-    // compute an optimal format for the ticks
-    if (hasAccessToData) {
-      const temporalData = data.map(d => d.x);
-      const format = getTimeFormat(temporalData);
-      if (format) xAxis.format = format;
-    }
+    // We compute an optimal format for the ticks
+    const temporalData = data.map(d => d.x);
+    const format = getTimeFormat(temporalData);
+    if (format) xAxis.format = format;
   }
 
   // If all the "dots" have the exact same y position,

--- a/utils/widgets/pie.js
+++ b/utils/widgets/pie.js
@@ -96,23 +96,20 @@ const defaultChart = {
  * Return the Vega chart configuration
  * 
  * @export
- * @param {any} { columns, data } 
+ * @param {any} { columns, data, url, embedData } 
  */
-export default function ({ columns, data }) {
+export default function ({ columns, data, url, embedData }) {
   const config = deepClone(defaultChart);
-  // Whether we have access to the data instead
-  // of having its URL
-  const hasAccessToData = isArray(data);
 
-  if (hasAccessToData) {
+  if (embedData) {
     // We directly set the data
     config.data[0].values = data;
   } else {
     // We set the URL of the dataset
-    config.data[0].url = data.url;
+    config.data[0].url = url;
     config.data[0].format = {
       "type": "json",
-      "property": data.property
+      "property": "data"
     };
   }
 
@@ -159,17 +156,15 @@ export default function ({ columns, data }) {
 
   // We add a default legend to the chart
   // In the default template above, category20 is used
-  if (hasAccessToData) {
-    const colorRange = scale.category20().range();
-    config.legend = [
-      {
-        type: 'color',
-        label: null,
-        shape: 'square',
-        values: data.map((d, i) => ({ label: d.x, value: colorRange[i % 20], type: columns.x.type }))
-      }
-    ];
-  }
+  const colorRange = scale.category20().range();
+  config.legend = [
+    {
+      type: 'color',
+      label: null,
+      shape: 'square',
+      values: data.map((d, i) => ({ label: d.x, value: colorRange[i % 20], type: columns.x.type }))
+    }
+  ];
 
   return config;
 };

--- a/utils/widgets/pie.js
+++ b/utils/widgets/pie.js
@@ -166,7 +166,7 @@ export default function ({ columns, data }) {
         type: 'color',
         label: null,
         shape: 'square',
-        values: data.map((d, i) => ({ label: d.x, value: colorRange[i % 20] }))
+        values: data.map((d, i) => ({ label: d.x, value: colorRange[i % 20], type: columns.x.type }))
       }
     ];
   }

--- a/utils/widgets/pie.js
+++ b/utils/widgets/pie.js
@@ -1,5 +1,6 @@
 import deepClone from 'lodash/cloneDeep';
 import isArray from 'lodash/isArray';
+import { scale } from 'd3';
 
 /* eslint-disable */
 const defaultChart = {
@@ -21,6 +22,8 @@ const defaultChart = {
       "name": "c",
       "type": "ordinal",
       "domain": {"data": "table", "field": "x"},
+      // If you update this range, don't forget to
+      // update the code below
       "range": "category20"
     }
   ],
@@ -65,24 +68,27 @@ const defaultChart = {
           "fill": {"scale": "c", "field": "x"}
         }
       }
-    },
-    {
-      "type": "text",
-      "from": {"data": "table"},
-      "properties": {
-        "enter": {
-          "x": {"field": {"group": "width"}, "mult": 0.5},
-          "y": {"field": {"group": "height"}, "mult": 0.5},
-          "radius": {"value": 110},
-          "theta": {"field": "layout_mid"},
-          "fill": {"value": "#000"},
-          "align": {"value": "center"},
-          "baseline": {"value": "middle"},
-          "text": {"field": "x"},
-          "opacity": {"value": 0.6}
-        }
-      }
     }
+    // If everyone's ok having the value displayed in the
+    // legend instead of on the chart, we can permanently
+    // delete the following bit
+    // {
+    //   "type": "text",
+    //   "from": {"data": "table"},
+    //   "properties": {
+    //     "enter": {
+    //       "x": {"field": {"group": "width"}, "mult": 0.5},
+    //       "y": {"field": {"group": "height"}, "mult": 0.5},
+    //       "radius": {"value": 110},
+    //       "theta": {"field": "layout_mid"},
+    //       "fill": {"value": "#000"},
+    //       "align": {"value": "center"},
+    //       "baseline": {"value": "middle"},
+    //       "text": {"field": "x"},
+    //       "opacity": {"value": 0.6}
+    //     }
+    //   }
+    // }
   ]
 }
 
@@ -149,6 +155,20 @@ export default function ({ columns, data }) {
       "field": "size",
       "offset": 10
     }
+  }
+
+  // We add a default legend to the chart
+  // In the default template above, category20 is used
+  if (hasAccessToData) {
+    const colorRange = scale.category20().range();
+    config.legend = [
+      {
+        type: 'color',
+        label: null,
+        shape: 'square',
+        values: data.map((d, i) => ({ label: d.x, value: colorRange[i % 20] }))
+      }
+    ];
   }
 
   return config;

--- a/utils/widgets/scatter.js
+++ b/utils/widgets/scatter.js
@@ -93,12 +93,18 @@ export default function ({ columns, data }) {
   }
 
   if (columns.size.present) {
+    const sizeScaleType = 'linear';
+    const sizeScaleRange = [10, 150];
+    // The following formula comes from:
+    // https://github.com/vega/vega-scenegraph/blob/master/src/path/symbols.js#L10
+    const getCircleRadius = (d) => Math.sqrt(d) / 2;
+
     // We add the scale
     config.scales.push({
       "name": "s",
-      "type": "linear",
+      "type": sizeScaleType,
       "domain": {"data": "table", "field": "size"},
-      "range": [10, 150],
+      "range": sizeScaleRange,
       "zero": false
     });
 
@@ -107,6 +113,30 @@ export default function ({ columns, data }) {
       "scale": "s",
       "field": "size"
     };
+
+    // We add a legend to explain what the size
+    // variation means
+    if (hasAccessToData) {
+      const sizeDate = data.map(d => d.size);
+      config.legend = [
+        {
+          type: 'size',
+          label: columns.size.alias || columns.size.name,
+          shape: 'circle',
+          scale: sizeScaleType,
+          values: [
+            {
+              label: Math.max(...sizeDate),
+              value: getCircleRadius(sizeScaleRange[1])
+            },
+            {
+              label: Math.min(...sizeDate),
+              value: getCircleRadius(sizeScaleRange[0])
+            }
+          ]
+        }
+      ];
+    }
   }
 
   // If all the dots have the exact same y position,

--- a/utils/widgets/scatter.js
+++ b/utils/widgets/scatter.js
@@ -50,23 +50,20 @@ const defaultChart = {
  * Return the Vega chart configuration
  * 
  * @export
- * @param {any} { columns, data } 
+ * @param {any} { columns, data, url, embedData } 
  */
-export default function ({ columns, data }) {
+export default function ({ columns, data, url, embedData }) {
   const config = deepClone(defaultChart);
-  // Whether we have access to the data instead
-  // of having its URL
-  const hasAccessToData = isArray(data);
 
-  if (hasAccessToData) {
+  if (embedData) {
     // We directly set the data
     config.data[0].values = data;
   } else {
     // We set the URL of the dataset
-    config.data[0].url = data.url;
+    config.data[0].url = url;
     config.data[0].format = {
       "type": "json",
-      "property": data.property
+      "property": "data"
     };
   }
 
@@ -116,27 +113,25 @@ export default function ({ columns, data }) {
 
     // We add a legend to explain what the size
     // variation means
-    if (hasAccessToData) {
-      const sizeDate = data.map(d => d.size);
-      config.legend = [
-        {
-          type: 'size',
-          label: columns.size.alias || columns.size.name,
-          shape: 'circle',
-          scale: sizeScaleType,
-          values: [
-            {
-              label: Math.max(...sizeDate),
-              value: getCircleRadius(sizeScaleRange[1])
-            },
-            {
-              label: Math.min(...sizeDate),
-              value: getCircleRadius(sizeScaleRange[0])
-            }
-          ]
-        }
-      ];
-    }
+    const sizeDate = data.map(d => d.size);
+    config.legend = [
+      {
+        type: 'size',
+        label: columns.size.alias || columns.size.name,
+        shape: 'circle',
+        scale: sizeScaleType,
+        values: [
+          {
+            label: Math.max(...sizeDate),
+            value: getCircleRadius(sizeScaleRange[1])
+          },
+          {
+            label: Math.min(...sizeDate),
+            value: getCircleRadius(sizeScaleRange[0])
+          }
+        ]
+      }
+    ];
   }
 
   // If all the dots have the exact same y position,

--- a/utils/widgets/theme.js
+++ b/utils/widgets/theme.js
@@ -8,7 +8,7 @@ const defaultTheme = {
                    // because it will break several graphs
                    // (primarly the bar and pie ones)
   marks: {
-    color: '#3BB2D0'
+    color: '#1f77b4'
   },
   axis_x: {
     axisColor: '#A9ABAD',

--- a/utils/widgets/vega-theme-thumbnails.json
+++ b/utils/widgets/vega-theme-thumbnails.json
@@ -2,17 +2,6 @@
   "render": {
     "retina": true
   },
-  "axis": {
-    "gridColor": "#eeeeee",
-    "gridOpacity": 1,
-    "tickColor": "#eeeeee",
-    "tickLabelColor": "#758290",
-    "tickLabelFont": "\"Roboto\"",
-    "titleFont": "\"Roboto\"",
-    "titleFontSize": 12,
-    "titleFontWeight": "regular",
-    "titleColor": "#758290"
-  },
   "range": {
     "colorRange1":[
       "#3bb2d0",
@@ -35,5 +24,14 @@
       "#ffe01b",
       "#6e23bd"
     ]
+  },
+  "marks": {
+    "color": "#1f77b4"
+  },
+  "axis": {
+    "ticks": 0,
+    "tickSize": 0,
+    "axisWidth": 0,
+    "tickLabelFontSize": 0
   }
 }


### PR DESCRIPTION
This PR adds the support for legends for the charts. By default, in the widget editor, only the pie chart and the scatter chart with dots of varying sizes will get one.

<p align="center">
<img width="556" alt="Screenshot of a pie chart with a legend at the top right showing the name of the country corresponding to each slice" src="https://user-images.githubusercontent.com/6073968/28728803-ecc0525a-73c1-11e7-9cbc-ba9b698f96c3.png">
</p>


In addition to that, the PR:
* fixes an issue where the widgets wouldn't be saved with the custom formattings of the ticks and the tooltip
* fixes the layout of the My RW > My Widgets section (the pie and bar charts, as thumbnails, still have an issue that will be dealt with later)
* updates the default color of the charts to dark blue

The PR includes these changes to the `VegaChart` component:
- a new `showLegend` prop to hide it if needed
- a new  `getForceUpdate` prop (a function) which is passed a function to call to force the re-render of the chart (useful when the grid/list layout changes)