### PR TITLE
Feature/raster improvements

### DIFF
--- a/components/app/myrw/widgets/pages/edit.js
+++ b/components/app/myrw/widgets/pages/edit.js
@@ -150,7 +150,7 @@ class WidgetsEdit extends React.Component {
         {
           paramsConfig: {
             visualizationType,
-            band,
+            band: { name: band.name },
             limit,
             value,
             category,

--- a/components/app/myrw/widgets/pages/new.js
+++ b/components/app/myrw/widgets/pages/new.js
@@ -129,7 +129,7 @@ class WidgetsNew extends React.Component {
         {
           paramsConfig: {
             visualizationType,
-            band,
+            band: { name: band.name },
             limit,
             value,
             category,

--- a/components/modal/SaveWidgetModal.js
+++ b/components/modal/SaveWidgetModal.js
@@ -113,7 +113,7 @@ class SaveWidgetModal extends React.Component {
             chartType,
             filters,
             areaIntersection,
-            band,
+            band: { name: band.name },
             layer: layer && layer.id
           }
         },

--- a/components/widgets/RasterChartEditor.js
+++ b/components/widgets/RasterChartEditor.js
@@ -103,7 +103,19 @@ class RasterChartEditor extends React.Component {
           return res;
         });
       })
-      .then(bands => this.setState({ bands }))
+      .then((bands) => {
+        // We save the bands
+        this.setState({ bands }, () => {
+          // At this point, if this.props.band is defined, it's
+          // because we're restoring the state of the widget editor
+          // That means that this.props.band only has its name attribute
+          // defined (we don't have the alias nor the description), we thus
+          // need to reset the band based on the band list
+          if (this.props.band) {
+            this.onChangeBand(this.props.band.name);
+          }
+        });
+      })
       .catch(({ message }) => this.setState({ error: message }))
       .then(() => this.setState({ loading: false }));
   }
@@ -126,6 +138,9 @@ class RasterChartEditor extends React.Component {
               options={bands.map(b => ({ label: b.alias || b.name, value: b.name }))}
               onChange={this.onChangeBand}
             />
+          ) }
+          { band && band.description && (
+            <p className="description">{band.description}</p>
           ) }
         </div>
         <div className="buttons">

