### PR TITLE
Fix/embeds

### DIFF
--- a/components/ui/Tooltip.js
+++ b/components/ui/Tooltip.js
@@ -3,7 +3,7 @@ import TetherComponent from 'react-tether';
 import classnames from 'classnames';
 import { initStore } from 'store';
 import withRedux from 'next-redux-wrapper';
-import { toggleTooltip, setTooltipPosition } from 'redactions/tooltip';
+import { setTooltipPosition } from 'redactions/tooltip';
 
 class Tooltip extends React.Component {
 
@@ -72,9 +72,11 @@ class Tooltip extends React.Component {
         ref={(node) => { this.tether = node; }}
         attachment="bottom center"
         targetAttachment="top center"
-        constraints={[{ // Make the tooltip follow the page (i.e. can be hidden if scrolled)
-          to: 'scrollParent',
-          attachment: 'together'
+        constraints={[{
+          // Don't use the "together attachement" without making sure
+          // the tooltip doesn't disappear in an embedded widget when
+          // the cursor is at the top of the iframe
+          to: 'scrollParent'
         }]}
         classes={{
           element: tooltipClasses
@@ -103,7 +105,6 @@ const mapStateToProps = ({ tooltip }) => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  toggleTooltip: () => { dispatch(toggleTooltip()); },
   setTooltipPosition: (pos) => { dispatch(setTooltipPosition(pos)); }
 });
 

--- a/components/widgets/VegaChart.js
+++ b/components/widgets/VegaChart.js
@@ -145,7 +145,8 @@ class VegaChart extends React.Component {
     // [2] As the scatter plot can have several points at the same
     //     x position, we want to avoid showing the data of a
     //     random point when not hovering a dot
-    const hasXAxis = !!(vegaConfig.axes && vegaConfig.axes.find(axis => axis.type === 'x'));
+    const xAxis = vegaConfig.axes && vegaConfig.axes.find(axis => axis.type === 'x');
+    const hasXAxis = !!(xAxis && (xAxis.real === undefined || xAxis.real));
     const isScatter = vegaConfig.marks.length === 1 && vegaConfig.marks[0].type === 'symbol';
     if (!hasXAxis || !visData || x === undefined || x === null || isScatter) {
       return this.props.toggleTooltip(false);

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -53,8 +53,8 @@ export default class EmbedWidget extends React.Component {
     return (
       <div className="c-embed-widget">
         <Head
-          title={widget && widget.attributes.name}
-          description={widget && widget.attributes.name}
+          title={(widget && widget.attributes.name) || 'Loading...'}
+          description={(widget && widget.attributes.name) || 'Loading..'}
         />
         <Tooltip />
         <Spinner
@@ -67,6 +67,7 @@ export default class EmbedWidget extends React.Component {
               data={widget.attributes.widgetConfig}
               theme={ChartTheme()}
               toggleLoading={this.triggerToggleLoading}
+              reloadOnResize
             />
             <div className="info">
               <div className="widget-title">

--- a/utils/widgets/bar.js
+++ b/utils/widgets/bar.js
@@ -35,7 +35,8 @@ const defaultChart = {
       name: 'x',
       type: 'ordinal',
       range: 'width',
-      domain: { data: 'table', field: 'x' }
+      domain: { data: 'table', field: 'x' },
+      real: false
     },
     {
       name: 'y',
@@ -43,6 +44,7 @@ const defaultChart = {
       "rangeMin": 300,
       "rangeMax": 0,
       domain: { data: 'table', field: 'y' },
+      real: false
     }
   ],
   // This axis is not used by the marks

--- a/utils/widgets/pie.js
+++ b/utils/widgets/pie.js
@@ -38,7 +38,8 @@ const defaultChart = {
         "labels": {
           "text": {"template": ""},
         }
-      }
+      },
+      "real": false
     },
     {
       "type": "y",
@@ -49,7 +50,8 @@ const defaultChart = {
         "labels": {
           "text": {"template": ""},
         }
-      }
+      },
+      "real": false
     }
   ],
   "marks": [


### PR DESCRIPTION
This PR fixes 3 issues with the embedded widgets:
* The tooltip would disappear if it wouldn't fit in the iframe; it's now cut at the top (not the ideal solution though)
* Some prop validation failures would be thrown in the console
* The tooltip would show wrong information for the pie chart when a slice wouldn't be hovered anymore (broader issue than the embed)