### PR TITLE
Fix an issue where Explore Detail wouldn't load

### DIFF
--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -95,7 +95,8 @@ class ExploreDetail extends Page {
           loading: false
         });
       }).catch((error) => {
-        toastr.error('Error', error);
+        toastr.error('Error', 'Unable to load the dataset');
+        console.error(error);
         this.setState({
           loading: false
         });
@@ -260,7 +261,8 @@ class ExploreDetail extends Page {
                         Learn more
                       </a>
                     }
-                    {dataset && dataset.attributes && dataset.attributes.subscribable && this.props.user.id &&
+                    {dataset && dataset.attributes && dataset.attributes.subscribable
+                      && this.props.user.id &&
                       <button
                         className="c-button -secondary -fullwidth"
                         onClick={this.handleSubscribe}
@@ -425,6 +427,8 @@ class ExploreDetail extends Page {
 
 ExploreDetail.propTypes = {
   url: PropTypes.object.isRequired,
+  // Store
+  user: PropTypes.object,
   // ACTIONS
   resetDataset: PropTypes.func.isRequired,
   toggleModal: PropTypes.func.isRequired,
@@ -432,6 +436,7 @@ ExploreDetail.propTypes = {
 };
 
 const mapStateToProps = state => ({
+  user: state.user,
   exploreDetail: state.exploreDetail,
   layersShown: updateLayersShown(state)
 });

--- a/redactions/user.js
+++ b/redactions/user.js
@@ -1,4 +1,3 @@
-import isEmpty from 'lodash/isEmpty';
 import UserService from 'services/UserService';
 
 const service = new UserService({ apiURL: process.env.CONTROL_TOWER_URL });
@@ -40,8 +39,13 @@ export default function (state = initialState, action) {
  * - setUser
 */
 export function setUser(user) {
-  const userObj = Object.assign({}, user || {});
-  if (!isEmpty(userObj) && userObj.token) {
+  // If the user isn't logged in, we set the user variable as an empty object
+  if (!user) {
+    return dispatch => dispatch({ type: SET_USER, payload: {} });
+  }
+
+  const userObj = Object.assign({}, user);
+  if (userObj.token) {
     userObj.token = userObj.token.includes('Bearer') ? userObj.token : `Bearer ${userObj.token}`;
   }
   return dispatch => dispatch({ type: SET_USER, payload: userObj });

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -194,14 +194,18 @@ export default class UserService {
    * Get user areas
    */
   getUserAreas(token) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       fetch(`${this.opts.apiURL}/area?application=rw`, {
         headers: {
           Authorization: token
         }
       })
-        .then(response => response.json())
-        .then(jsonData => resolve(jsonData.data));
+        .then((response) => {
+          if (response.ok) return response.json();
+          throw new Error(response.statusText);
+        })
+        .then(jsonData => resolve(jsonData.data))
+        .catch(err => reject(err.message));
     });
   }
 


### PR DESCRIPTION
_UPDATE: the initial bug has been solved by Pablo._

This PR removes a bug preventing the Explore Detail page from loading when the user wouldn't be logged in.

The bug was due to the fact we would try to load the user's intersection area whereas they wouldn't be logged.

An additional bug has been fixed: when requesting the areas, the API could return a 20X error and the code would try to access attributes of the response which was empty. To fix it, I've add a line to check the status of the request (`response.ok`).

[Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/150884771)