--- a/components/widgets/RasterChartEditor.js
+++ b/components/widgets/RasterChartEditor.js
@@ -47,10 +47,11 @@ class RasterChartEditor extends React.Component {
 
   /**
    * Event handler executed when the user selects a band
-   * @param {string} band
+   * @param {string} bandName - Name of the band
    */
   @Autobind
-  onChangeBand(band) {
+  onChangeBand(bandName) {
+    const band = this.state.bands.find(b => b.name === bandName);
     this.props.setBand(band);
   }
 
@@ -120,7 +121,7 @@ class RasterChartEditor extends React.Component {
             <Select
               properties={{
                 name: 'raster-bands',
-                default: band
+                default: band && band.name
               }}
               options={bands.map(b => ({ label: b.alias || b.name, value: b.name }))}
               onChange={this.onChangeBand}
@@ -160,7 +161,7 @@ RasterChartEditor.propTypes = {
   onUpdateWidget: PropTypes.func,
 
   // REDUX
-  band: PropTypes.string,
+  band: PropTypes.object,
   bandsInfo: PropTypes.object,
   toggleModal: PropTypes.func.isRequired,
   setBand: PropTypes.func.isRequired

--- a/components/widgets/RasterChartEditor.js
+++ b/components/widgets/RasterChartEditor.js
@@ -110,6 +110,10 @@ class RasterChartEditor extends React.Component {
           const bandInfo = this.props.bandsInfo[band];
           if (bandInfo) {
             res = Object.assign({}, res, bandInfo);
+          } else if (this.props.provider === 'cartodb') {
+            // If there's no alias for a Carto dataset, then
+            // we use a prettier name than just a number
+            res = Object.assign({}, res, { alias: `Band ${band}` });
           }
 
           return res;

--- a/components/widgets/WidgetEditor.js
+++ b/components/widgets/WidgetEditor.js
@@ -935,7 +935,7 @@ WidgetEditor.propTypes = {
   onChange: PropTypes.func,
   onError: PropTypes.func,
   // Store
-  band: PropTypes.string,
+  band: PropTypes.object,
   widgetEditor: PropTypes.object.isRequired,
   resetWidgetEditor: PropTypes.func.isRequired,
   setFields: PropTypes.func.isRequired,

--- a/components/widgets/WidgetEditor.js
+++ b/components/widgets/WidgetEditor.js
@@ -332,7 +332,7 @@ class WidgetEditor extends React.Component {
 
           // If the widget is a raster one, we save the information
           // related to its bands (alias, description, etc.)
-          if (attributes.type === 'raster') {
+          if (attributes.type === 'raster' && metadata) {
             // Here metadata is an object whose keys are names of bands
             // and the values the following:
             // { type: string, alias: string, description: string }

--- a/components/widgets/WidgetEditor.js
+++ b/components/widgets/WidgetEditor.js
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import {
   resetWidgetEditor,
   setFields,
+  setBandsInfo,
   setVisualizationType
 } from 'redactions/widgetEditor';
 import { toggleModal } from 'redactions/modal';
@@ -252,7 +253,7 @@ class WidgetEditor extends React.Component {
       .catch((err) => {
         this.setState({ fieldsError: true });
         toastr.error('Error loading fields');
-        console.error('Error loading fields', err)
+        console.error('Error loading fields', err);
       })
       // If we reach this point, either we have already resolved the promise
       // and so rejecting it has no effect, or we haven't and so we reject it
@@ -328,6 +329,17 @@ class WidgetEditor extends React.Component {
             alias: getMetadata(field.columnName, 'alias'),
             description: getMetadata(field.columnName, 'description')
           }));
+
+          // If the widget is a raster one, we save the information
+          // related to its bands (alias, description, etc.)
+          if (attributes.type === 'raster') {
+            // Here metadata is an object whose keys are names of bands
+            // and the values the following:
+            // { type: string, alias: string, description: string }
+            // NOTE: The object is not exhaustive and it might be empty
+            // whereas there are bands
+            this.props.setBandsInfo(metadata);
+          }
 
           this.props.setFields(fields);
 
@@ -906,6 +918,7 @@ const mapStateToProps = ({ widgetEditor }) => ({
 const mapDispatchToProps = dispatch => ({
   resetWidgetEditor: hardReset => dispatch(resetWidgetEditor(hardReset)),
   setFields: (fields) => { dispatch(setFields(fields)); },
+  setBandsInfo: bands => dispatch(setBandsInfo(bands)),
   setVisualizationType: vis => dispatch(setVisualizationType(vis)),
   toggleModal: (open, options) => dispatch(toggleModal(open, options))
 });
@@ -928,7 +941,8 @@ WidgetEditor.propTypes = {
   setFields: PropTypes.func.isRequired,
   setVisualizationType: PropTypes.func.isRequired,
   selectedVisualizationType: PropTypes.string,
-  toggleModal: PropTypes.func
+  toggleModal: PropTypes.func,
+  setBandsInfo: PropTypes.func
 };
 
 WidgetEditor.defaultProps = {

--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -20,6 +20,28 @@
     margin-top: 10px;
   }
 
+  .c-table {
+    position: relative;
+    min-height: 100px;
+    margin-top: 20px;
+
+    table {
+      display: block;
+      width: 100%;
+      font-size: $font-size-normal;
+
+      thead, tbody, tr {
+        display: block;
+        width: 100%;
+      }
+
+      th, td {
+        display: inline-block;
+        width: calc(100% / 6);
+      }
+    }
+  }
+
   // > div > .info { // Without that much specificity, we break the legend
   //   margin-top: 20px;
 

--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -16,6 +16,10 @@
     padding: $margin-size-extra-small;
   }
 
+  .band-information {
+    margin-top: 10px;
+  }
+
   // > div > .info { // Without that much specificity, we break the legend
   //   margin-top: 20px;
 

--- a/css/components/widgets/raster_chart_editor.scss
+++ b/css/components/widgets/raster_chart_editor.scss
@@ -20,6 +20,28 @@
       margin-top: 20px;
       font-size: $font-size-normal;
     }
+
+    .stats {
+      position: relative;
+      min-height: 100px;
+      margin-top: 20px;
+
+      table {
+        display: block;
+        width: 100%;
+        font-size: $font-size-normal;
+
+        thead, tbody, tr {
+          display: block;
+          width: 100%;
+        }
+
+        th, td {
+          display: inline-block;
+          width: calc(100% / 6);
+        }
+      }
+    }
   }
 
   .error {

--- a/css/components/widgets/raster_chart_editor.scss
+++ b/css/components/widgets/raster_chart_editor.scss
@@ -15,6 +15,11 @@
     .Select {
       max-width: none;
     }
+
+    .description {
+      margin-top: 20px;
+      font-size: $font-size-normal;
+    }
   }
 
   .error {

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import isEqual from 'lodash/isEqual';
 import isEmpty from 'lodash/isEmpty';
+import d3 from 'd3';
 
 // Redux
 import withRedux from 'next-redux-wrapper';
@@ -44,10 +44,10 @@ class EmbedWidget extends Page {
   }
 
   render() {
-    const { widget } = this.props;
+    const { widget, loading, bandDescription, bandStats } = this.props;
     const { isLoading } = this.state;
 
-    if (isEmpty(widget)) {
+    if (loading) {
       return (
         <EmbedLayout
           title={'Loading widget...'}
@@ -74,11 +74,37 @@ class EmbedWidget extends Page {
                 height={300}
                 data={widget.attributes.widgetConfig}
                 theme={ChartTheme()}
-                toggleLoading={isLoading => this.setState({ isLoading })}
+                toggleLoading={l => this.setState({ isLoading: l })}
                 reloadOnResize
               />
             </div>
           </div>
+          { bandDescription && (
+            <div className="band-information">
+              {bandDescription}
+            </div>
+          ) }
+          {!isEmpty(bandStats) && (
+            <div className="c-table">
+              <table>
+                <thead>
+                  <tr>
+                    { Object.keys(bandStats).map(name => <th key={name}>{name}</th>) }
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    { Object.keys(bandStats).map((name) => {
+                      const number = d3.format('.4s')(bandStats[name]);
+                      return (
+                        <td key={name}>{number}</td>
+                      );
+                    }) }
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          ) }
           { this.isLoadedExternally() &&
             <img
               className="embed-logo"
@@ -96,7 +122,10 @@ class EmbedWidget extends Page {
 EmbedWidget.propTypes = {
   widget: PropTypes.object,
   isLoading: PropTypes.bool,
-  getWidget: PropTypes.func
+  getWidget: PropTypes.func,
+  bandDescription: PropTypes.string,
+  bandStats: PropTypes.object,
+  loading: PropTypes.bool
 };
 
 EmbedWidget.defaultProps = {
@@ -106,6 +135,9 @@ EmbedWidget.defaultProps = {
 
 const mapStateToProps = state => ({
   widget: state.widget.data,
+  loading: state.widget.loading,
+  bandDescription: state.widget.bandDescription,
+  bandStats: state.widget.bandStats,
   isLoading: state.widget.loading
 });
 

--- a/pages/app/embed/_EmbedWidget.js
+++ b/pages/app/embed/_EmbedWidget.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { Autobind } from 'es-decorators';
 import { Link } from 'routes';
 import { toastr } from 'react-redux-toastr';
+import isEmpty from 'lodash/isEmpty';
+import d3 from 'd3';
 
 // Layout
 import Head from 'components/app/layout/head';
@@ -20,6 +22,8 @@ import Legend from 'components/ui/Legend';
 // Services
 import WidgetService from 'services/WidgetService';
 import LayersService from 'services/LayersService';
+import DatasetService from 'services/DatasetService';
+import RasterService from 'services/RasterService';
 
 // Utils
 import ChartTheme from 'utils/widgets/theme';
@@ -40,7 +44,12 @@ class EmbedWidget extends Page {
       visualizationLoading: false,
       layer: null,
       layerGroups: [],
-      modalOpen: false
+      modalOpen: false,
+      /** @type {string} */
+      bandInfo: null, // Information about the raster band
+      bandStats: {}, // Stats about the band
+      /** @type {object} */
+      dataset: null
     };
 
     // WidgetService
@@ -114,6 +123,59 @@ class EmbedWidget extends Page {
   }
 
   /**
+   * Fetch the dataset and set the dataset attribute
+   * of the state
+   * NOTE: returns when the state is updated
+   * @param {string} datasetId
+   * @returns {Promise<void>}
+   */
+  fetchDataset(datasetId) {
+    return new Promise((resolve, reject) => {
+      const datasetService = new DatasetService(datasetId, { apiURL: process.env.WRI_API_URL });
+      datasetService.fetchData('metadata')
+        .then(dataset => this.setState({ dataset }, resolve))
+        .catch(reject);
+    });
+  }
+
+  /**
+   * Get the information of band of a raster dataset and
+   * set bandInfo of the state
+   * @param {string} datasetId Dataset ID
+   * @param {string} bandName Name of the band
+   */
+  async fetchRasterBandInfo(datasetId, bandName) {
+    try {
+      if (!this.state.dataset) {
+        await this.fetchDataset(datasetId);
+      }
+
+      const dataset = this.state.dataset.attributes;
+
+      // We don't need the "else" for the following conditions
+      // because the band information is not vital and also because
+      // it's not mandatory
+      let { metadata } = dataset;
+      if (metadata && metadata.length) {
+        metadata = metadata[0].attributes;
+        const { columns } = metadata;
+
+        if (columns[bandName]) {
+          this.setState({ bandInfo: columns[bandName] });
+        }
+      }
+
+      const { provider, tableName } = dataset;
+      const rasterService = new RasterService(datasetId, tableName, provider);
+      const bandStats = await rasterService.getBandStatsInfo(bandName);
+      this.setState({ bandStats });
+    } catch (err) {
+      toastr.error('Error', 'Unable to load the additional information about the widget');
+      console.error(err);
+    }
+  }
+
+  /**
    * Load the initial data and sets the state of the component
    */
   loadData() {
@@ -134,6 +196,12 @@ class EmbedWidget extends Page {
           const id = widgetConfig.paramsConfig.layer;
           layerPromise = new LayersService().fetchData({ id })
             .then(layer => new Promise(resolve => this.setState({ layer }, resolve)));
+        }
+
+        // If the widget is based on a raster dataset, we need to fetch the
+        // information related to its band
+        if (widgetConfig.paramsConfig && widgetConfig.paramsConfig.visualizationType === 'raster_chart') {
+          this.fetchRasterBandInfo(widget.dataset, widgetConfig.paramsConfig.band.name);
         }
 
         return Promise.all([
@@ -185,7 +253,7 @@ class EmbedWidget extends Page {
   }
 
   render() {
-    const { widget, loading } = this.state;
+    const { widget, loading, bandInfo, bandStats } = this.state;
 
     return (
       <div className="c-embed-widget">
@@ -215,6 +283,33 @@ class EmbedWidget extends Page {
               </div>
               <div className="widget-description">
                 {widget.description}
+              </div>
+              { bandInfo && bandInfo.description && (
+                <div className="band-information">
+                  {bandInfo.description}
+                </div>
+              ) }
+              <div className="c-table">
+                <Spinner isLoading={isEmpty(bandStats)} className="-light -small" />
+                {!isEmpty(bandStats) && (
+                  <table>
+                    <thead>
+                      <tr>
+                        { Object.keys(bandStats).map(name => <th key={name}>{name}</th>) }
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        { Object.keys(bandStats).map((name) => {
+                          const number = d3.format('.4s')(bandStats[name]);
+                          return (
+                            <td key={name}>{number}</td>
+                          );
+                        }) }
+                      </tr>
+                    </tbody>
+                  </table>
+                ) }
               </div>
             </div>
           </div>

--- a/redactions/widget.js
+++ b/redactions/widget.js
@@ -1,5 +1,10 @@
 import 'isomorphic-fetch';
+import isEmpty from 'lodash/isEmpty';
+
+// Services
 import WidgetService from 'services/WidgetService';
+import DatasetService from 'services/DatasetService';
+import RasterService from 'services/RasterService';
 
 /**
  * CONSTANTS
@@ -7,13 +12,20 @@ import WidgetService from 'services/WidgetService';
 const GET_WIDGET_SUCCESS = 'GET_WIDGET_SUCCESS';
 const GET_WIDGET_ERROR = 'GET_WIDGET_ERROR';
 const GET_WIDGET_LOADING = 'GET_WIDGET_LOADING';
+const SET_WIDGET_DATA = 'SET_WIDGET_DATA';
+const SET_WIDGET_DATASET = 'SET_WIDGET_DATASET';
+const SET_WIDGET_BAND_DESCRIPTION = 'SET_WIDGET_BAND_DESCRIPTION';
+const SET_WIDGET_BAND_STATS = 'SET_WIDGET_BAND_STATS';
 
 /**
  * STORE
  */
 const initialState = {
-  data: {}, // Actual list of widgets
-  loading: false, // Are we loading the data?
+  data: {}, // Actual widget
+  dataset: {}, // Dataset associated with the widget
+  bandDescription: null, // Description of the band if a raster widget
+  bandStats: {}, // Stats about the band if a raster widget
+  loading: true, // Are we loading the data?
   error: null // An error was produced while loading the data
 };
 
@@ -23,28 +35,55 @@ const initialState = {
 export default function (state = initialState, action) {
   switch (action.type) {
     case GET_WIDGET_LOADING: {
-      const widgets = {
+      const widget = {
         loading: true,
         error: null
       };
-      return Object.assign({}, state, widgets);
+      return Object.assign({}, state, widget);
     }
 
     case GET_WIDGET_SUCCESS: {
-      const widgets = {
-        data: action.payload,
+      const widget = {
         loading: false,
         error: null
       };
-      return Object.assign({}, state, widgets);
+      return Object.assign({}, state, widget);
     }
 
     case GET_WIDGET_ERROR: {
-      const widgets = {
+      const widget = {
         loading: false,
         error: action.payload
       };
-      return Object.assign({}, state, widgets);
+      return Object.assign({}, state, widget);
+    }
+
+    case SET_WIDGET_DATA: {
+      const widget = {
+        data: action.payload
+      };
+      return Object.assign({}, state, widget);
+    }
+
+    case SET_WIDGET_DATASET: {
+      const widget = {
+        dataset: action.payload
+      };
+      return Object.assign({}, state, widget);
+    }
+
+    case SET_WIDGET_BAND_DESCRIPTION: {
+      const widget = {
+        bandDescription: action.payload
+      };
+      return Object.assign({}, state, widget);
+    }
+
+    case SET_WIDGET_BAND_STATS: {
+      const widget = {
+        bandStats: action.payload
+      };
+      return Object.assign({}, state, widget);
     }
 
     default:
@@ -57,7 +96,66 @@ export default function (state = initialState, action) {
  */
 
 /**
+ * Fetch the dataset and set the dataset attribute
+ * of the state
+ * NOTE: returns when the state is updated
+ * @param {string} datasetId
+ * @returns {Promise<void>}
+ */
+function fetchDataset(datasetId) {
+  return (dispatch) => {
+    const datasetService = new DatasetService(datasetId, { apiURL: process.env.WRI_API_URL });
+    return datasetService.fetchData('metadata')
+      .then(dataset => dispatch({ type: SET_WIDGET_DATASET, payload: dataset }));
+  };
+}
+
+/**
+ * Get the information of band of a raster dataset
+ * @param {string} datasetId Dataset ID
+ * @param {string} bandName Name of the band
+ */
+function fetchRasterBandInfo(datasetId, bandName) {
+  return (dispatch, getState) => new Promise(async (resolve) => {
+    try {
+      if (isEmpty(getState().widget.dataset)) {
+        await dispatch(fetchDataset(datasetId));
+      }
+
+      const dataset = getState().widget.dataset.attributes;
+
+      // We don't need the "else" for the following conditions
+      // because the band information is not vital and also because
+      // it's not mandatory
+      let { metadata } = dataset;
+      if (metadata && metadata.length) {
+        metadata = metadata[0].attributes;
+        const { columns } = metadata;
+
+        if (columns[bandName] && columns[bandName].description) {
+          dispatch({ type: SET_WIDGET_BAND_DESCRIPTION, payload: columns[bandName].description });
+        }
+      }
+
+      const { provider, tableName } = dataset;
+      const rasterService = new RasterService(datasetId, tableName, provider);
+      const bandStats = await rasterService.getBandStatsInfo(bandName);
+      dispatch({ type: SET_WIDGET_BAND_STATS, payload: bandStats });
+      resolve();
+    } catch (err) {
+      // We can't use Toastr here because an embed doesn't display a notification
+      console.error(err);
+
+      // Even if we failed to load some data, we still resolve because we can still
+      // display the graph (only the additional info will be missing)
+      resolve();
+    }
+  });
+}
+
+/**
  * Retrieve the list of widgets
+ * @param {string} widgetId
  */
 export function getWidget(widgetId) {
   return (dispatch) => {
@@ -65,8 +163,23 @@ export function getWidget(widgetId) {
     const service = new WidgetService(widgetId, { apiURL: process.env.WRI_API_URL });
     return service.fetchData()
       .then((data) => {
-        dispatch({ type: GET_WIDGET_SUCCESS, payload: data });
+        dispatch({ type: SET_WIDGET_DATA, payload: data });
+        return data;
       })
+      .then((data) => {
+        const { widgetConfig } = data.attributes;
+        const isRaster = widgetConfig.paramsConfig
+          && widgetConfig.paramsConfig.visualizationType === 'raster_chart';
+
+        if (isRaster) {
+          const datasetId = data.attributes.dataset;
+          const bandName = widgetConfig.paramsConfig.band.name;
+          return dispatch(fetchRasterBandInfo(datasetId, bandName));
+        }
+
+        return data;
+      })
+      .then(() => dispatch({ type: GET_WIDGET_SUCCESS }))
       .catch((err) => {
         dispatch({ type: GET_WIDGET_ERROR, payload: err.message });
       });

--- a/redactions/widgetEditor.js
+++ b/redactions/widgetEditor.js
@@ -25,6 +25,7 @@ const SET_AREA_INTERSEACTION = 'widgetEditor/SET_AREA_INTERSEACTION';
 const SET_VISUALIZATION_TYPE = 'widgetEditor/SET_VISUALIZATION_TYPE';
 const SET_BAND = 'widgetEditor/SET_BAND';
 const SET_LAYER = 'widgetEditor/SET_LAYER';
+const SET_BANDS_INFO = 'widgetEditor/SET_BANDS_INFO';
 
 /**
  * REDUCER
@@ -43,7 +44,9 @@ const initialState = {
   visualizationType: null,
   limit: 500,
   areaIntersection: null, // ID of the geostore object
-  band: null // Band of the raster dataset
+  band: null, // Band of the raster dataset
+  /** @type {{ [name: string]: { type: string, alias: string, description: string } }} */
+  bandsInfo: {} // Information of the raster bands
 };
 
 export default function (state = initialState, action) {
@@ -164,7 +167,7 @@ export default function (state = initialState, action) {
         {},
         initialState,
         !action.payload // If not a hard reset...
-          ? { fields: state.fields }
+          ? { fields: state.fields, bandsInfo: state.bandsInfo }
           : {}
       );
     }
@@ -215,6 +218,10 @@ export default function (state = initialState, action) {
       return Object.assign({}, state, {
         layer: action.payload
       });
+    }
+
+    case SET_BANDS_INFO: {
+      return Object.assign({}, state, { bandsInfo: action.payload });
     }
 
     default:
@@ -330,4 +337,8 @@ export function setBand(band) {
 
 export function setLayer(layer) {
   return dispatch => dispatch({ type: SET_LAYER, payload: layer });
+}
+
+export function setBandsInfo(bandsInfo) {
+  return dispatch => dispatch({ type: SET_BANDS_INFO, payload: bandsInfo });
 }

--- a/redactions/widgetEditor.js
+++ b/redactions/widgetEditor.js
@@ -44,6 +44,7 @@ const initialState = {
   visualizationType: null,
   limit: 500,
   areaIntersection: null, // ID of the geostore object
+  /** @type {{ name: string, type: string, alias: string, description: string }} */
   band: null, // Band of the raster dataset
   /** @type {{ [name: string]: { type: string, alias: string, description: string } }} */
   bandsInfo: {} // Information of the raster bands

--- a/services/RasterService.js
+++ b/services/RasterService.js
@@ -34,7 +34,7 @@ export default class RasterService {
         if (this.provider === 'gee') {
           return data[0].bands.map(b => b.id);
         } else if (this.provider === 'cartodb') {
-          return Array.from({ length: data[0].numbands }, (_, i) => `Band ${i + 1}`);
+          return Array.from({ length: data[0].numbands }, (_, i) => `${i + 1}`);
         }
 
         throw new Error('Unsupported provider');

--- a/services/RasterService.js
+++ b/services/RasterService.js
@@ -42,6 +42,51 @@ export default class RasterService {
   }
 
   /**
+   * Return the statistical information of a band
+   * @param {string} bandName Name of the band
+   * @returns {Promise<object>}
+   */
+  getBandStatInfo(bandName) {
+    return new Promise((resolve, reject) => {
+      // First we build the query
+      let query;
+      if (this.provider === 'gee') {
+        // If we already have cached the information about all the bands
+        // we don't fetch it again
+        if (this.geeBandStatInfo) {
+          return resolve(this.geeBandStatInfo[bandName]);
+        }
+
+        query = `SELECT ST_SUMMARYSTATS() from '${this.tableName}'`;
+      } else if (this.provider === 'cartodb') {
+        query = `select (ST_SummaryStatsAgg(the_raster_webmercator, ${bandName}, True)).* from ${this.tableName}`;
+      } else {
+        // We don't support this provider yet
+        reject();
+      }
+
+      // We now fetch the actual data
+      return fetch(`https://api.resourcewatch.org/v1/query/${this.dataset}?sql=${query}`)
+        .then((res) => {
+          if (!res.ok) reject();
+          return res.json();
+        })
+        .then((data) => {
+          if (this.provider === 'gee') {
+            // We cache the data because the information of all the
+            // bands comes at once
+            this.geeBandStatInfo = data.data[0];
+
+            resolve(this.geeBandStatInfo[bandName]);
+          } else if (this.provider === 'cartodb') {
+            resolve(data.data[0]);
+          }
+        })
+        .catch(reject);
+    });
+  }
+
+  /**
    * Return the ChartInfo object for a raster chart
    * @static
    * @returns {ChartInfo}

--- a/services/RasterService.js
+++ b/services/RasterService.js
@@ -46,7 +46,7 @@ export default class RasterService {
    * @param {string} bandName Name of the band
    * @returns {Promise<object>}
    */
-  getBandStatInfo(bandName) {
+  getBandStatsInfo(bandName) {
     return new Promise((resolve, reject) => {
       // First we build the query
       let query;

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -209,23 +209,63 @@ export function getChartInfo(dataset, datasetType, datasetProvider, widgetEditor
 }
 
 /**
+ * Return the number of bins for the raster
+ * @export
+ * @param {string} dataset - Dataset ID
+ * @param {string} tableName - Name of the table
+ * @param {{ name: string, type: string, alias: string, description: string }} band
+ * Band (in case of a raster dataset)
+ * @param {string} provider - Name of the provider
+ * @returns {Promise<number>}
+ */
+export async function getBinsCount(dataset, tableName, band, provider) {
+  return new Promise((resolve) => {
+    let query;
+    if (provider === 'gee') {
+      query = ''; // TODO: implement for GEE
+    } else {
+      query = `select ST_ValueCount(st_union(the_raster_webmercator), ${band.name}, true).value from ${tableName}`;
+    }
+
+    fetch(`${process.env.WRI_API_URL}/query/${dataset}?sql=${query}`)
+      .then((res) => {
+        if (!res.ok) throw new Error('Unable to retrieve the number of bins');
+        return res.json();
+      })
+      .then(() => {
+        // TODO: implement the real code
+        if (provider === 'gee') {
+          resolve(10);
+        } else {
+          resolve(10);
+        }
+      })
+      // If the query fails, we return 10 bins
+      .catch(() => resolve(10));
+  });
+}
+
+/**
  * Return the URL of the data needed for the Vega chart in case
  * of a raster dataset
  * @export
  * @param {string} dataset - Dataset ID
  * @param {string} datasetType - Type of dataset
  * @param {string} tableName - Name of the table
- * @param {string} band - Name of band (in case of a raster dataset)
+ * @param {{ name: string, type: string, alias: string, description: string }} band
+ * Band (in case of a raster dataset)
  * @param {string} provider - Name of the provider
  * @return {string}
  */
-export function getRasterDataURL(dataset, datasetType, tableName, band, provider) {
+export async function getRasterDataURL(dataset, datasetType, tableName, band, provider) {
+  const bins = band.type === 'continuous' ? 'auto' : await getBinsCount(dataset, tableName, band, provider);
+
   let query;
   if (provider === 'gee') {
-    query = `SELECT ST_HISTOGRAM(rast, ${band}, 10, true) from "${tableName}"`;
+    query = `SELECT ST_HISTOGRAM(rast, ${band.name}, ${bins}, true) from "${tableName}"`;
   } else if (provider === 'cartodb') {
-    const bandNumber = band.split(' ')[1];
-    query = `SELECT (ST_Histogram(st_union(the_raster_webmercator), ${bandNumber}, 10, true)).* from ${tableName}`;
+    const bandNumber = band.name.split(' ')[1];
+    query = `SELECT (ST_Histogram(st_union(the_raster_webmercator), ${bandNumber}, ${bins}, true)).* from ${tableName}`;
   }
 
   return `${process.env.WRI_API_URL}/query/${dataset}?sql=${query}`;
@@ -237,12 +277,14 @@ export function getRasterDataURL(dataset, datasetType, tableName, band, provider
  * @param {string} dataset - Dataset ID
  * @param {string} datasetType - Type of dataset
  * @param {string} tableName - Name of the table
- * @param {string} band - Name of band (in case of a raster dataset)
+ * @param {{ name: string, type: string, alias: string, description: string }} band
+ * Band (in case of a raster dataset)
  * @param {string} provider - Name of the provider
  * @param {ChartInfo} chartInfo
+ * @param {boolean} [isTable=false] Whether we fetch the data of a table
  * @return {string}
  */
-export function getDataURL(dataset, datasetType, tableName, band, provider,
+export async function getDataURL(dataset, datasetType, tableName, band, provider,
   chartInfo, isTable = false) {
   // If the dataset is a raster one, the behaviour is totally different
   if (datasetType === 'raster') {
@@ -386,13 +428,14 @@ export function getTimeFormat(data) {
  * Parse and return the data of a raster band
  * @export
  * @param {any[]} data - Raw data of the band
- * @param {string} band - Name of the band
+ * @param {{ name: string, type: string, alias: string, description: string }} band
+ * Band (in case of a raster dataset)
  * @param {string} provider - Name of the provider
  * @returns {object[]}
  */
 export function parseRasterData(data, band, provider) {
   if (provider === 'gee') {
-    return data[0][band].map(d => ({ x: d[0], y: d[1] }));
+    return data[0][band.name].map(d => ({ x: d[0], y: d[1] }));
   } else if (provider === 'cartodb') {
     return data.map(d => ({ x: d.max, y: d.count }));
   }
@@ -407,7 +450,8 @@ export function parseRasterData(data, band, provider) {
  * @param {string} dataset - Dataset ID
  * @param {string} datasetType - Type of dataset
  * @param {string} tableName - Name of the table
- * @param {string} band - Name of the band (in case of a raster dataset)
+ * @param {{ name: string, type: string, alias: string, description: string }} band
+ * Band (in case of a raster dataset)
  * @param {string} provider - Name of the provider
  * @param {ChartInfo} chartInfo
  * @param {boolean} [embedData=false] Whether the configuration should
@@ -423,7 +467,7 @@ export async function getChartConfig(
   embedData = false
 ) {
   // URL of the data needed to display the chart
-  const url = getDataURL(dataset, datasetType, tableName, band, provider, chartInfo);
+  const url = await getDataURL(dataset, datasetType, tableName, band, provider, chartInfo);
 
   // We fetch the data to have clever charts
   let data = await fetchData(url);
@@ -485,7 +529,8 @@ export async function getChartConfig(
  * Fetch the data of a raster dataset and return the parsed data
  * @export
  * @param {string} url - URL of the data
- * @param {string} band - Band name
+ * @param {{ name: string, type: string, alias: string, description: string }} band
+ * Band (in case of a raster dataset)
  * @param {string} provider - Dataset provider
  * @returns
  */

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -264,8 +264,7 @@ export async function getRasterDataURL(dataset, datasetType, tableName, band, pr
   if (provider === 'gee') {
     query = `SELECT ST_HISTOGRAM(rast, ${band.name}, ${bins}, true) from "${tableName}"`;
   } else if (provider === 'cartodb') {
-    const bandNumber = band.name.split(' ')[1];
-    query = `SELECT (ST_Histogram(st_union(the_raster_webmercator), ${bandNumber}, ${bins}, true)).* from ${tableName}`;
+    query = `SELECT (ST_Histogram(st_union(the_raster_webmercator), ${band.name}, ${bins}, true)).* from ${tableName}`;
   }
 
   return `${process.env.WRI_API_URL}/query/${dataset}?sql=${query}`;


### PR DESCRIPTION
This PR adds some improvements to the widgets created with a raster dataset:
* the aliases are used when possible instead of the raw band names in the editor
* the widget editor and the embedded widget display a text description and a table containing statistical information about the band
* for the visualisation, the number of bins is computed based on the type of band (categorical or continuous data)

<p align="center"><img width="494" alt="screen shot 2017-09-12 at 17 24 26" src="https://user-images.githubusercontent.com/6073968/30334265-53ec1f86-97df-11e7-8441-531f45b945b8.png"></p>

To test the PR, you can use the datasets `62494370-3799-4165-838e-0ebaf42804c2` (GEE) or `d8a45b34-4cc0-42f4-957d-e13b37e9182e ` (Carto) and the widgets `2b32e0e3-06dd-4663-8388-1948fcb5604c` (GEE) or `d81a14b0-8388-4b75-abb0-8149102426f0 ` (Carto) by replacing the file `EmbedWidget` by `_EmbedWidget` and removing the underscore from its name.

A few important notes about this PR:
* previously created raster widgets will be broken
* the bins feature is not implemented (the code is ready but I'm waiting for @aagm to give me the queries)
* the ExploreDetails page throws the error "Error loading fields" which is a bug from `develop`
* I still don't have any design for the table and the description for the editor and the embedded widget
* you have to replace the `EmbedWidget` file because it's been migrated and the Raster widget might be implemented as a separate file

[Pivotal task](https://www.pivotaltracker.com/story/show/150841908)