### PR TITLE
Let the user upload an area when subscribing to a dataset

### DIFF
--- a/components/modal/SubscribeToDatasetModal.js
+++ b/components/modal/SubscribeToDatasetModal.js
@@ -241,7 +241,7 @@ class SubscribeToDatasetModal extends React.Component {
             </div>
             { uploadArea && (
               <div className="upload-form">
-                <UploadAreaIntersectionModal onUploadArea={this.onUploadArea} />
+                <UploadAreaIntersectionModal onUploadArea={this.onUploadArea} embed />
               </div>
             ) }
           </div>

--- a/components/modal/SubscribeToDatasetModal.js
+++ b/components/modal/SubscribeToDatasetModal.js
@@ -13,6 +13,7 @@ import UserService from 'services/UserService';
 // Components
 import CustomSelect from 'components/ui/CustomSelect';
 import Spinner from 'components/ui/Spinner';
+import UploadAreaIntersectionModal from 'components/modal/UploadAreaIntersectionModal';
 
 const AREAS = [
   {
@@ -30,7 +31,6 @@ const AREAS = [
 
 
 class SubscribeToDatasetModal extends React.Component {
-
   constructor(props) {
     super(props);
 
@@ -42,7 +42,8 @@ class SubscribeToDatasetModal extends React.Component {
       loading: false,
       saved: false,
       name: '',
-      geostore: null
+      geostore: null,
+      uploadArea: false // Whether the user wants to upload an area
     };
 
     // Services
@@ -54,29 +55,32 @@ class SubscribeToDatasetModal extends React.Component {
     this.loadAreas();
   }
 
+  componentDidUpdate(previousProps, previousState) {
+    // When the user clicks on "Upload area", the selector awaits for
+    // a confirmation before selecting the option
+    // During this period, the selector stays open, so we trigger a click
+    // somewhere else so it closes
+    if (!previousState.uploadArea && this.state.uploadArea) {
+      if (this.el) this.el.click();
+    }
+  }
+
   @Autobind
   async onChangeSelectedArea(value) {
     return new Promise((resolve) => {
-      if (value.value === 'upload') {
-        // this.props.toggleModal(true, {
-        //   children: UploadAreaIntersectionModal,
-        //   childrenProps: {
-        //     onUploadArea: (id) => {
-        //       // We close the modal
-        //       this.props.toggleModal(false, {});
-        //
-        //       this.setState({
-        //         geostore: id
-        //       });
-        //
-        //       resolve(true);
-        //     }
-        //   },
-        //   onCloseModal: () => resolve(false)
-        // });
+      // We delete the pointer to the old resolve method
+      if (this.activePromiseResolve) this.activePromiseResolve = null;
+
+      if (value && value.value === 'upload') {
+        // We store the resolve method so we can call it from another
+        // method and at any time
+        this.activePromiseResolve = resolve;
+
+        this.setState({ uploadArea: true });
       } else {
         this.setState({
-          selectedArea: value
+          selectedArea: value,
+          uploadArea: false
         });
         resolve(true);
       }
@@ -90,27 +94,31 @@ class SubscribeToDatasetModal extends React.Component {
     });
   }
 
-  loadAreas() {
-    this.setState({
-      loadingAreaOptions: true
-    });
-    this.areasService.fetchCountries().then((response) => {
-      this.setState({
-        areaOptions: [...AREAS, ...response.data],
-        loadingAreaOptions: false
-      });
-    });
+  @Autobind
+  onChangeSelectedType(type) {
+    this.setState({ selectedType: type });
   }
 
-  loadDatasets() {
-    this.datasetService.getSubscribableDatasets().then((response) => {
-      this.setState({
-        loadingDatasets: false,
-        datasets: response.filter(val => val.attributes.subscribable).map(val => (
-          { label: val.attributes.name, value: val.attributes.name, id: val.id }))
-      });
-    }).catch(err => console.log(err));
+  /**
+   * Event handler executed when the user sucessfully upload an area
+   * @param {string} id - Geostore ID
+   */
+  @Autobind
+  onUploadArea(id) {
+    // We tell the selector an area has been uploaded
+    if (this.activePromiseResolve) this.activePromiseResolve(true);
+    
+    this.setState({ selectedArea: id });
   }
+
+  @Autobind
+  handleCancel() {
+    this.setState({
+      saved: false
+    });
+    this.props.toggleModal(false);
+  }
+
 
   @Autobind
   handleSubscribe() {
@@ -149,17 +157,26 @@ class SubscribeToDatasetModal extends React.Component {
     });
   }
 
-  @Autobind
-  onChangeSelectedType(type) {
-    this.setState({ selectedType: type });
+  loadAreas() {
+    this.setState({
+      loadingAreaOptions: true
+    });
+    this.areasService.fetchCountries().then((response) => {
+      this.setState({
+        areaOptions: [...AREAS, ...response.data],
+        loadingAreaOptions: false
+      });
+    });
   }
 
-  @Autobind
-  handleCancel() {
-    this.setState({
-      saved: false
-    });
-    this.props.toggleModal(false);
+  loadDatasets() {
+    this.datasetService.getSubscribableDatasets().then((response) => {
+      this.setState({
+        loadingDatasets: false,
+        datasets: response.filter(val => val.attributes.subscribable).map(val => (
+          { label: val.attributes.name, value: val.attributes.name, id: val.id }))
+      });
+    }).catch(err => console.error(err)); // TODO: update the UI
   }
 
   render() {
@@ -170,7 +187,8 @@ class SubscribeToDatasetModal extends React.Component {
       selectedType,
       loading,
       saved,
-      name
+      name,
+      uploadArea
     } = this.state;
     const { dataset } = this.props;
     let headerText;
@@ -186,7 +204,7 @@ class SubscribeToDatasetModal extends React.Component {
       .map(val => ({ value: val, label: val }));
 
     return (
-      <div className="c-subscribe-to-dataset-modal">
+      <div className="c-subscribe-to-dataset-modal" ref={(node) => { this.el = node; }}>
         <div className="header-div">
           <h2>{headerText}</h2>
           <p>{paragraphText}</p>
@@ -221,6 +239,11 @@ class SubscribeToDatasetModal extends React.Component {
                 />
               </div>
             </div>
+            { uploadArea && (
+              <div className="upload-form">
+                <UploadAreaIntersectionModal onUploadArea={this.onUploadArea} />
+              </div>
+            ) }
           </div>
         }
 

--- a/components/modal/UploadAreaIntersectionModal.js
+++ b/components/modal/UploadAreaIntersectionModal.js
@@ -164,7 +164,8 @@ class UploadAreaIntersectionModal extends React.Component {
       accepted: accepted[0],
       rejected: rejected[0],
       dropzoneActive: false,
-      loading: true
+      loading: true,
+      errors: []
     }, () => {
       if (this.state.accepted) {
         UploadAreaIntersectionModal.processFile(this.state.accepted)
@@ -194,10 +195,25 @@ class UploadAreaIntersectionModal extends React.Component {
       fileInputContent = UploadAreaIntersectionModal.getFileName(this.state.accepted);
     }
 
+    const description = (
+      <div>
+        <p>
+          Drop a file in the designated area or click the button to upload it.
+          The recommended <strong>maximum file size is 1MB</strong>.
+          Anything larger than that may not work properly.
+        </p>
+        <p>
+          If you want to draw the area, you can use&nbsp;
+          <a href="http://geojson.io" target="_blank" rel="noopener noreferrer">geojson.io</a>
+          &nbsp;and download a file with one of the supported format below.
+        </p>
+      </div>
+    );
+
     return (
-      <div className="c-upload-area-intersection-modal">
+      <div className={classnames('c-upload-area-intersection-modal', { '-embed': this.props.embed })}>
         <Spinner isLoading={loading} className="-light" />
-        <h2>Upload a new area</h2>
+        { !this.props.embed && <h2>Upload a new area</h2> }
 
         <Dropzone
           ref={(node) => { this.dropzone = node; }}
@@ -211,17 +227,8 @@ class UploadAreaIntersectionModal extends React.Component {
           onDragEnter={this.onDragEnter}
           onDragLeave={this.onDragLeave}
         >
-          <p>
-            Drop a file in the designated area below or click the button to upload it.
-            The recommended <strong>maximum file size is 1MB</strong>.
-            Anything larger than that may not work properly.
-          </p>
-          <p>
-            If you want to draw the area, you can use&nbsp;
-            <a href="http://geojson.io" target="_blank" rel="noopener noreferrer">geojson.io</a>
-            &nbsp;and download a file with one of the supported format below.
-          </p>
 
+          { !this.props.embed && description }
 
           <div className={classnames({ 'dropzone-file-input': true, '-active': dropzoneActive })}>
             <div
@@ -247,18 +254,22 @@ class UploadAreaIntersectionModal extends React.Component {
             </ul>
           }
 
-          <div className="complementary-info">
-            <p>
-              List of supported file formats:
-            </p>
-            <ul>
-              <li>
-                Unzipped: <strong>.csv</strong> (must contain a geom column that contains geographic information), <strong>.geojson</strong>, <strong>.kml</strong>, <strong>.kmz</strong>, <strong>.wkt</strong>
-              </li>
-              <li>
-                Zipped: <strong>.shp</strong> (must include the .shp, .shx, .dbf and .prj files)
-              </li>
-            </ul>
+          <div className="info">
+            { this.props.embed && description }
+
+            <div className="complementary-info">
+              <p>
+                List of supported file formats:
+              </p>
+              <ul>
+                <li>
+                  Unzipped: <strong>.csv</strong> (must contain a geom column that contains geographic information), <strong>.geojson</strong>, <strong>.kml</strong>, <strong>.kmz</strong>, <strong>.wkt</strong>
+                </li>
+                <li>
+                  Zipped: <strong>.shp</strong> (must include the .shp, .shx, .dbf and .prj files)
+                </li>
+              </ul>
+            </div>
           </div>
         </Dropzone>
       </div>
@@ -268,7 +279,13 @@ class UploadAreaIntersectionModal extends React.Component {
 
 UploadAreaIntersectionModal.propTypes = {
   // Callback to call with the id of the area
-  onUploadArea: PropTypes.func.isRequired
+  onUploadArea: PropTypes.func.isRequired,
+  // Whether this component is embedded somewhere (not in a modal)
+  embed: PropTypes.bool
+};
+
+UploadAreaIntersectionModal.defaultProps = {
+  embed: false
 };
 
 export default UploadAreaIntersectionModal;

--- a/css/components/modal/subscribe_to_dataset_modal.scss
+++ b/css/components/modal/subscribe_to_dataset_modal.scss
@@ -5,7 +5,7 @@
   }
 
   .custom-select-options {
-    max-height: 200px;
+    max-height: 150px;
   }
 
   .name-container {
@@ -36,16 +36,15 @@
   }
 
   .upload-form {
-    border: 1px solid $border-color-2;
-    border-radius: 4px;
-    padding: $margin-size-small;
 
-    h2 {
-      font-size: $font-size-h3;
-    }
-
-    .c-dropzone {
-      margin-bottom: 0;
+    .info {
+      margin-top: 20px;
+      padding: $margin-size-extra-small;
+      border: 1px solid $border-color-2;
+      border-radius: 4px;
+      max-height: 120px;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
     }
   }
 

--- a/css/components/modal/subscribe_to_dataset_modal.scss
+++ b/css/components/modal/subscribe_to_dataset_modal.scss
@@ -39,8 +39,6 @@
 
     .info {
       margin-top: 20px;
-      padding: $margin-size-extra-small;
-      border: 1px solid $border-color-2;
       border-radius: 4px;
       max-height: 120px;
       overflow-y: auto;

--- a/css/components/modal/subscribe_to_dataset_modal.scss
+++ b/css/components/modal/subscribe_to_dataset_modal.scss
@@ -1,6 +1,4 @@
 .c-subscribe-to-dataset-modal {
-  position: relative;
-  height: 400px;
 
   h2 {
     color: $color-dark-pink;
@@ -37,6 +35,20 @@
     }
   }
 
+  .upload-form {
+    border: 1px solid $border-color-2;
+    border-radius: 4px;
+    padding: $margin-size-small;
+
+    h2 {
+      font-size: $font-size-h3;
+    }
+
+    .c-dropzone {
+      margin-bottom: 0;
+    }
+  }
+
   .icon-container {
     display: flex;
     justify-content: center;
@@ -44,9 +56,7 @@
   }
 
   .buttons {
-    position: absolute;
-    bottom: 0px;
-    left: 0px;
+    justify-content: flex-start;
 
     button:last-of-type {
       margin-left: 10px;

--- a/css/components/modal/upload_area_intersection_modal.scss
+++ b/css/components/modal/upload_area_intersection_modal.scss
@@ -13,7 +13,7 @@
     height: 45px;
     margin-top: 40px;
     padding: 5px;
-    border: 1px solid $border-color-1;
+    border: 1px solid $border-color-2;
     border-radius: 4px;
 
     &.-active {
@@ -63,6 +63,20 @@
       li + li {
         margin-top: 5px;
       }
+    }
+  }
+
+  &.-embed {
+    .c-dropzone {
+      margin-top: 0;
+    }
+
+    .dropzone-file-input {
+      margin-top: 0;
+    }
+
+    .info {
+      margin-top: 45px;
     }
   }
 }

--- a/css/components/ui/custom_select.scss
+++ b/css/components/ui/custom_select.scss
@@ -64,6 +64,9 @@
 
   .clear-button {
     margin-right: 15px;
+    // Without this property, the user will be unable to click on the
+    // clear button (the click gets caught by the input)
+    z-index: 1;
 
     .c-icon {
       fill: rgba($dove-grey, .5);
@@ -107,6 +110,13 @@
       // Don't capitalise the text here because the case of the
       // content of the input won't match the case of the text
       // when the focus is somewhere else
+
+      > span {
+        .c-spinner {
+          vertical-align: middle;
+          margin-right: 10px;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This PR lets the user upload an area to filter the results of a dataset subscription when registering it.

Additionally, the `SliderSelect` component has been updated to fix an issue where the clear button couldn't be triggered and to add a message when it waits for an action from the user.

[Pivotal task](https://www.pivotaltracker.com/story/show/150142421)