### PR TITLE
Feature/new dashboards

### DIFF
--- a/css/components/app/pages/dashboards.scss
+++ b/css/components/app/pages/dashboards.scss
@@ -126,6 +126,60 @@
 
   .user-content {
     margin-top: 30px;
+
+    img {
+      max-width: 100%;
+      border-radius: 4px;
+
+      @media screen and (min-width: $grid-row-width) {
+        max-width: $grid-row-width;
+        max-height: 100vh; // Improvement for portrait images
+        margin: 0 auto; // Needed for portrait images
+        // The following 3 lines are used to center the photo
+        // with the content
+        position: relative;
+        left: 50%;
+        transform: translateX(-50%);
+      }
+    }
+
+    .columns {
+      display: flex;
+      justify-content: space-between;
+      align-items: stretch;
+      margin: 50px 0;
+      padding: 0;
+
+      @media screen and (min-width: $grid-row-width) {
+        width: $grid-row-width;
+        // The following 3 lines are used to center the photo
+        // with the content
+        position: relative;
+        left: 50%;
+        transform: translateX(-50%);
+      }
+
+      @for $i from 1 through 2 {
+        > .column-#{$i} {
+          flex-basis: 100%;
+          flex-shrink: 0;
+          flex-grow: 0;
+
+          @media screen and (min-width: map-get($breakpoints, medium)) {
+            flex-basis: calc(#{100% / $i} - #{(($i - 1) * 20px) / $i});
+          }
+
+          & + .column-#{$i} {
+            margin-top: 20px;
+
+            @media screen and (min-width: map-get($breakpoints, medium)) {
+              margin-top: 0;
+              margin-left: 20px;
+            }
+          }
+        }
+      }
+    }
   }
 
 }

--- a/css/components/app/pages/dashboards.scss
+++ b/css/components/app/pages/dashboards.scss
@@ -1,8 +1,14 @@
 .c-page-dashboards {
 
   .info {
+    position: relative; // Needed for the spinner
     padding: 50px 0 70px;
     background-color: $bg-color-2;
+  }
+
+  .error {
+    text-align: center;
+    font-weight: $font-weight-bold;
   }
 
   .dashboards-list {
@@ -101,6 +107,11 @@
   }
 
   .widgets-list {
+    // For some reasons, because .info has a relative position,
+    // if this selector doesn't have it too, the cards inside of
+    // it are cut at the top (probably a conflict with the
+    // negative margin)
+    position: relative;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
@@ -111,6 +122,10 @@
       flex-basis: calc(50% - 10px);
       margin-bottom: 20px;
     }
+  }
+
+  .user-content {
+    margin-top: 30px;
   }
 
 }

--- a/css/components/app/pages/dashboards.scss
+++ b/css/components/app/pages/dashboards.scss
@@ -143,7 +143,7 @@
       }
     }
 
