### PR TITLE
Fix an issue that prevented the size field  from working in the editor

### DIFF
--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -193,6 +193,7 @@ export function getChartInfo(dataset, datasetType, datasetProvider, widgetEditor
 
   if (color) {
     chartInfo.color = {
+      name: color.name,
       alias: fields.length && fields.find(f => f.columnName === color.name).alias,
       aggregateFunction: color.aggregateFunction
     };
@@ -200,6 +201,7 @@ export function getChartInfo(dataset, datasetType, datasetProvider, widgetEditor
 
   if (size) {
     chartInfo.size = {
+      name: size.name,
       alias: fields.length && fields.find(f => f.columnName === size.name).alias,
       aggregateFunction: size.aggregateFunction
     };


### PR DESCRIPTION
This PR fixes an issue that prevented the editor from letting the user use the size field.

Remember that only numerical columns can be used in the size field.

[Pivotal task](https://www.pivotaltracker.com/story/show/151286241)