### PR TITLE
Fix/cms widget edit

### DIFF
--- a/components/admin/layers/LayersTab.js
+++ b/components/admin/layers/LayersTab.js
@@ -11,7 +11,7 @@ import LayersNew from 'components/admin/layers/pages/new';
 import LayersShow from 'components/admin/layers/pages/show';
 
 function LayersTab(props) {
-  const { tab, subtab, id, user } = props;
+  const { tab, subtab, id, user, dataset } = props;
 
   return (
     <div className="c-layers-tab">
@@ -20,7 +20,7 @@ function LayersTab(props) {
       }
 
       {user.token && id && id === 'new' &&
-        <LayersNew tab={tab} subtab={subtab} id={id} user={user} />
+        <LayersNew tab={tab} subtab={subtab} id={id} user={user} dataset={dataset} />
       }
 
       {user.token && id && id !== 'new' &&
@@ -34,7 +34,8 @@ LayersTab.propTypes = {
   user: PropTypes.object,
   tab: PropTypes.string,
   id: PropTypes.string,
-  subtab: PropTypes.string
+  subtab: PropTypes.string,
+  dataset: PropTypes.string // Id of the dataset to be pre-selected in the New layer form
 };
 
 const mapStateToProps = state => ({

--- a/components/admin/layers/form/LayersForm.js
+++ b/components/admin/layers/form/LayersForm.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // Services
 import DatasetsService from 'services/DatasetsService';
@@ -17,13 +18,18 @@ class LayersForm extends React.Component {
   constructor(props) {
     super(props);
 
+    const formObj = props.dataset ?
+      Object.assign({}, STATE_DEFAULT.form,
+        { dataset: props.dataset, application: props.application }) :
+      Object.assign({}, STATE_DEFAULT.form, {
+        application: props.application
+      });
+
     this.state = Object.assign({}, STATE_DEFAULT, {
       id: props.id,
       dataset: props.dataset,
       datasets: [],
-      form: Object.assign({}, STATE_DEFAULT.form, {
-        application: props.application
-      }),
+      form: formObj,
       loading: !!props.id
     });
 
@@ -185,11 +191,11 @@ class LayersForm extends React.Component {
 }
 
 LayersForm.propTypes = {
-  id: React.PropTypes.string,
-  dataset: React.PropTypes.string,
-  authorization: React.PropTypes.string,
-  application: React.PropTypes.array,
-  onSubmit: React.PropTypes.func
+  id: PropTypes.string,
+  dataset: PropTypes.string,
+  authorization: PropTypes.string,
+  application: PropTypes.array,
+  onSubmit: PropTypes.func
 };
 
 export default LayersForm;

--- a/components/admin/layers/form/LayersForm.js
+++ b/components/admin/layers/form/LayersForm.js
@@ -69,7 +69,7 @@ class LayersForm extends React.Component {
         });
       })
       .catch((err) => {
-        console.error(err);
+        toastr.error('Error', err);
       });
   }
 
@@ -110,13 +110,12 @@ class LayersForm extends React.Component {
             })
             .catch((err) => {
               this.setState({ submitting: false });
-              toastr.error('Error', `Oops! There was an error, try again`);
-              console.error(err);
+              toastr.error('Error', `Oops! There was an error, try again. ${err}`);
             });
         } else {
           this.setState({
             step: this.state.step + 1
-          }, () => console.info(this.state));
+          });
         }
       } else {
         toastr.error('Error', 'Fill all the required fields');
@@ -126,7 +125,7 @@ class LayersForm extends React.Component {
 
   onChange(obj) {
     const form = Object.assign({}, this.state.form, obj);
-    this.setState({ form }, () => console.info(this.state.form));
+    this.setState({ form });
   }
 
   onChangeDataset(dataset) {

--- a/components/admin/layers/pages/index.js
+++ b/components/admin/layers/pages/index.js
@@ -5,13 +5,13 @@ import PropTypes from 'prop-types';
 import LayersTable from 'components/admin/layers/table/LayersTable';
 
 function LayersIndex(props) {
-  const { user } = props;
+  const { user, dataset } = props;
 
   return (
     <div className="c-layers-index">
       <LayersTable
         application={[process.env.APPLICATIONS]}
-        dataset={props.dataset}
+        dataset={dataset}
         authorization={user.token}
       />
     </div>

--- a/components/admin/layers/pages/new.js
+++ b/components/admin/layers/pages/new.js
@@ -6,20 +6,21 @@ import PropTypes from 'prop-types';
 import LayersForm from 'components/admin/layers/form/LayersForm';
 
 function LayersNew(props) {
-  const { user } = props;
-
+  const { user, dataset } = props;
   return (
     <div className="c-layers-new">
       <LayersForm
         application={[process.env.APPLICATIONS]}
         authorization={user.token}
         onSubmit={() => Router.pushRoute('admin_data', { tab: 'layers' })}
+        dataset={dataset}
       />
     </div>
   );
 }
 
 LayersNew.propTypes = {
+  dataset: PropTypes.string, // Id of the dataset to be pre-selected
   // Store
   user: PropTypes.object.isRequired
 };

--- a/components/admin/layers/table/LayersTable.js
+++ b/components/admin/layers/table/LayersTable.js
@@ -65,7 +65,7 @@ class LayersTable extends React.Component {
           link={{
             label: 'New layer',
             route: 'admin_data_detail',
-            params: { tab: 'layers', id: 'new' }
+            params: { tab: 'layers', id: 'new', dataset: this.props.dataset }
           }}
           onSearch={this.onSearch}
         />

--- a/components/admin/widget/pages/index.js
+++ b/components/admin/widget/pages/index.js
@@ -8,7 +8,6 @@ import ButtonContainer from 'components/ui/ButtonContainer';
 
 function WidgetIndex(props) {
   const classes = classnames('c-widgets-index', { '-embed': props.embed });
-
   return (
     <div className={classes}>
       <ButtonContainer
@@ -16,7 +15,7 @@ function WidgetIndex(props) {
         buttons={[{
           label: 'New Widget',
           route: 'admin_data_detail',
-          params: { tab: 'widgets', id: 'new' },
+          params: { tab: 'widgets', id: 'new', dataset: props.dataset },
           className: 'c-button -secondary'
         }]}
       />

--- a/components/admin/widget/pages/index.js
+++ b/components/admin/widget/pages/index.js
@@ -11,7 +11,7 @@ function WidgetIndex(props) {
   return (
     <div className={classes}>
       <ButtonContainer
-        className="-j-end"
+        className="-j-end button-container"
         buttons={[{
           label: 'New Widget',
           route: 'admin_data_detail',

--- a/components/admin/widgets/WidgetsTab.js
+++ b/components/admin/widgets/WidgetsTab.js
@@ -11,7 +11,7 @@ import WidgetsNew from 'components/admin/widgets/pages/new';
 import WidgetsShow from 'components/admin/widgets/pages/show';
 
 function WidgetsTab(props) {
-  const { tab, subtab, id, user } = props;
+  const { tab, subtab, id, user, dataset } = props;
 
   return (
     <div className="c-widgets-tab">
@@ -20,7 +20,7 @@ function WidgetsTab(props) {
       }
 
       {user.token && id && id === 'new' &&
-        <WidgetsNew tab={tab} subtab={subtab} id={id} user={user} />
+        <WidgetsNew tab={tab} subtab={subtab} id={id} user={user} dataset={dataset} />
       }
 
       {user.token && id && id !== 'new' &&

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -19,10 +19,14 @@ class WidgetsForm extends React.Component {
   constructor(props) {
     super(props);
 
+    const formObj = props.dataset ?
+      Object.assign({}, STATE_DEFAULT.form, { dataset: props.dataset }) :
+      STATE_DEFAULT.form;
+
     this.state = Object.assign({}, STATE_DEFAULT, {
       id: props.id,
       loading: !!props.id,
-      form: STATE_DEFAULT.form
+      form: formObj
     });
 
     // BINDINGS
@@ -179,7 +183,8 @@ class WidgetsForm extends React.Component {
 WidgetsForm.propTypes = {
   authorization: PropTypes.string,
   id: PropTypes.string,
-  onSubmit: PropTypes.func
+  onSubmit: PropTypes.func,
+  dataset: PropTypes.string // ID of the dataset that should be pre-selected
 };
 
 export default WidgetsForm;

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -69,7 +69,7 @@ class WidgetsForm extends React.Component {
         });
       })
       .catch((err) => {
-        console.error(err);
+        toastr.error(err);
       });
   }
 
@@ -111,13 +111,12 @@ class WidgetsForm extends React.Component {
             })
             .catch((err) => {
               this.setState({ submitting: false });
-              toastr.error('Error', `Oops! There was an error, try again`);
-              console.error(err);
+              toastr.error('Error', `Oops! There was an error, try again. ${err}`);
             });
         } else {
           this.setState({
             step: this.state.step + 1
-          }, () => console.info(this.state));
+          });
         }
       } else {
         toastr.error('Error', 'Fill all the required fields');
@@ -127,7 +126,7 @@ class WidgetsForm extends React.Component {
 
   onChange(obj) {
     const form = Object.assign({}, this.state.form, obj);
-    this.setState({ form }, () => console.info(this.state.form));
+    this.setState({ form });
   }
 
   onStepChange(step) {

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -97,13 +97,19 @@ class WidgetsForm extends React.Component {
           // Start the submitting
           this.setState({ submitting: true });
 
-          // Save data
-          this.service.saveData({
+          const obj = {
             dataset: this.state.form.dataset,
             id: id || '',
             type: (id) ? 'PATCH' : 'POST',
-            body: this.state.form
-          })
+            body: this.state.form,
+          };
+
+          if (obj.body.sourceUrl === '') {
+            delete obj.body.sourceUrl;
+          }
+
+          // Save data
+          this.service.saveData(obj)
             .then((data) => {
               toastr.success('Success', `The widget "${data.id}" - "${data.name}" has been uploaded correctly`);
 

--- a/components/admin/widgets/form/constants.js
+++ b/components/admin/widgets/form/constants.js
@@ -11,6 +11,7 @@ export const STATE_DEFAULT = {
   partners: [],
   form: {
     // STEP 1
+    application: ['rw'],
     name: '',
     queryUrl: '',
     description: '',

--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -24,7 +24,7 @@ class Step1 extends React.Component {
     this.state = {
       id: props.id,
       form: props.form,
-      mode: 'advanced'
+      mode: 'editor'
     };
 
     // BINDINGS

--- a/components/admin/widgets/pages/new.js
+++ b/components/admin/widgets/pages/new.js
@@ -10,19 +10,21 @@ import { connect } from 'react-redux';
 import WidgetsForm from 'components/admin/widgets/form/WidgetsForm';
 
 function WidgetsNew(props) {
-  const { user } = props;
+  const { user, dataset } = props;
 
   return (
     <div className="c-widgets-new">
       <WidgetsForm
         authorization={user.token}
         onSubmit={() => Router.pushRoute('admin_data', { tab: 'widgets' })}
+        dataset={dataset}
       />
     </div>
   );
 }
 
 WidgetsNew.propTypes = {
+  dataset: PropTypes.string, // ID of the dataset that should be pre-selected
   // Store
   user: PropTypes.object.isRequired
 };

--- a/css/components/admin/layer/layers_new.scss
+++ b/css/components/admin/layer/layers_new.scss
@@ -1,0 +1,9 @@
+.c-layers-new {
+
+  .c-field {
+    
+    .Select {
+      min-width: 100%;
+    }
+  }
+}

--- a/css/components/admin/widget/widget_index.scss
+++ b/css/components/admin/widget/widget_index.scss
@@ -1,4 +1,9 @@
 .c-widgets-index {
+
+  .button-container {
+      margin-bottom: 10px;
+  }
+
   .table {
     td {
       max-width: 400px;

--- a/css/index.scss
+++ b/css/index.scss
@@ -133,6 +133,9 @@
 @import "./components/admin/widget/layer_chart";
 @import "./components/admin/widget/widget_index";
 
+// Layers
+@import "./components/admin/layer/layers_new";
+
 // Vocabularies
 @import "./components/admin/vocabularies/vocabulary_item";
 @import "./components/admin/vocabularies/vocabularies_form";

--- a/pages/admin/DataDetail.js
+++ b/pages/admin/DataDetail.js
@@ -140,7 +140,7 @@ class DataDetail extends Page {
             }
 
             {tab === 'layers' &&
-              <LayersTab tab={tab} subtab={subtab} id={id} />
+              <LayersTab tab={tab} subtab={subtab} id={id} dataset={dataset} />
             }
           </div>
         </div>

--- a/pages/admin/DataDetail.js
+++ b/pages/admin/DataDetail.js
@@ -27,13 +27,14 @@ class DataDetail extends Page {
   constructor(props) {
     super(props);
 
-    const { tab, id, subtab } = props.url.query;
+    const { tab, id, subtab, dataset } = props.url.query;
 
     this.state = {
       tab,
       id,
       subtab,
-      data: {}
+      data: {},
+      dataset
     };
 
     this.service = null;
@@ -77,9 +78,9 @@ class DataDetail extends Page {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { tab, id, subtab } = nextProps.url.query;
+    const { tab, id, subtab, dataset } = nextProps.url.query;
 
-    this.setState({ tab, id, subtab });
+    this.setState({ tab, id, subtab, dataset });
   }
 
 
@@ -103,7 +104,7 @@ class DataDetail extends Page {
 
   render() {
     const { url, user } = this.props;
-    const { tab, subtab, id } = this.state;
+    const { tab, subtab, id, dataset } = this.state;
 
     return (
       <Layout
@@ -135,7 +136,7 @@ class DataDetail extends Page {
             }
 
             {tab === 'widgets' &&
-              <WidgetsTab tab={tab} subtab={subtab} id={id} />
+              <WidgetsTab tab={tab} subtab={subtab} id={id} dataset={dataset} />
             }
 
             {tab === 'layers' &&


### PR DESCRIPTION
This pull request fixes the following bugs found in the back office:

1. Editor mode should be set by default when creating a new widget
2. Pre-select the dataset in New Widget page when coming from dataset detail page
3. Pre-select the dataset in New Widget page when coming from dataset detail page
4. Fix bug that didn't allow users to create widgets in the back office

> It also adds some styles that were missing in the components involved