-    .columns {
+    .dashboard-row {
       display: flex;
       justify-content: space-between;
       align-items: stretch;
@@ -160,7 +160,7 @@
       }
 
       @for $i from 1 through 2 {
-        > .column-#{$i} {
+        > .dashboard-column-#{$i} {
           flex-basis: 100%;
           flex-shrink: 0;
           flex-grow: 0;
@@ -169,7 +169,7 @@
             flex-basis: calc(#{100% / $i} - #{(($i - 1) * 20px) / $i});
           }
 
-          & + .column-#{$i} {
+          & + .dashboard-column-#{$i} {
             margin-top: 20px;
 
             @media screen and (min-width: map-get($breakpoints, medium)) {

--- a/pages/app/Dashboards.js
+++ b/pages/app/Dashboards.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import classnames from 'classnames';
 
 // Router
 import { Router } from 'routes';
@@ -9,17 +8,36 @@ import Page from 'components/app/layout/Page';
 import Layout from 'components/app/layout/Layout';
 import Title from 'components/ui/Title';
 import Breadcrumbs from 'components/ui/Breadcrumbs';
+import Spinner from 'components/ui/Spinner';
 
 // Utils
 import DASHBOARDS from 'utils/dashboards/config';
 
 class Dashboards extends Page {
 
+  /**
+   * Fetch the list of dashboards
+   * @static
+   * @returns {Promise<{ name: string, slug: string, photo: string }[]>}
+   */
+  static async fetchDashboards() {
+    return fetch(`${process.env.API_URL}/dashboards?fields[dashboards]=name,slug,photo`)
+      .then((response) => {
+        if (response.ok) return response.json();
+        throw new Error('Unable to fetch the dashboards');
+      })
+      .then(({ data }) => data.map(d => d.attributes));
+  }
+
   constructor(props) {
     super(props);
     this.state = {
       // List of dashboards
-      dashboards: []
+      dashboards: [],
+      // Whether we're loading the dashboards
+      loading: false,
+      // Error message
+      error: null
     };
   }
 
@@ -45,10 +63,18 @@ class Dashboards extends Page {
   /**
    * Fetch the dashboards and save them in the state
    */
-  getDashboards() {
-    // We store the dashboards in the state
-    const dashboards = DASHBOARDS;
-    this.setState({ dashboards });
+  async getDashboards() {
+    this.setState({ loading: true, error: null });
+
+    try {
+      const staticDashboards = DASHBOARDS;
+      const dynamicDashboards = await Dashboards.fetchDashboards();
+      this.setState({ dashboards: [...staticDashboards, ...dynamicDashboards] });
+    } catch (err) {
+      this.setState({ error: err.message });
+    } finally {
+      this.setState({ loading: false });
+    }
   }
 
   render() {
@@ -73,6 +99,7 @@ class Dashboards extends Page {
           </div>
 
           <div className="info">
+            { this.state.loading && <Spinner isLoading className="-light" /> }
             <div className="row">
               <div className="column small-12">
                 <ul className="dashboards-list">
@@ -80,18 +107,14 @@ class Dashboards extends Page {
                     this.state.dashboards
                       .map(dashboard => (
                         <li
-                          className={classnames({
-                            '-disabled': !dashboard.widgets.length
-                          })}
                           key={dashboard.slug}
-                          style={{ backgroundImage: `url(/${dashboard.image})` }}
+                          style={{ backgroundImage: `url(/${dashboard.photo})` }}
                         >
                           <input
                             type="radio"
                             name="dashboard"
                             id={`dashboard-${dashboard.slug}`}
                             value={dashboard.slug}
-                            disabled={!dashboard.widgets.length}
                             onChange={e => Dashboards.onChangeDashboard(e.target.value)}
                           />
                           <label className="content" htmlFor={`dashboard-${dashboard.slug}`}>
@@ -104,9 +127,16 @@ class Dashboards extends Page {
               </div>
             </div>
             <div className="row">
-              <div className="column small-12 large-7 dashboard-info">
-                <Title className="-extrabig -secondary">Select a topic to start exploring</Title>
-              </div>
+              { this.state.error && (
+                <div className="column small-12">
+                  <p className="error">{this.state.error}</p>
+                </div>
+              ) }
+              { !this.state.loading && !this.state.error && (
+                <div className="column small-12 large-7 dashboard-info">
+                  <Title className="-extrabig -secondary">Select a topic to start exploring</Title>
+                </div>
+              ) }
             </div>
           </div>
 

--- a/pages/app/Dashboards.js
+++ b/pages/app/Dashboards.js
@@ -108,7 +108,9 @@ class Dashboards extends Page {
                       .map(dashboard => (
                         <li
                           key={dashboard.slug}
-                          style={{ backgroundImage: `url(/${dashboard.photo})` }}
+                          style={{ backgroundImage: dashboard.photo && (
+                            dashboard.photo.startsWith('data:image/') ? `url(${dashboard.photo})` : `url(/${dashboard.photo})`
+                          ) }}
                         >
                           <input
                             type="radio"

--- a/pages/app/DashboardsDetail.js
+++ b/pages/app/DashboardsDetail.js
@@ -253,7 +253,7 @@ export default class DashboardsDetail extends Page {
             ) }
             { selectedDashboard && !selectedDashboard.widgets && (
               <div
-                className="column small-12 user-content"
+                className="user-content column small-12 large-8 large-offset-2"
                 dangerouslySetInnerHTML={{ __html: selectedDashboard.content }} // eslint-disable-line react/no-danger, max-len
               />
             ) }

--- a/pages/app/DashboardsDetail.js
+++ b/pages/app/DashboardsDetail.js
@@ -182,7 +182,9 @@ export default class DashboardsDetail extends Page {
                             '-active': selectedDashboard === dashboard
                           })}
                           key={dashboard.slug}
-                          style={{ backgroundImage: `url(/${dashboard.photo})` }}
+                          style={{ backgroundImage: dashboard.photo && (
+                            dashboard.photo.startsWith('data:image/') ? `url(${dashboard.photo})` : `url(/${dashboard.photo})`
+                          ) }}
                         >
                           <input
                             type="radio"

--- a/pages/app/DashboardsDetail.js
+++ b/pages/app/DashboardsDetail.js
@@ -10,6 +10,7 @@ import Layout from 'components/app/layout/Layout';
 import Title from 'components/ui/Title';
 import Breadcrumbs from 'components/ui/Breadcrumbs';
 import DashboardCard from 'components/app/dashboards/DashboardCard';
+import Spinner from 'components/ui/Spinner';
 
 // Services
 import UserService from 'services/UserService';
@@ -19,9 +20,27 @@ import DASHBOARDS from 'utils/dashboards/config';
 
 export default class DashboardsDetail extends Page {
 
+  /**
+   * Fetch the list of dashboards
+   * @static
+   * @returns {Promise<{ name: string, slug: string, photo: string }[]>}
+   */
+  static async fetchDashboards() {
+    return fetch(`${process.env.API_URL}/dashboards?fields[dashboards]=name,slug,photo`)
+      .then((response) => {
+        if (response.ok) return response.json();
+        throw new Error('Unable to fetch the dashboards');
+      })
+      .then(({ data }) => data.map(d => d.attributes));
+  }
+
   constructor(props) {
     super(props);
     this.state = {
+      // Whether we're loading the dashboards
+      loading: false,
+      // Error message
+      error: null,
       // List of dashboards
       dashboards: [],
       // Pointer to the selected dashboard
@@ -108,13 +127,22 @@ export default class DashboardsDetail extends Page {
    * Fetch the dashboards, save them in the state, set a default
    * selected dashboard and update the URL
    */
-  getDashboards() {
-    // We store the dashboards in the state
-    const dashboards = DASHBOARDS;
-    this.setState({ dashboards });
+  async getDashboards() {
+    this.setState({ loading: true, error: null });
 
-    // We set the dashboard associated with the slug
-    this.onChangeDashboard(this.props.url.query.slug, dashboards);
+    try {
+      const staticDashboards = DASHBOARDS;
+      const dynamicDashboards = await DashboardsDetail.fetchDashboards();
+      const dashboards = [...staticDashboards, ...dynamicDashboards];
+      this.setState({ dashboards });
+
+      // We set the dashboard associated with the slug
+      this.onChangeDashboard(this.props.url.query.slug, dashboards);
+    } catch (err) {
+      this.setState({ error: err.message });
+    } finally {
+      this.setState({ loading: false });
+    }
   }
 
   render() {
@@ -124,7 +152,7 @@ export default class DashboardsDetail extends Page {
     return (
       <Layout
         title={dashboardName}
-        description="Resource Watch Dashboards"
+        description={selectedDashboard ? selectedDashboard.summary : 'Resource Watch Dashboards'}
         url={url}
         user={user}
         pageHeader
@@ -142,6 +170,7 @@ export default class DashboardsDetail extends Page {
           </div>
 
           <div className="info">
+            { this.state.loading && <Spinner isLoading className="-light" /> }
             <div className="row">
               <div className="column small-12">
                 <ul className="dashboards-list">
@@ -150,11 +179,10 @@ export default class DashboardsDetail extends Page {
                       .map(dashboard => (
                         <li
                           className={classnames({
-                            '-active': selectedDashboard === dashboard,
-                            '-disabled': !dashboard.widgets.length
+                            '-active': selectedDashboard === dashboard
                           })}
                           key={dashboard.slug}
-                          style={{ backgroundImage: `url(/${dashboard.image})` }}
+                          style={{ backgroundImage: `url(/${dashboard.photo})` }}
                         >
                           <input
                             type="radio"
@@ -162,7 +190,6 @@ export default class DashboardsDetail extends Page {
                             id={`dashboard-${dashboard.slug}`}
                             value={dashboard.slug}
                             checked={selectedDashboard === dashboard}
-                            disabled={!dashboard.widgets.length}
                             onChange={e => this.onChangeDashboard(e.target.value)}
                           />
                           <label className="content" htmlFor={`dashboard-${dashboard.slug}`}>
@@ -172,47 +199,64 @@ export default class DashboardsDetail extends Page {
                       ))
                       .slice(0, showMore ? dashboards.length : 5)
                   }
-                  <li className="-toggle">
-                    <button
-                      type="button"
-                      className="content"
-                      onClick={() => this.setState({ showMore: !showMore })}
-                    >
-                      <span>{ this.state.showMore ? 'Close' : 'More' }</span>
-                    </button>
-                  </li>
+                  { dashboards.length > 5 && (
+                    <li className="-toggle">
+                      <button
+                        type="button"
+                        className="content"
+                        onClick={() => this.setState({ showMore: !showMore })}
+                      >
+                        <span>{ this.state.showMore ? 'Close' : 'More' }</span>
+                      </button>
+                    </li>
+                  ) }
                 </ul>
               </div>
             </div>
-            <div className="row">
-              <div className="column small-12 large-7 dashboard-info">
-                <Title className="-extrabig -secondary">{selectedDashboard.name}</Title>
-                <p className="description">
-                  {selectedDashboard.description}
-                </p>
+            { this.state.error && (
+              <div className="column small-12">
+                <p className="error">{this.state.error}</p>
               </div>
-            </div>
+            ) }
+            { selectedDashboard && (
+              <div className="row">
+                <div className="column small-12 large-7 dashboard-info">
+                  <Title className="-extrabig -secondary">{selectedDashboard.name}</Title>
+                  <p className="description">
+                    {selectedDashboard.summary}
+                  </p>
+                </div>
+              </div>
+            ) }
           </div>
 
           <div className="row">
-            <div className="column small-12 widgets-list">
-              {
-                selectedDashboard.widgets.map(widget => (
-                  <DashboardCard
-                    key={widget.name || widget.widgetId}
-                    // widget.widgetId doesn't exist for the "fake" widget
-                    // so React can complain about a null widgetId
-                    widgetId={widget.widgetId}
-                    categories={widget.categories}
-                    isFavourite={this.isFavourite(widget.widgetId)}
-                    // The following attributes will be deprecated once all the
-                    // widgets are fetched from the API
-                    name={widget.name}
-                    data={widget.data}
-                  />
-                ))
-              }
-            </div>
+            { selectedDashboard && selectedDashboard.widgets && (
+              <div className="column small-12 widgets-list">
+                {
+                  selectedDashboard.widgets.map(widget => (
+                    <DashboardCard
+                      key={widget.name || widget.widgetId}
+                      // widget.widgetId doesn't exist for the "fake" widget
+                      // so React can complain about a null widgetId
+                      widgetId={widget.widgetId}
+                      categories={widget.categories}
+                      isFavourite={this.isFavourite(widget.widgetId)}
+                      // The following attributes will be deprecated once all the
+                      // widgets are fetched from the API
+                      name={widget.name}
+                      data={widget.data}
+                    />
+                  ))
+                }
+              </div>
+            ) }
+            { selectedDashboard && !selectedDashboard.widgets && (
+              <div
+                className="column small-12 user-content"
+                dangerouslySetInnerHTML={{ __html: selectedDashboard.content }} // eslint-disable-line react/no-danger, max-len
+              />
+            ) }
           </div>
 
         </div>

--- a/utils/dashboards/config.js
+++ b/utils/dashboards/config.js
@@ -7,8 +7,8 @@ export default [
   {
     name: 'Water',
     slug: 'water',
-    description: 'Water is vital to the natural and manmade systems of our planet. Understanding global water challenges requires timely, relevant information about the many factors that impact water quantity and quality, the health of freshwater ecosystems, and access to safe water sources.',
-    image: 'static/images/dashboards/dashboard-water.jpg',
+    summary: 'Water is vital to the natural and manmade systems of our planet. Understanding global water challenges requires timely, relevant information about the many factors that impact water quantity and quality, the health of freshwater ecosystems, and access to safe water sources.',
+    photo: 'static/images/dashboards/dashboard-water.jpg',
     widgets: [
       {
         widgetId: '6f01a91e-bb68-4d10-9da4-e48b553193f3',
@@ -132,64 +132,64 @@ export default [
   {
     name: 'Countries',
     slug: 'countries',
-    image: 'static/images/dashboards/dashboard-Cities.jpg',
+    photo: 'static/images/dashboards/dashboard-Cities.jpg',
     widgets: [{}]
   },
-  {
-    name: 'Cities',
-    slug: 'cities',
-    description: '',
-    image: 'static/images/dashboards/dashboard-Cities.jpg',
-    widgets: []
-  },
-  {
-    name: 'Society',
-    slug: 'society',
-    description: '',
-    image: 'static/images/dashboards/dashboard-Society.jpg',
-    widgets: []
-  },
-  {
-    name: 'Food',
-    slug: 'food',
-    description: '',
-    image: 'static/images/dashboards/dashboard-Food.jpg',
-    widgets: []
-  },
-  {
-    name: 'Energy',
-    slug: 'energy',
-    description: '',
-    image: 'static/images/dashboards/dashboard-Energy.jpg',
-    widgets: []
-  },
-  {
-    name: 'Forests',
-    slug: 'forests',
-    description: '',
-    image: 'static/images/dashboards/dashboard-Forests.jpg',
-    widgets: []
-  },
-  {
-    name: 'Biodiversity',
-    slug: 'biodiversity',
-    description: '',
-    image: 'static/images/dashboards/dashboard-Biodiversity.jpg',
-    widgets: []
-  },
-  {
-    name: 'Climate',
-    slug: 'climate',
-    description: '',
-    image: 'static/images/dashboards/dashboard-Climate.jpg',
-    widgets: []
-  },
-  {
-    name: 'Disasters',
-    slug: 'disasters',
-    description: '',
-    image: 'static/images/dashboards/dashboard-Disasters.jpg',
-    widgets: []
-  }
+  // {
+  //   name: 'Cities',
+  //   slug: 'cities',
+  //   summary: '',
+  //   photo: 'static/images/dashboards/dashboard-Cities.jpg',
+  //   widgets: []
+  // },
+  // {
+  //   name: 'Society',
+  //   slug: 'society',
+  //   summary: '',
+  //   photo: 'static/images/dashboards/dashboard-Society.jpg',
+  //   widgets: []
+  // },
+  // {
+  //   name: 'Food',
+  //   slug: 'food',
+  //   summary: '',
+  //   photo: 'static/images/dashboards/dashboard-Food.jpg',
+  //   widgets: []
+  // },
+  // {
+  //   name: 'Energy',
+  //   slug: 'energy',
+  //   summary: '',
+  //   photo: 'static/images/dashboards/dashboard-Energy.jpg',
+  //   widgets: []
+  // },
+  // {
+  //   name: 'Forests',
+  //   slug: 'forests',
+  //   summary: '',
+  //   photo: 'static/images/dashboards/dashboard-Forests.jpg',
+  //   widgets: []
+  // },
+  // {
+  //   name: 'Biodiversity',
+  //   slug: 'biodiversity',
+  //   summary: '',
+  //   photo: 'static/images/dashboards/dashboard-Biodiversity.jpg',
+  //   widgets: []
+  // },
+  // {
+  //   name: 'Climate',
+  //   slug: 'climate',
+  //   summary: '',
+  //   photo: 'static/images/dashboards/dashboard-Climate.jpg',
+  //   widgets: []
+  // },
+  // {
+  //   name: 'Disasters',
+  //   slug: 'disasters',
+  //   summary: '',
+  //   photo: 'static/images/dashboards/dashboard-Disasters.jpg',
+  //   widgets: []
+  // }
 ];
 /* eslint-enable */


### PR DESCRIPTION
This PR updates the dashboard pages so they can take into account the dashboards created through the wysiwyg.

I've created a sample dashboard to test the styles: http://localhost:3000/data/dashboards/cities
There you can see how landscape and portrait images, lists, basic formatting (bold, italic, underlined) and the widgets would look like.

By default, all the images will resize to take the full width, if landscape, or won't be taller than the screen height, if portrait. In order to have a big widget or to have two of them side by side, you need to use a wrapper with the class `columns` and then for each column, you'll have a div with the class `column-X` (`X` being `1` or `2`). For example, this would display two columns side by side:
```html
<div class="columns">
  <div class="column-2">Column 1</div>
  <div class="column-2">Column 2</div>
</div>
```

And this would display one column taking the full width:
```html
<div class="columns">
  <div class="column-1">Some important content here</div>
</div>
```

**NOTE:** I've been unable to upload a photo for the dashboard through the API, but I've locally tested displaying a base64 image for the dashboards list.