### PR TITLE
Area intersection in the widget editor

### DIFF
--- a/components/app/layout/Layout.js
+++ b/components/app/layout/Layout.js
@@ -119,9 +119,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   toggleTooltip: () => dispatch(toggleTooltip()),
-  toggleModal: () => {
-    dispatch(toggleModal());
-  },
+  toggleModal: open => dispatch(toggleModal(open, {}, true)),
   setModalOptions: () => {
     dispatch(setModalOptions());
   },

--- a/components/app/myrw/widgets/MyRWWidgetsEdit.js
+++ b/components/app/myrw/widgets/MyRWWidgetsEdit.js
@@ -84,7 +84,7 @@ class MyRWWidgetsEdit extends React.Component {
     const dataset = widgetAtts.dataset;
     const { widgetEditor, tableName, user } = this.props;
     const { limit, value, category, color, size, orderBy, aggregateFunction,
-      chartType, filters } = widgetEditor;
+      chartType, filters, areaIntersection } = widgetEditor;
 
     let chartConfig;
     try {
@@ -112,7 +112,8 @@ class MyRWWidgetsEdit extends React.Component {
             orderBy,
             aggregateFunction,
             chartType,
-            filters
+            filters,
+            areaIntersection
           }
         },
         chartConfig

--- a/components/modal/SaveWidgetModal.js
+++ b/components/modal/SaveWidgetModal.js
@@ -69,7 +69,7 @@ class SaveWidgetModal extends React.Component {
     });
     const { widgetEditor, tableName, dataset } = this.props;
     const { limit, value, category, color, size, orderBy, aggregateFunction,
-      chartType, filters } = widgetEditor;
+      chartType, filters, areaIntersection } = widgetEditor;
 
     let chartConfig;
     try {
@@ -97,7 +97,8 @@ class SaveWidgetModal extends React.Component {
             orderBy,
             aggregateFunction,
             chartType,
-            filters
+            filters,
+            areaIntersection
           }
         },
         chartConfig

