### PR TITLE
Re-implement the embed of the map widgets

### DIFF
--- a/components/modal/EmbedMyWidgetModal.js
+++ b/components/modal/EmbedMyWidgetModal.js
@@ -23,10 +23,10 @@ class EmbedMyWidgetModal extends React.Component {
   }
 
   render() {
-    const { widgetId } = this.props;
+    const { widgetId, visualizationType } = this.props;
     const { protocol, hostname, port } = window && window.location ? window.location : {};
     const embedHost = window && window.location ? `${protocol}//${hostname}${port !== '' ? `:${port}` : port}` : '';
-    const url = `${embedHost}/embed/widget/${widgetId}`;
+    const url = `${embedHost}/embed/${visualizationType === 'map' ? 'map' : 'widget'}/${widgetId}`;
     const iframeText = `<iframe src="${url}" width="100%" height="474" frameBorder="0"></iframe>`;
     return (
       <div className="c-embed-my-widget-modal">
@@ -45,7 +45,8 @@ class EmbedMyWidgetModal extends React.Component {
 }
 
 EmbedMyWidgetModal.propTypes = {
-  widgetId: PropTypes.string.isRequired
+  widgetId: PropTypes.string.isRequired,
+  visualizationType: PropTypes.string.isRequired
 };
 
 export default EmbedMyWidgetModal;

--- a/components/ui/Legend.js
+++ b/components/ui/Legend.js
@@ -233,17 +233,22 @@ class Legend extends React.Component {
            </button>
         */
         }
-        <button
-          className="toggle"
-          onClick={() => this.onToggleLayerGroupVisibility(layerGroup)}
-          aria-label="Toggle the visibility"
-        >
-          <Icon name={layerGroup.visible ? 'icon-hide' : 'icon-show'} />
-        </button>
-        <button className="info" onClick={() => this.onLayerInfoModal(layerGroup)} aria-label="More information">
-          <Icon name="icon-info" />
-        </button>
+        { !this.props.interactionDisabled
+          && <button
+            className="toggle"
+            onClick={() => this.onToggleLayerGroupVisibility(layerGroup)}
+            aria-label="Toggle the visibility"
+          >
+            <Icon name={layerGroup.visible ? 'icon-hide' : 'icon-show'} />
+          </button>
+        }
+        { !this.props.interactionDisabled
+          && <button className="info" onClick={() => this.onLayerInfoModal(layerGroup)} aria-label="More information">
+            <Icon name="icon-info" />
+          </button>
+        }
         { !this.props.readonly
+          && !this.props.interactionDisabled
           && <button className="close" onClick={() => this.onRemoveLayerGroup(layerGroup)} aria-label="Remove">
             <Icon name="icon-cross" />
           </button>
@@ -373,6 +378,9 @@ Legend.propTypes = {
   layerGroups: PropTypes.array,
   // Layers can't be removed or hidden
   readonly: PropTypes.bool,
+  // Layers can't be removed, hidden or toggled
+  // and the information button is hidden
+  interactionDisabled: PropTypes.bool,
   // Whether by default the legend is expanded or not
   expanded: PropTypes.bool,
 
@@ -399,6 +407,7 @@ Legend.propTypes = {
 
 Legend.defaultProps = {
   readonly: false,
+  interactionDisabled: false,
   expanded: true
 };
 

--- a/components/widgets/WidgetCard.js
+++ b/components/widgets/WidgetCard.js
@@ -273,7 +273,11 @@ class WidgetCard extends React.Component {
     const options = {
       children: EmbedMyWidgetModal,
       childrenProps: {
-        widgetId: this.props.widget.id
+        widgetId: this.props.widget.id,
+        visualizationType: (this.props.widget.attributes.widgetConfig
+          && this.props.widget.attributes.widgetConfig.paramsConfig
+          && this.props.widget.attributes.widgetConfig.paramsConfig.visualizationType)
+          || 'chart'
       }
     };
     this.props.toggleModal(true);

--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -1,4 +1,5 @@
 .c-embed-widget {
+  position: relative; // Limit the scope of the map and spinner
   width: 100%;
   height: 100%;
   min-height: 150px;
@@ -13,6 +14,11 @@
   }
 
   .widget-content {
+    position: relative; // Needed to position the legend of the map
+    margin: $margin-size-extra-small;
+  }
+
+  .widget-description {
     padding: $margin-size-extra-small;
   }
 
@@ -62,14 +68,9 @@
   //   }
   // }
 
-  .visualization {
-    position: relative; // Limit the scope of the map and spinner
-    min-height: 100vh;
-  }
-
   .c-map {
     height: 300px;
-    position: static;
+    position: relative;
 
     // Without this property, the legend is hidden behind
     // the map

--- a/css/components/ui/legend.scss
+++ b/css/components/ui/legend.scss
@@ -2,11 +2,16 @@
   position: absolute;
   bottom: 35px;
   right: 30px;
-  min-width: 400px;
+  width: 80%; // Limit the width for mobile devices
   max-width: 500px;
   background: $color-white;
   z-index: 2;
   border-radius: 4px;
+
+  @media screen and (min-width: $grid-row-width) {
+    width: 100%;
+    min-width: 400px;
+  }
 
   .legend-title {
     display: flex;

--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -1,0 +1,127 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Redux
+import withRedux from 'next-redux-wrapper';
+import { initStore } from 'store';
+import { bindActionCreators } from 'redux';
+import { getWidget, toggleLayerGroupVisibility } from 'redactions/widget';
+import { setUser } from 'redactions/user';
+import { setRouter } from 'redactions/routes';
+
+// Components
+import Page from 'components/app/layout/Page';
+import EmbedLayout from 'components/app/layout/EmbedLayout';
+import Spinner from 'components/ui/Spinner';
+import Map from 'components/vis/Map';
+import Legend from 'components/ui/Legend';
+
+// Utils
+import LayerManager from 'utils/layers/LayerManager';
+
+class EmbedMap extends Page {
+  static getInitialProps({ asPath, pathname, query, req, store, isServer }) {
+    const { user } = isServer ? req : store.getState();
+    const url = { asPath, pathname, query };
+    const referer = isServer ? req.headers.referer : location.href;
+    store.dispatch(setUser(user));
+    store.dispatch(setRouter(url));
+    return { user, isServer, url, referer, isLoading: true };
+  }
+
+  isLoadedExternally() {
+    return !/localhost|staging.resourcewatch.org/.test(this.props.referer);
+  }
+
+  componentDidMount() {
+    this.props.getWidget(this.props.url.query.id);
+  }
+
+  render() {
+    const { widget, loading, layerGroups } = this.props;
+
+    if (loading) {
+      return (
+        <EmbedLayout
+          title={'Loading widget...'}
+          description={''}
+        >
+          <Spinner isLoading={loading} className="-light" />
+        </EmbedLayout>
+      );
+    }
+
+    const mapConfig = { zoom: 3, latLng: { lat: 0, lng: 0 } };
+
+    return (
+      <EmbedLayout
+        title={`${widget.attributes.name}`}
+        description={`${widget.attributes.description || ''}`}
+      >
+        <div className="c-embed-widget">
+          <div className="visualization">
+            <div className="widget-title">
+              <h4>{widget.attributes.name}</h4>
+            </div>
+            <div className="widget-content">
+              <Map
+                LayerManager={LayerManager}
+                mapConfig={mapConfig}
+                layerGroups={layerGroups}
+              />
+
+              <Legend
+                layerGroups={layerGroups}
+                className={{ color: '-dark' }}
+                toggleLayerGroupVisibility={
+                  layerGroup => this.props.toggleLayerGroupVisibility(layerGroup)
+                }
+                setLayerGroupsOrder={() => {}}
+                setLayerGroupActiveLayer={() => {}}
+                interactionDisabled
+                expanded={false}
+              />
+            </div>
+            <p className="widget-description">
+              {widget.attributes.description}
+            </p>
+          </div>
+          { this.isLoadedExternally() &&
+            <img
+              className="embed-logo"
+              height={21}
+              width={129}
+              src={'/static/images/logo-embed.png'}
+              alt="Resource Watch"
+            /> }
+        </div>
+      </EmbedLayout>
+    );
+  }
+}
+
+EmbedMap.propTypes = {
+  widget: PropTypes.object,
+  isLoading: PropTypes.bool,
+  getWidget: PropTypes.func,
+  toggleLayerGroupVisibility: PropTypes.func,
+  loading: PropTypes.bool,
+  layerGroups: PropTypes.array
+};
+
+EmbedMap.defaultProps = {
+  widget: {}
+};
+
+const mapStateToProps = state => ({
+  widget: state.widget.data,
+  loading: state.widget.loading,
+  layerGroups: state.widget.layerGroups
+});
+
+const mapDispatchToProps = dispatch => ({
+  getWidget: bindActionCreators(getWidget, dispatch),
+  toggleLayerGroupVisibility: bindActionCreators(toggleLayerGroupVisibility, dispatch)
+});
+
+export default withRedux(initStore, mapStateToProps, mapDispatchToProps)(EmbedMap);

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -78,6 +78,9 @@ class EmbedWidget extends Page {
                 reloadOnResize
               />
             </div>
+            <p className="widget-description">
+              {widget.attributes.description}
+            </p>
           </div>
           { bandDescription && (
             <div className="band-information">
@@ -121,7 +124,6 @@ class EmbedWidget extends Page {
 
 EmbedWidget.propTypes = {
   widget: PropTypes.object,
-  isLoading: PropTypes.bool,
   getWidget: PropTypes.func,
   bandDescription: PropTypes.string,
   bandStats: PropTypes.object,
@@ -129,16 +131,14 @@ EmbedWidget.propTypes = {
 };
 
 EmbedWidget.defaultProps = {
-  widget: {},
-  isLoading: true
+  widget: {}
 };
 
 const mapStateToProps = state => ({
   widget: state.widget.data,
   loading: state.widget.loading,
   bandDescription: state.widget.bandDescription,
-  bandStats: state.widget.bandStats,
-  isLoading: state.widget.loading
+  bandStats: state.widget.bandStats
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/routes.js
+++ b/routes.js
@@ -48,6 +48,7 @@ routes.add('myrw_detail', '/myrw-detail/:tab?/:id?/:subtab?', 'app/MyRWDetail');
 
 // ------ EMBED -------------
 routes.add('embed_widget', '/embed/widget/:id', 'app/embed/EmbedWidget');
+routes.add('embed_map', '/embed/map/:id', 'app/embed/EmbedMap');
 routes.add('embed_dataset', '/embed/dataset/:id', 'app/embed/EmbedDataset');
 routes.add('embed_layer', '/embed/layers', 'app/embed/EmbedLayer');
 routes.add('embed_table', '/embed/table', 'app/embed/EmbedTable');


### PR DESCRIPTION
This PR re-implements the embed of the map widgets. Their URLs are now different because a different file manages the map widgets.

<p align="center">
<img width="412" alt="Embedded map with description" src="https://user-images.githubusercontent.com/6073968/30535505-8a4afd8e-9c5a-11e7-914f-ef8674bee04f.png">
</p>

The `Legend` component has been added a new prop called `interactionDisabled` to disable all of its interactions.

You can test an embedded map widget here: http://localhost:3000/embed/map/72a9871e-2fdb-44e4-adcd-239c5456b98f