### PR TITLE
Adds ownership column to widget and layer tables

### DIFF
--- a/components/admin/layers/table/LayersTable.js
+++ b/components/admin/layers/table/LayersTable.js
@@ -24,6 +24,7 @@ import GoToDatasetAction from './actions/GoToDatasetAction';
 // TDs
 import NameTD from './td/NameTD';
 import UpdatedAtTD from './td/UpdatedAtTD';
+import OwnershipTD from './td/OwnershipTD';
 
 class LayersTable extends React.Component {
   componentDidMount() {
@@ -50,7 +51,7 @@ class LayersTable extends React.Component {
   }
 
   render() {
-    const { dataset, application } = this.props;
+    const { dataset, application, user } = this.props;
     return (
       <div className="c-layer-table">
         <Spinner className="-light" isLoading={this.props.loading} />
@@ -77,7 +78,8 @@ class LayersTable extends React.Component {
             columns={[
               { label: 'Name', value: 'name', td: NameTD },
               { label: 'Provider', value: 'provider' },
-              { label: 'Updated at', value: 'updatedAt', td: UpdatedAtTD }
+              { label: 'Updated at', value: 'updatedAt', td: UpdatedAtTD },
+              { label: 'Ownership', value: 'ownership', td: OwnershipTD, tdProps: { user } }
             ]}
             actions={{
               show: true,
@@ -112,7 +114,8 @@ LayersTable.defaultProps = {
   columns: [],
   actions: {},
   // Store
-  layers: []
+  layers: [],
+  users: {}
 };
 
 LayersTable.propTypes = {
@@ -124,6 +127,7 @@ LayersTable.propTypes = {
   loading: PropTypes.bool.isRequired,
   layers: PropTypes.array.isRequired,
   error: PropTypes.string,
+  user: PropTypes.object,
 
   // Actions
   getLayers: PropTypes.func.isRequired,
@@ -133,7 +137,8 @@ LayersTable.propTypes = {
 const mapStateToProps = state => ({
   loading: state.layers.layers.loading,
   layers: getFilteredLayers(state),
-  error: state.layers.layers.error
+  error: state.layers.layers.error,
+  user: state.user
 });
 const mapDispatchToProps = dispatch => ({
   getLayers: ({ dataset, application }) => dispatch(getLayers({ dataset, application })),

--- a/components/admin/layers/table/LayersTable.js
+++ b/components/admin/layers/table/LayersTable.js
@@ -79,7 +79,7 @@ class LayersTable extends React.Component {
               { label: 'Name', value: 'name', td: NameTD },
               { label: 'Provider', value: 'provider' },
               { label: 'Updated at', value: 'updatedAt', td: UpdatedAtTD },
-              { label: 'Ownership', value: 'ownership', td: OwnershipTD, tdProps: { user } }
+              { label: 'Ownership', value: 'userId', td: OwnershipTD, tdProps: { user } }
             ]}
             actions={{
               show: true,

--- a/components/admin/layers/table/td/OwnershipTD.js
+++ b/components/admin/layers/table/td/OwnershipTD.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function OwnershipTD(props) {
+  const { user, index, row } = props;
+  const { userId } = row;
+  const { id } = user;
+
+  return (
+    <td className="boolean" key={index}>
+      {(userId === id) ? <span className="-true">Me</span> : <span className="-false">Others</span> }
+    </td>
+  );
+}
+
+OwnershipTD.propTypes = {
+  index: PropTypes.string,
+  user: PropTypes.object,
+  row: PropTypes.object
+};
+
+export default OwnershipTD;

--- a/components/admin/widgets/table/WidgetsTable.js
+++ b/components/admin/widgets/table/WidgetsTable.js
@@ -86,7 +86,7 @@ class WidgetsTable extends React.Component {
               { label: 'Title', value: 'name', td: TitleTD },
               // { label: 'Dataset', value: 'dataset', td: DatasetTD },
               { label: 'Published', value: 'published', td: PublishedTD },
-              { label: 'Ownership', value: 'ownership', td: OwnershipTD, tdProps: { user } }
+              { label: 'Ownership', value: 'userId', td: OwnershipTD, tdProps: { user } }
             ]}
             actions={{
               show: true,

--- a/components/admin/widgets/table/WidgetsTable.js
+++ b/components/admin/widgets/table/WidgetsTable.js
@@ -22,6 +22,7 @@ import DeleteAction from './actions/DeleteAction';
 // TDs
 import TitleTD from './td/TitleTD';
 import PublishedTD from './td/PublishedTD';
+import OwnershipTD from './td/OwnershipTD';
 // import DatasetTD from './td/DatasetTD';
 
 
@@ -58,6 +59,7 @@ class WidgetsTable extends React.Component {
   }
 
   render() {
+    const { user } = this.props;
     return (
       <div className="c-widgets-table">
         <Spinner className="-light" isLoading={this.props.loading} />
@@ -83,7 +85,8 @@ class WidgetsTable extends React.Component {
             columns={[
               { label: 'Title', value: 'name', td: TitleTD },
               // { label: 'Dataset', value: 'dataset', td: DatasetTD },
-              { label: 'Published', value: 'published', td: PublishedTD }
+              { label: 'Published', value: 'published', td: PublishedTD },
+              { label: 'Ownership', value: 'ownership', td: OwnershipTD, tdProps: { user } }
             ]}
             actions={{
               show: true,
@@ -117,7 +120,8 @@ WidgetsTable.defaultProps = {
   actions: {},
   // Store
   widgets: [],
-  filteredWidgets: []
+  filteredWidgets: [],
+  user: {}
 };
 
 WidgetsTable.propTypes = {
@@ -127,6 +131,7 @@ WidgetsTable.propTypes = {
   widgets: PropTypes.array.isRequired,
   filteredWidgets: PropTypes.array.isRequired,
   error: PropTypes.string,
+  user: PropTypes.object,
 
   // Actions
   getWidgets: PropTypes.func.isRequired,
@@ -137,7 +142,8 @@ const mapStateToProps = state => ({
   loading: state.widgets.widgets.loading,
   widgets: state.widgets.widgets.list,
   filteredWidgets: getFilteredWidgets(state),
-  error: state.widgets.widgets.error
+  error: state.widgets.widgets.error,
+  user: state.user
 });
 const mapDispatchToProps = dispatch => ({
   getWidgets: () => dispatch(getWidgets()),

--- a/components/admin/widgets/table/td/OwnershipTD.js
+++ b/components/admin/widgets/table/td/OwnershipTD.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function OwnershipTD(props) {
+  const { user, index, row } = props;
+  const { userId } = row;
+  const { id } = user;
+
+  return (
+    <td className="boolean" key={index}>
+      {(userId === id) ? <span className="-true">Me</span> : <span className="-false">Others</span> }
+    </td>
+  );
+}
+
+OwnershipTD.propTypes = {
+  index: PropTypes.string,
+  user: PropTypes.object,
+  row: PropTypes.object
+};
+
+export default OwnershipTD;


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/151253803
![image](https://user-images.githubusercontent.com/999124/30732526-444039be-9f73-11e7-8705-7a24219f9c26.png)

The ownership is determined by the comparison of the resource's `userId` and the `id` of the current user.