--- a/components/modal/UploadAreaIntersectionModal.js
+++ b/components/modal/UploadAreaIntersectionModal.js
@@ -1,0 +1,272 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Autobind } from 'es-decorators';
+import Dropzone from 'react-dropzone';
+
+// Components
+import Spinner from 'components/ui/Spinner';
+
+class UploadAreaIntersectionModal extends React.Component {
+
+  /**
+   * Return the name of the file
+   * @param {File} file
+   * @returns {string}
+   */
+  static getFileName(file) {
+    return file.name;
+  }
+
+  /**
+   * Return the extension of the file
+   * @param {File} file
+   * @returns {string}
+   */
+  static getFileType(file) {
+    return file.name.split('.').pop();
+  }
+
+  /**
+   * Return the JSON object that the file represents
+   * @static
+   * @param {File} file JSON-compatible file
+   * @returns {Promise<Object>}
+   */
+  static readJSONFile(file) {
+    return new Promise((resolve) => {
+      // We read the file and resolve the json object
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => {
+        throw new Error('Unable to read the geojson file. Please try to upload it again.')
+      };
+      reader.readAsText(file);
+    });
+  }
+
+  /**
+   * Convert a file with one of these formats to a geojson one:
+   * .csv, .kml, .kmz, .wkt, .shp
+   * @static
+   * @param {File} file File to convert
+   * @returns {Promise<Object>} geojson object
+   */
+  static convertToJSON(file) {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    return fetch(`${process.env.WRI_API_URL}/ogr/convert`, {
+      method: 'POST',
+      body: formData,
+      multipart: true
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error('The file couldn\'t be processed correctly. Try again in a few minutes.');
+        return response.json();
+      })
+      .then(({ data }) => {
+        const features = data.attributes.features;
+
+        if (!features || !features.length || !Array.isArray(features)) {
+          throw new Error('The geometry seems to be empty. Please make sure the file isn\'t empty.');
+        }
+
+        return data.attributes;
+      });
+  }
+
+  /**
+   * Convert the file to the geojson format if necessary
+   * and store it in the geostore
+   * NOTE: the method doesn't catch the errors but sends
+   * comprehensive errors
+   * @static
+   * @param {File} file File to process
+   * @returns {Promise<string>} hash Hash of the store file
+   */
+  static processFile(file) {
+    // First step: we convert the file to a geojson format
+    return new Promise((resolve) => {
+      const fileType = UploadAreaIntersectionModal.getFileType(file);
+
+      // If the file is already a geojson, we don't need to convert it
+      if (fileType === 'geojson') {
+        // If there's an error, it will be caught at a higher level
+        UploadAreaIntersectionModal.readJSONFile(file)
+          .then(resolve);
+      } else { // Otherwise, we convert it
+        // If there's an error, it will be caught at a higher level
+        UploadAreaIntersectionModal.convertToJSON(file)
+          .then(resolve);
+      }
+    })
+    // Second: we store it in the geostore
+    .then(geojson => fetch(`${process.env.WRI_API_URL}/geostore`, {
+      method: 'POST',
+      body: JSON.stringify({ geojson })
+    }))
+    .then((response) => {
+      if (!response.ok) throw new Error('The file couldn\'t be processed correctly. Try again in a few minutes.');
+      return response.json();
+    })
+    // Finally: we return the id of the geojson
+    .then(({ id }) => id);
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      accepted: null, // Accepted file
+      rejected: null, // Rejected file
+      dropzoneActive: false,
+      loading: false,
+      errors: []
+    };
+  }
+
+  /**
+   * Event handler executed when the user drags a file over the
+   * drop zone
+   */
+  @Autobind
+  onDragEnter() {
+    this.setState({
+      dropzoneActive: true
+    });
+  }
+
+  /**
+   * Event handler executed when the user drags a file over the
+   * drop zone
+   */
+  @Autobind
+  onDragLeave() {
+    this.setState({
+      dropzoneActive: false
+    });
+  }
+
+  /**
+   * Event handler executed when the user drops a file in the
+   * drop zone
+   * @param {File[]} accepted List of accepted files
+   * @param {File[]} rejected List of rejected files
+   */
+  @Autobind
+  onDrop(accepted, rejected) {
+    this.setState({
+      accepted: accepted[0],
+      rejected: rejected[0],
+      dropzoneActive: false,
+      loading: true
+    }, () => {
+      if (this.state.accepted) {
+        UploadAreaIntersectionModal.processFile(this.state.accepted)
+          .then(id => this.props.onAreaUploaded(id))
+          .catch(err => this.setState({ errors: [err.message] }))
+          .then(() => this.setState({ loading: false }));
+      }
+    });
+  }
+
+  /**
+   * Event handler executed when the user clicks on the drop
+   * zone
+   */
+  @Autobind
+  onOpenDialog() {
+    this.dropzone.open();
+  }
+
+  render() {
+    const { dropzoneActive, loading, errors } = this.state;
+
+    return (
+      <div className="c-upload-area-intersection-modal">
+        <Spinner isLoading={loading} />
+
+        <Dropzone
+          ref={(node) => { this.dropzone = node; }}
+          className="c-dropzone"
+          activeClassName="-active"
+          rejectClassName="-reject"
+          multiple={false}
+          disableClick
+          disablePreview
+          onDrop={this.onDrop}
+          onDragEnter={this.onDragEnter}
+          onDragLeave={this.onDragLeave}
+        >
+          {dropzoneActive &&
+            <div className="dropzone-active">
+              <h2>Drop files...</h2>
+            </div>
+          }
+
+          <header className="dropzone-header">
+            <h2>Import files</h2>
+            <p>
+              Drop a file in the designated area to upload it.
+              The recommended maximum file size is 1MB.
+              Anything larger than that may not work properly.
+            </p>
+            <p>
+              List of supported file formats
+              <i>(click on any format to download the template)</i>:
+            </p>
+            <ul>
+              <li>
+                Unzipped: .csv, .geojson, .kml, .kmz, .wkt
+                <i>(.csv files must contain a geom column that contains geographic information)</i>
+              </li>
+              <li>
+                Zipped: .shp
+                <i>(zipped shapefiles must include .shp, .shx, .dbf and .prj files)</i>
+              </li>
+            </ul>
+          </header>
+
+          <div className="dropzone-file">
+            <div className="dropzone-file-input">
+              <div
+                role="presentation" // Disable the accessibility warning, don't know which other role to give
+                className="dropzone-file-name"
+                onClick={this.onOpenDialog}
+              >
+                { this.state.accepted
+                  ? UploadAreaIntersectionModal.getFileName(this.state.accepted)
+                  : 'Select file to import data'
+                }
+              </div>
+              <button
+                className="c-btn -primary -light"
+                onClick={this.onOpenDialog}
+              >
+                Select file
+              </button>
+            </div>
+
+            {errors && Array.isArray(errors) && !!errors.length &&
+              <div className="dropzone-file-errors">
+                <ul>
+                  {errors.map(err =>
+                    <li key={err.detail}>{err.detail}</li>
+                  )}
+                </ul>
+              </div>
+            }
+          </div>
+        </Dropzone>
+      </div>
+    );
+  }
+
+}
+
+UploadAreaIntersectionModal.propTypes = {
+  // Callback to call with the id of the area
+  onAreaUploaded: PropTypes.func.isRequired
+};
+
+export default UploadAreaIntersectionModal;

