### PR TITLE
Fix/area intersection select

### DIFF
--- a/components/widgets/ChartEditor.js
+++ b/components/widgets/ChartEditor.js
@@ -80,7 +80,9 @@ class ChartEditor extends React.Component {
   componentDidMount() {
     if (this.props.hasGeoInfo) {
       this.fetchAreas();
-      this.fetchUserAreas();
+      if (this.props.user.id) { // Only try to load the user areas when an user is logged in
+        this.fetchUserAreas();
+      }
     }
   }
 

--- a/components/widgets/ChartEditor.js
+++ b/components/widgets/ChartEditor.js
@@ -78,8 +78,10 @@ class ChartEditor extends React.Component {
   * - componentDidMount
   */
   componentDidMount() {
-    this.fetchAreas();
-    this.fetchUserAreas();
+    if (this.props.hasGeoInfo) {
+      this.fetchAreas();
+      this.fetchUserAreas();
+    }
   }
 
   /**
@@ -220,15 +222,14 @@ class ChartEditor extends React.Component {
       tableViewMode,
       user,
       mode,
-      showSaveButton
+      showSaveButton,
+      hasGeoInfo
     } = this.props;
-    const { chartType, fields, category, value, hasGeoInfo } = widgetEditor;
+    const { chartType, fields, category, value } = widgetEditor;
     const { areaOptions, loadingAreaIntersection } = this.state;
-
     const showSaveButtonFlag =
       chartType && category && value && user && user.token && showSaveButton;
     const showUpdateButton = showSaveButtonFlag;
-
     const chartOptions = (
       jiminy
       && jiminy.general
@@ -331,6 +332,7 @@ class ChartEditor extends React.Component {
 ChartEditor.propTypes = {
   mode: PropTypes.oneOf(['save', 'update']).isRequired,
   tableName: PropTypes.string.isRequired,
+  hasGeoInfo: PropTypes.bool.isRequired,
   jiminy: PropTypes.object,
   dataset: PropTypes.string.isRequired, // Dataset ID
   datasetType: PropTypes.string,

--- a/components/widgets/WidgetEditor.js
+++ b/components/widgets/WidgetEditor.js
@@ -12,8 +12,7 @@ import { connect } from 'react-redux';
 import {
   resetWidgetEditor,
   setFields,
-  setVisualizationType,
-  setHasGeoInfo
+  setVisualizationType
 } from 'redactions/widgetEditor';
 import { toggleModal } from 'redactions/modal';
 
@@ -40,8 +39,7 @@ import {
   getChartConfig,
   canRenderChart,
   getChartType,
-  isFieldAllowed,
-  hasGeographicalInfo
+  isFieldAllowed
 } from 'utils/widgets/WidgetHelper';
 import ChartTheme from 'utils/widgets/theme';
 import LayerManager from 'utils/layers/LayerManager';
@@ -81,6 +79,7 @@ const DEFAULT_STATE = {
   fieldsLoaded: false,
   fieldsError: false,
 
+  hasGeoInfo: false, // Whether the dataset includes geographical information
   tableName: null, // Name of the table
   chartLoading: false, // Whether the chart is loading its data/rendering
 
@@ -227,8 +226,6 @@ class WidgetEditor extends React.Component {
 
     this.datasetService.getFields()
       .then((response) => {
-        const hasGeoInfo = hasGeographicalInfo(response.fields);
-        this.props.setHasGeoInfo(hasGeoInfo);
         const fields = response.fields.filter(field => !!isFieldAllowed(field));
         const fieldsError = !response.fields || !response.fields.length || fields.length === 0;
 
@@ -332,6 +329,7 @@ class WidgetEditor extends React.Component {
           this.setState({
             datasetInfoLoaded: true,
             tableName: attributes.tableName,
+            hasGeoInfo: attributes.geoInfo,
             datasetType: attributes.type,
             datasetProvider: attributes.provider
           }, resolve);
@@ -719,7 +717,8 @@ class WidgetEditor extends React.Component {
       layers,
       datasetType,
       datasetProvider,
-      visualizationOptions
+      visualizationOptions,
+      hasGeoInfo
     } = this.state;
 
     let { jiminy } = this.state;
@@ -793,6 +792,7 @@ class WidgetEditor extends React.Component {
                         mode={chartEditorMode}
                         onUpdateWidget={this.handleUpdateWidget}
                         showSaveButton={showSaveButton}
+                        hasGeoInfo={hasGeoInfo}
                       />
                     )
                 }
@@ -849,7 +849,6 @@ const mapStateToProps = ({ widgetEditor }) => ({
 const mapDispatchToProps = dispatch => ({
   resetWidgetEditor: hardReset => dispatch(resetWidgetEditor(hardReset)),
   setFields: (fields) => { dispatch(setFields(fields)); },
-  setHasGeoInfo: (hasGeoInfo) => { dispatch(setHasGeoInfo(hasGeoInfo)); },
   setVisualizationType: vis => dispatch(setVisualizationType(vis)),
   toggleModal: (open, options) => dispatch(toggleModal(open, options))
 });
@@ -870,7 +869,6 @@ WidgetEditor.propTypes = {
   widgetEditor: PropTypes.object.isRequired,
   resetWidgetEditor: PropTypes.func.isRequired,
   setFields: PropTypes.func.isRequired,
-  setHasGeoInfo: PropTypes.func.isRequired,
   setVisualizationType: PropTypes.func.isRequired,
   selectedVisualizationType: PropTypes.string,
   toggleModal: PropTypes.func

--- a/css/components/widgets/chart_editor.scss
+++ b/css/components/widgets/chart_editor.scss
@@ -19,11 +19,15 @@
 
     .chart-type {
       width: 100%;
-      margin-right: $margin-between-fields;
+      
+      .Select {
+        max-width: none;
+      }
     }
 
     .area-intersection {
       width: 100%;
+      margin-left: $margin-between-fields;
 
       .area-intersection-selector {
         max-width: none;

--- a/redactions/widgetEditor.js
+++ b/redactions/widgetEditor.js
@@ -25,7 +25,6 @@ const SET_AREA_INTERSEACTION = 'widgetEditor/SET_AREA_INTERSEACTION';
 const SET_VISUALIZATION_TYPE = 'widgetEditor/SET_VISUALIZATION_TYPE';
 const SET_BAND = 'widgetEditor/SET_BAND';
 const SET_LAYER = 'widgetEditor/SET_LAYER';
-const SET_HAS_GEOINFO = 'widgetEditor/SET_HAS_GEOINFO';
 
 /**
  * REDUCER
@@ -44,8 +43,7 @@ const initialState = {
   visualizationType: null,
   limit: 500,
   areaIntersection: null, // ID of the geostore object
-  band: null, // Band of the raster dataset
-  hasGeoInfo: false // Whether the dataset includes geographical information
+  band: null // Band of the raster dataset
 };
 
 export default function (state = initialState, action) {
@@ -219,12 +217,6 @@ export default function (state = initialState, action) {
       });
     }
 
-    case SET_HAS_GEOINFO: {
-      return Object.assign({}, state, {
-        hasGeoInfo: action.payload
-      });
-    }
-
     default:
       return state;
   }
@@ -338,8 +330,4 @@ export function setBand(band) {
 
 export function setLayer(layer) {
   return dispatch => dispatch({ type: SET_LAYER, payload: layer });
-}
-
-export function setHasGeoInfo(hasGeoInfo) {
-  return dispatch => dispatch({ type: SET_HAS_GEOINFO, payload: hasGeoInfo });
 }

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -56,16 +56,6 @@ const ALLOWED_FIELD_TYPES = [
   { name: 'array', type: 'array', provider: 'sql' }
 ];
 
-const GEOGRAPHICAL_FIELDS = [
-  // CARTO
-  { name: 'the_geom', type: 'geometry', provider: 'carto' },
-  { name: 'the_geom_webmercator', type: 'geometry', provider: 'carto' },
-  { name: 'the_raster_webmercator', type: 'geometry', provider: 'carto' },
-  // DOCUMENT
-  { name: 'lat', type: 'number', provider: 'document' },
-  { name: 'long', type: 'number', provider: 'document' }
-];
-
 const oneDimensionalChartTypes = ['1d_scatter', '1d_tick'];
 
 /* eslint-disable max-len */
@@ -91,21 +81,6 @@ const oneDimensionalChartTypes = ['1d_scatter', '1d_tick'];
  */
 function isBidimensionalChart(chartType) {
   return !oneDimensionalChartTypes.includes(chartType);
-}
-
-/**
- * Returns whether the set of fields provided include geographical information
- * @param {Array} fields - Array of fields
- * @returns {boolean}
- */
-export function hasGeographicalInfo(fields) {
-  let found = false;
-  fields.forEach((element) => {
-    if (GEOGRAPHICAL_FIELDS.find(val => val.name === element.columnName)) {
-      found = true;
-    }
-  });
-  return found;
 }
 
 export function isFieldAllowed(field) {


### PR DESCRIPTION
- Show area intersection select in the widget editor only when the dataset has the `geoInfo` attribute equals to true
- Minor fixes in styles
- Load user areas only when there's a user logged in