--- a/components/modal/UploadAreaIntersectionModal.js
+++ b/components/modal/UploadAreaIntersectionModal.js
@@ -36,9 +36,9 @@ class UploadAreaIntersectionModal extends React.Component {
     return new Promise((resolve) => {
       // We read the file and resolve the json object
       const reader = new FileReader();
-      reader.onload = () => resolve(reader.result);
+      reader.onload = () => resolve(JSON.parse(reader.result));
       reader.onerror = () => {
-        throw new Error('Unable to read the geojson file. Please try to upload it again.')
+        throw new Error('Unable to read the geojson file. Please try to upload it again.');
       };
       reader.readAsText(file);
     });
@@ -103,6 +103,9 @@ class UploadAreaIntersectionModal extends React.Component {
     // Second: we store it in the geostore
     .then(geojson => fetch(`${process.env.WRI_API_URL}/geostore`, {
       method: 'POST',
+      headers: new Headers({
+        'content-type': 'application/json'
+      }),
       body: JSON.stringify({ geojson })
     }))
     .then((response) => {
@@ -110,7 +113,7 @@ class UploadAreaIntersectionModal extends React.Component {
       return response.json();
     })
     // Finally: we return the id of the geojson
-    .then(({ id }) => id);
+    .then(({ data }) => data.id);
   }
 
   constructor(props) {
@@ -163,7 +166,7 @@ class UploadAreaIntersectionModal extends React.Component {
     }, () => {
       if (this.state.accepted) {
         UploadAreaIntersectionModal.processFile(this.state.accepted)
-          .then(id => this.props.onAreaUploaded(id))
+          .then(id => this.props.onUploadArea(id))
           .catch(err => this.setState({ errors: [err.message] }))
           .then(() => this.setState({ loading: false }));
       }
@@ -251,7 +254,7 @@ class UploadAreaIntersectionModal extends React.Component {
               <div className="dropzone-file-errors">
                 <ul>
                   {errors.map(err =>
-                    <li key={err.detail}>{err.detail}</li>
+                    <li key={err}>{err}</li>
                   )}
                 </ul>
               </div>
@@ -266,7 +269,7 @@ class UploadAreaIntersectionModal extends React.Component {
 
 UploadAreaIntersectionModal.propTypes = {
   // Callback to call with the id of the area
-  onAreaUploaded: PropTypes.func.isRequired
+  onUploadArea: PropTypes.func.isRequired
 };
 
 export default UploadAreaIntersectionModal;

--- a/components/ui/SliderSelect.js
+++ b/components/ui/SliderSelect.js
@@ -457,7 +457,7 @@ export default class SliderSelect extends React.Component {
 SliderSelect.propTypes = {
   /** @type {Item[]} */
   options: PropTypes.array, // List of the options (see the type Item)
-  /** @type {(item: Item, path: string[]) => void} */
+  /** @type {(item: Item, path?: string[]) => void} */
   onValueChange: PropTypes.func, // Callback when the selected option changes
   /** @type {string} */
   value: PropTypes.string, // Initial selected value (value of an Item)

--- a/components/widgets/ChartEditor.js
+++ b/components/widgets/ChartEditor.js
@@ -16,9 +16,24 @@ import DimensionsContainer from 'components/widgets/DimensionsContainer';
 import FieldsContainer from 'components/widgets/FieldsContainer';
 import SortContainer from 'components/widgets/SortContainer';
 import LimitContainer from 'components/widgets/LimitContainer';
+import CustomSelect from 'components/ui/CustomSelect';
 import Select from 'components/form/SelectInput';
 import SaveWidgetModal from 'components/modal/SaveWidgetModal';
 import HowToWidgetEditorModal from 'components/modal/HowToWidgetEditorModal';
+import UploadAreaIntersectionModal from 'components/modal/UploadAreaIntersectionModal';
+
+const AREAS = [
+  {
+    label: 'Custom area',
+    value: 'custom',
+    items: [
+      {
+        label: 'Upload new area',
+        value: 'upload'
+      }
+    ]
+  }
+];
 
 @DragDropContext(HTML5Backend)
 class ChartEditor extends React.Component {
@@ -29,6 +44,32 @@ class ChartEditor extends React.Component {
     this.state = {
       areaOptions: []
     };
+  }
+
+  componentWillMount() {
+    this.fetchAreas();
+  }
+
+  /**
+   * Event handler executed when the selected area
+   * intersection is changed
+   * @param {{ label: string, value: string }} item Option of the selector
+   */
+  @Autobind
+  onChangeAreaIntersection(item) {
+    if (item.value === 'upload') {
+      this.props.toggleModal(true, {
+        children: UploadAreaIntersectionModal,
+        childrenProps: {
+          onAreaUploaded: (id) => {
+            // We close the modal
+            this.props.toggleModal(false, {});
+
+            // TODO: do something with the id
+          }
+        }
+      });
+    }
   }
 
   @Autobind
@@ -64,9 +105,12 @@ class ChartEditor extends React.Component {
     this.props.setModalOptions(options);
   }
 
-  @Autobind
-  handleShareEmbed() {
-
+  /**
+   * Fetch the list of the areas for the area intersection
+   * filter
+   */
+  fetchAreas() {
+    this.setState({ areaOptions: AREAS });
   }
 
   render() {
@@ -112,7 +156,8 @@ class ChartEditor extends React.Component {
           }
           <div className="area-intersection">
             <h5>Area intersection</h5>
-            <Select
+            <CustomSelect placeholder="Select area" options={areaOptions} onValueChange={this.onChangeAreaIntersection} />
+            {/* <Select
               properties={{
                 className: 'area-intersection-selector',
                 name: 'area-intersection',
@@ -121,7 +166,7 @@ class ChartEditor extends React.Component {
               }}
               options={areaOptions}
               onChange={this.handleAreaIntersectionChange}
-            />
+            /> */}
           </div>
         </div>
         <div className="text-container">
@@ -208,7 +253,7 @@ const mapDispatchToProps = dispatch => ({
   setChartType: (type) => {
     dispatch(setChartType(type));
   },
-  toggleModal: (open) => { dispatch(toggleModal(open)); },
+  toggleModal: (open, opts) => { dispatch(toggleModal(open, opts)); },
   setModalOptions: (options) => { dispatch(setModalOptions(options)); }
 });
 

--- a/components/widgets/ChartEditor.js
+++ b/components/widgets/ChartEditor.js
@@ -213,8 +213,7 @@ class ChartEditor extends React.Component {
             </div>
           }
           <div className="area-intersection">
-            { loadingAreaIntersection && <Spinner isLoading className="-light -small" /> }
-            <h5>Area intersection</h5>
+            <h5>Area intersection { loadingAreaIntersection && <Spinner isLoading className="-light -small -inline" /> }</h5>
             <CustomSelect
               placeholder="Select area"
               options={areaOptions}

--- a/css/components/modal/upload_area_intersection_modal.scss
+++ b/css/components/modal/upload_area_intersection_modal.scss
@@ -1,0 +1,68 @@
+.c-upload-area-intersection-modal {
+  p a {
+    color: $color-secondary;
+    text-decoration: none;
+  }
+
+  .c-dropzone {
+    margin: 40px 0;
+  }
+
+  .dropzone-file-input {
+    display: flex;
+    height: 45px;
+    margin-top: 40px;
+    padding: 5px;
+    border: 1px solid $border-color-1;
+    border-radius: 4px;
+
+    &.-active {
+      border-color: $color-primary;
+    }
+
+    > div {
+      flex-grow: 1;
+      padding: 5px 15px;
+    }
+
+    > button {
+      flex-shrink: 0;
+      padding: 0 5px;
+    }
+  }
+
+  .dropzone-file-errors {
+    width: 100%;
+    padding: 10px 20px;
+    list-style: none;
+    background-color: rgba(250,183,46,0.2);
+    border-radius: 4px;
+
+    span {
+      display: inline-block;
+      margin-right: 5px;
+      padding: 2px 8px;
+      color: $color-white;
+      background-color: $color-mango;
+      border-radius: 4px;
+    }
+  }
+
+  .complementary-info {
+    margin-top: 40px;
+    font-size: $font-size-default;
+
+    p {
+      margin: 0;
+    }
+
+    ul {
+      margin: 10px 0;
+      padding-left: 25px;
+
+      li + li {
+        margin-top: 5px;
+      }
+    }
+  }
+}

--- a/css/components/ui/custom_select.scss
+++ b/css/components/ui/custom_select.scss
@@ -34,7 +34,12 @@
 
   &.-closed {
     .custom-select-search {
-      display: none;
+      // Don't use display: none here
+      // For accessibility reasons (focus) the input
+      // can't be hidden
+      opacity: 0;
+      visibility: none;
+      cursor: pointer;
     }
 
     &:after {
@@ -57,6 +62,10 @@
     &:focus {
       outline: none;
     }
+  }
+
+  .clear-button {
+    z-index: 20; // Must be superior than the z-index of custom-select-search
   }
 
   .no-results {
@@ -150,6 +159,10 @@
         background-color: rgba($color-charcoal-grey, .05);
       }
 
+      &[aria-selected="true"] {
+        color: $color-primary;
+      }
+
       & .label {
         flex-grow: 1;
         display: inline-block;
@@ -160,6 +173,7 @@
       .next {
         padding: 17px;
         height: 100%;
+        cursor: pointer;
 
         &:hover {
           background-color: rgba(#4a81b9, .05);
@@ -170,7 +184,6 @@
 
   .custom-select-search {
     background-color: transparent;
-    cursor: pointer;
     color: $base-font-color;
     outline: none;
     border: none;

--- a/css/components/ui/spinner.scss
+++ b/css/components/ui/spinner.scss
@@ -17,6 +17,16 @@
   // Position
   &.-fixed { position: fixed;}
   &.-relative { position: relative;}
+  &.-inline {
+    position: static;
+    display: inline-block;
+    background: none;
+
+    .spinner-box {
+      position: static;
+      transform: none;
+    }
+  }
 
   // State
   &.-loading {

--- a/css/components/widgets/chart_editor.scss
+++ b/css/components/widgets/chart_editor.scss
@@ -16,6 +16,7 @@
     }
 
     .area-intersection {
+      position: relative; // Needed for the spinner
       width: 100%;
 
       .area-intersection-selector {

--- a/css/components/widgets/chart_editor.scss
+++ b/css/components/widgets/chart_editor.scss
@@ -5,18 +5,23 @@
     display: flex;
     justify-content: space-between;
 
-    .chart-type {
-      width: 100%;
-      margin-right: 20px;
+    h5 {
+      font-size: $font-size-small-medium;
+      line-height: 23px; // Height needed for the spinner
+      margin-bottom: 2px;
 
-      h5 {
-        margin: 0 0 10px;
-        font-size: $font-size-small-medium;
+      .c-spinner {
+        margin-left: 5px;
+        vertical-align: middle;
       }
     }
 
+    .chart-type {
+      width: 100%;
+      margin-right: 20px;
+    }
+
     .area-intersection {
-      position: relative; // Needed for the spinner
       width: 100%;
 
       .area-intersection-selector {

--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -19,7 +19,7 @@
     box-shadow: 0 1px 2px 0 rgba($color-black, .09);
     background-color: $color-white;
 
-    .title {
+    > .title {
       margin: 20px 0;
       color: $color-dark-pink;
       font-weight: $font-weight-light;

--- a/css/index.scss
+++ b/css/index.scss
@@ -56,6 +56,7 @@
 @import "./components/modal/embed_my_widget_modal";
 @import "./components/modal/share_modal_explore";
 @import "./components/modal/embed_layer_modal";
+@import "./components/modal/upload_area_intersection_modal";
 
 // VIS
 @import "./components/vis/globe";

--- a/redactions/modal.js
+++ b/redactions/modal.js
@@ -25,7 +25,12 @@ export default function (state = initialState, action) {
     case MODAL_TOGGLE:
       return Object.assign({}, state, { open: action.payload });
     case MODAL_SET_OPTIONS:
-      return Object.assign({}, state, { options: action.payload });
+      return Object.assign({}, state, {
+        options: Object.assign({}, state.options, action.payload, {
+          // We remove the callback if not present
+          onCloseModal: action.payload.onCloseModal ? action.payload.onCloseModal : null
+        })
+      });
     case MODAL_LOADING:
       return Object.assign({}, state, { loading: action.payload });
     case MODAL_EXECUTE_CLOSE_CALLBACK:

--- a/redactions/modal.js
+++ b/redactions/modal.js
@@ -4,6 +4,7 @@
 const MODAL_TOGGLE = 'MODAL_TOGGLE';
 const MODAL_SET_OPTIONS = 'MODAL_SET_OPTIONS';
 const MODAL_LOADING = 'MODAL_LOADING';
+const MODAL_EXECUTE_CLOSE_CALLBACK = 'MODAL_EXECUTE_CLOSE_CALLBACK';
 
 // REDUCER
 const initialState = {
@@ -11,7 +12,10 @@ const initialState = {
   options: {
     children: null,
     childrenProps: null,
-    size: ''
+    size: '',
+    // Callback executed if the user closes the modal (user interaction)
+    // (not executed when toggleModal is executed)
+    onCloseModal: null
   },
   loading: false
 };
@@ -24,6 +28,13 @@ export default function (state = initialState, action) {
       return Object.assign({}, state, { options: action.payload });
     case MODAL_LOADING:
       return Object.assign({}, state, { loading: action.payload });
+    case MODAL_EXECUTE_CLOSE_CALLBACK:
+      if (state.options.onCloseModal) {
+        // We make the call asynchronous to avoid blocking the state
+        // from being computed
+        setTimeout(() => state.options.onCloseModal(), 0);
+      }
+      return state;
     default:
       return state;
   }
@@ -40,11 +51,16 @@ export function closeModal() {
   return dispatch => dispatch({ type: MODAL_TOGGLE });
 }
 
-export function toggleModal(open, opts = {}) {
+export function toggleModal(open, opts = {}, userInteraction = false) {
   return (dispatch) => {
     if (open && opts) {
       dispatch({ type: MODAL_SET_OPTIONS, payload: opts });
     }
+
+    if (userInteraction) {
+      dispatch({ type: MODAL_EXECUTE_CLOSE_CALLBACK });
+    }
+
     dispatch({ type: MODAL_TOGGLE, payload: open });
   };
 }

--- a/redactions/widgetEditor.js
+++ b/redactions/widgetEditor.js
@@ -21,6 +21,7 @@ const SHOW_LAYER = 'widgetEditor/SHOW_LAYER';
 const SET_FIELDS = 'widgetEditor/SET_FIELDS';
 const SET_LIMIT = 'widgetEditor/SET_LIMIT';
 const RESET = 'widgetEditor/RESET';
+const SET_AREA_INTERSEACTION = 'widgetEditor/SET_AREA_INTERSEACTION';
 
 /**
  * REDUCER
@@ -35,7 +36,8 @@ const initialState = {
   value: null,
   layer: null,
   fields: [],
-  limit: 500
+  limit: 500,
+  areaIntersection: null // ID of the geostore object
 };
 
 export default function (state = initialState, action) {
@@ -179,6 +181,12 @@ export default function (state = initialState, action) {
       });
     }
 
+    case SET_AREA_INTERSEACTION: {
+      return Object.assign({}, state, {
+        areaIntersection: action.payload
+      });
+    }
+
     default:
       return state;
   }
@@ -265,4 +273,8 @@ export function setFields(layer) {
 }
 export function setLimit(limit) {
   return dispatch => dispatch({ type: SET_LIMIT, payload: limit });
+}
+
+export function setAreaIntersection(id) {
+  return dispatch => dispatch({ type: SET_AREA_INTERSEACTION, payload: id });
 }

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -113,7 +113,8 @@ export function getDataURL(widgetEditor, tableName, dataset) {
     aggregateFunction,
     orderBy,
     limit,
-    chartType
+    chartType,
+    areaIntersection
   } = widgetEditor;
   const aggregateFunctionColor = color && color.aggregateFunction;
   const aggregateFunctionSize = size && size.aggregateFunction;
@@ -170,8 +171,9 @@ export function getDataURL(widgetEditor, tableName, dataset) {
   const sortOrder = orderBy ? orderBy.orderType : 'asc';
   const query = `${getQueryByFilters(tableName, filters, columns, orderByColumn, sortOrder)} LIMIT ${limit}`;
 
-  // TODO: remove the limit
-  return `${process.env.WRI_API_URL}/query/${dataset}?sql=${query}`;
+  const geostore = areaIntersection ? `&geostore=${areaIntersection}` : '';
+
+  return `${process.env.WRI_API_URL}/query/${dataset}?sql=${query}${geostore}`;
 }
 
 /**


### PR DESCRIPTION
This PR implements the feature to let the user upload an area or to select a country for intersection with the data of the widget.

<p align="center">
<img width="921" alt="Modal that lets the user upload an area" src="https://user-images.githubusercontent.com/6073968/28883485-8d0b685c-77a6-11e7-895e-ab57da2b52af.png">
</p>

In order to implement the feature, major changes has been made to the component `SliderSelect`:
* several (hopefully all) of its bugs have been fixed
* the code has been fully commented
* two props have been added:
  * `allowNonLeafSelection` forces the user to select a leaf node in the tree
  * `waitForChangeConfirmation` makes the component wait for the result of the callback prop `onValueChange` before setting an option as selected (can be asynchronous)

The `Modal` component has also received a small change: when the user closes it with the close button, by pressing the ESC key or by clicking the overlay, a callback can be executed (callback named `onCloseModal` that has to be passed with the options).