### PR TITLE
Fix issues with the raster datasets in the widget editor

### DIFF
--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -356,7 +356,7 @@ class WidgetEditor extends React.Component {
         });
       })
       // TODO: handle the error case in the UI
-      .catch(err => toastr.error('Error', `Unable to load the information about the dataset. ${err}`));
+      .catch(err => toastr.error('Error', `Unable to load the information about the dataset.`));
   }
 
   /**

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -812,7 +812,11 @@ class WidgetEditor extends React.Component {
 
     // TODO: instead of hiding the whole UI, let's show an error message or
     // some kind of feedback for the user
-    const componentShouldNotShow = fieldsError && (layersError || (layers && layers.length === 0));
+    // If the dataset is a raster, the fields won't load and it's possible
+    // we don't have layer either so the editor should show anyway
+    const componentShouldNotShow = datasetType !== 'raster'
+      && fieldsError
+      && (layersError || (layers && layers.length === 0));
 
     // In case Jiminy failed to give back a result, we let the user the possibility
     // to render any chart

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -252,12 +252,11 @@ class WidgetEditor extends React.Component {
           resolve();
         });
       })
-      // TODO: handle the error case in the UI
-      .catch((err) => {
-        this.setState({ fieldsError: true });
-        toastr.error('Error loading fields');
-        console.error('Error loading fields', err);
-      })
+      // We can't show an error here because for the raster datasets
+      // there won't be fields
+      // Unfortunately, at this stage, we don't know if the dataset
+      // is a raster one, so the error is never shown
+      .catch(err => this.setState({ fieldsError: true }))
       // If we reach this point, either we have already resolved the promise
       // and so rejecting it has no effect, or we haven't and so we reject it
       .then(reject);

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -561,6 +561,8 @@ class WidgetEditor extends React.Component {
       defaultVis = 'chart';
     } else if (visualizationOptions.find(vis => vis.value === 'map')) {
       defaultVis = 'map';
+    } else if (visualizationOptions.find(vis => vis.value === 'raster_chart')) {
+      defaultVis = 'raster_chart';
     }
 
     this.setState({ visualizationOptions }, () => {

--- a/components/widgets/editor/helpers/WidgetHelper.js
+++ b/components/widgets/editor/helpers/WidgetHelper.js
@@ -216,13 +216,22 @@ export function getChartInfo(dataset, datasetType, datasetProvider, widgetEditor
  * @param {string} provider - Name of the provider
  * @return {string}
  */
-export function getRasterDataURL(dataset, datasetType, tableName, band, provider) {
+export async function getRasterDataURL(dataset, datasetType, tableName, band, provider) {
+  const bandType = band.type || 'categorical';
+
   let query;
   if (provider === 'gee') {
-    query = `SELECT ST_HISTOGRAM(rast, ${band}, 10, true) from "${tableName}"`;
+    if (bandType === 'continuous') {
+      query = `SELECT ST_HISTOGRAM(rast, ${band.name}, auto, true) from "${tableName}"`;
+    } else {
+      query = `SELECT st_valuecount(rast, '${band.name}', true) from '${tableName}'`;
+    }
   } else if (provider === 'cartodb') {
-    const bandNumber = band.split(' ')[1];
-    query = `SELECT (ST_Histogram(st_union(the_raster_webmercator), ${bandNumber}, 10, true)).* from ${tableName}`;
+    if (bandType === 'continuous') {
+      query = `SELECT (ST_Histogram(st_union(the_raster_webmercator), ${band.name}, auto, true)).* from ${tableName}`;
+    } else {
+      query = `SELECT (ST_valueCount(st_union(the_raster_webmercator), ${band.name}, True)).* from ${tableName}`;
+    }
   }
 
   return `${process.env.WRI_API_URL}/query/${dataset}?sql=${query}`;
@@ -239,20 +248,28 @@ export function getRasterDataURL(dataset, datasetType, tableName, band, provider
  * @param {ChartInfo} chartInfo
  * @return {string}
  */
-export function getDataURL(dataset, datasetType, tableName, band, provider, chartInfo) {
+export async function getDataURL(dataset, datasetType, tableName, band, provider,
+  chartInfo, isTable = false) {
   // If the dataset is a raster one, the behaviour is totally different
   if (datasetType === 'raster') {
     if (!band) return '';
-    return getRasterDataURL(dataset, datasetType, tableName, band, provider);
+    return await getRasterDataURL(dataset, datasetType, tableName, band, provider);
   }
 
-  const isBidimensional = isBidimensionalChart(chartInfo.chartType);
+  let isBidimensional = false;
+  if (!isTable) {
+    isBidimensional = isBidimensionalChart(chartInfo.chartType);
+  } else if (!chartInfo.chartType) {
+    if (chartInfo.x && chartInfo.y) {
+      isBidimensional = true;
+    } else {
+      isBidimensional = false;
+    }
+  }
 
-  if (!chartInfo.x || (isBidimensional && !chartInfo.y)) return '';
+  if (!isTable && (!chartInfo.x || (isBidimensional && !chartInfo.y))) return '';
 
-  const columns = [
-    { key: 'x', value: chartInfo.x.name, as: true }
-  ];
+  const columns = [{ key: 'x', value: chartInfo.x.name, as: true }];
 
   if (isBidimensional) {
     columns.push({ key: 'y', value: chartInfo.y.name, as: true });
@@ -297,11 +314,7 @@ export function getDataURL(dataset, datasetType, tableName, band, provider, char
   }
 
   const sortOrder = chartInfo.order ? chartInfo.order.orderType : 'asc';
-  let query = `${getQueryByFilters(tableName, chartInfo.filters, columns, orderByColumn, sortOrder)}`;
-
-  if (chartInfo.limit) {
-    query += ` LIMIT ${chartInfo.limit}`;
-  }
+  const query = `${getQueryByFilters(tableName, chartInfo.filters, columns, orderByColumn, sortOrder)} LIMIT ${chartInfo.limit}`;
 
   const geostore = chartInfo.areaIntersection ? `&geostore=${chartInfo.areaIntersection}` : '';
 
@@ -379,15 +392,26 @@ export function getTimeFormat(data) {
  * Parse and return the data of a raster band
  * @export
  * @param {any[]} data - Raw data of the band
- * @param {string} band - Name of the band
+ * @param {{ name: string, type: string, alias: string, description: string }} band
+ * Band (in case of a raster dataset)
  * @param {string} provider - Name of the provider
  * @returns {object[]}
  */
 export function parseRasterData(data, band, provider) {
+  if (!data.length) return data;
+
   if (provider === 'gee') {
-    return data[0][band].map(d => ({ x: d[0], y: d[1] }));
+    if (band.type === 'continuous') {
+      return data[0][band.name].map(d => ({ x: d[0], y: d[1] }));
+    }
+
+    return Object.keys(data[0][band.name]).map(k => ({ x: k === 'null' ? 'No data' : k, y: data[0][band.name][k] }));
   } else if (provider === 'cartodb') {
-    return data.map(d => ({ x: d.max, y: d.count }));
+    if (band.type === 'continuous') {
+      return data.map(d => ({ x: d.max, y: d.count }));
+    }
+
+    return data.map(d => ({ x: d.value, y: d.count }));
   }
 
   return data;
@@ -416,10 +440,15 @@ export async function getChartConfig(
   embedData = false
 ) {
   // URL of the data needed to display the chart
-  const url = getDataURL(dataset, datasetType, tableName, band, provider, chartInfo);
+  const url = await getDataURL(dataset, datasetType, tableName, band, provider, chartInfo);
 
   // We fetch the data to have clever charts
-  let data = await fetchData(url);
+  let data
+  try {
+    data = await fetchData(url);
+  } catch(err) {
+    throw new Error('The request to load the data has failed');
+  }
 
   if (datasetType === 'raster') {
     data = parseRasterData(data, band, provider);

--- a/components/widgets/editor/redux/widgetEditor.js
+++ b/components/widgets/editor/redux/widgetEditor.js
@@ -25,6 +25,7 @@ const SET_AREA_INTERSEACTION = 'widgetEditor/SET_AREA_INTERSEACTION';
 const SET_VISUALIZATION_TYPE = 'widgetEditor/SET_VISUALIZATION_TYPE';
 const SET_BAND = 'widgetEditor/SET_BAND';
 const SET_LAYER = 'widgetEditor/SET_LAYER';
+const SET_BANDS_INFO = 'widgetEditor/SET_BANDS_INFO';
 
 /**
  * REDUCER
@@ -43,7 +44,9 @@ const initialState = {
   visualizationType: null,
   limit: 500,
   areaIntersection: null, // ID of the geostore object
-  band: null // Band of the raster dataset
+  band: null, // Band of the raster dataset
+  /** @type {{ [name: string]: { type: string, alias: string, description: string } }} */
+  bandsInfo: {} // Information of the raster bands
 };
 
 export default function (state = initialState, action) {
@@ -164,7 +167,7 @@ export default function (state = initialState, action) {
         {},
         initialState,
         !action.payload // If not a hard reset...
-          ? { fields: state.fields }
+          ? { fields: state.fields, bandsInfo: state.bandsInfo }
           : {}
       );
     }
@@ -209,6 +212,10 @@ export default function (state = initialState, action) {
       return Object.assign({}, state, {
         band: action.payload
       });
+    }
+
+    case SET_BANDS_INFO: {
+      return Object.assign({}, state, { bandsInfo: action.payload });
     }
 
     case SET_LAYER: {
@@ -326,6 +333,10 @@ export function setVisualizationType(vis) {
 
 export function setBand(band) {
   return dispatch => dispatch({ type: SET_BAND, payload: band });
+}
+
+export function setBandsInfo(bandsInfo) {
+  return dispatch => dispatch({ type: SET_BANDS_INFO, payload: bandsInfo });
 }
 
 export function setLayer(layer) {

--- a/components/widgets/editor/services/RasterService.js
+++ b/components/widgets/editor/services/RasterService.js
@@ -34,11 +34,56 @@ export default class RasterService {
         if (this.provider === 'gee') {
           return data[0].bands.map(b => b.id);
         } else if (this.provider === 'cartodb') {
-          return Array.from({ length: data[0].numbands }, (_, i) => `Band ${i + 1}`);
+          return Array.from({ length: data[0].numbands }, (_, i) => `${i + 1}`);
         }
 
         throw new Error('Unsupported provider');
       });
+  }
+
+  /**
+   * Return the statistical information of a band
+   * @param {string} bandName Name of the band
+   * @returns {Promise<object>}
+   */
+  getBandStatsInfo(bandName) {
+    return new Promise((resolve, reject) => {
+      // First we build the query
+      let query;
+      if (this.provider === 'gee') {
+        // If we already have cached the information about all the bands
+        // we don't fetch it again
+        if (this.geeBandStatInfo) {
+          return resolve(this.geeBandStatInfo[bandName]);
+        }
+
+        query = `SELECT ST_SUMMARYSTATS() from '${this.tableName}'`;
+      } else if (this.provider === 'cartodb') {
+        query = `select (ST_SummaryStatsAgg(the_raster_webmercator, ${bandName}, True)).* from ${this.tableName}`;
+      } else {
+        // We don't support this provider yet
+        reject();
+      }
+
+      // We now fetch the actual data
+      return fetch(`https://api.resourcewatch.org/v1/query/${this.dataset}?sql=${query}`)
+        .then((res) => {
+          if (!res.ok) reject();
+          return res.json();
+        })
+        .then((data) => {
+          if (this.provider === 'gee') {
+            // We cache the data because the information of all the
+            // bands comes at once
+            this.geeBandStatInfo = data.data[0];
+
+            resolve(this.geeBandStatInfo[bandName]);
+          } else if (this.provider === 'cartodb') {
+            resolve(data.data[0]);
+          }
+        })
+        .catch(reject);
+    });
   }
 
   /**

--- a/css/components/widgets/raster_chart_editor.scss
+++ b/css/components/widgets/raster_chart_editor.scss
@@ -26,6 +26,13 @@
       min-height: 100px;
       margin-top: 20px;
 
+      // If we don't set a low z-index, the
+      // selector above will open below the
+      // overlay
+      .c-spinner {
+        z-index: 0;
+      }
+
       table {
         display: block;
         width: 100%;

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -331,32 +331,26 @@ export async function getDataURL(dataset, datasetType, tableName, band, provider
 
 /**
  * Fetch the data of the chart
- * NOTE: if the request fails, an empty array will be
- * returned
+ * NOTE: by default, a timeout of 15s is applied and the
+ * function will reject with the string "timeout"
  * @export
  * @param {string} url URL of the data
- * @returns {object[]}
+ * @param {number} [timeout=15] Timeout in seconds
+ * @returns {Promise<object[]>}
  */
-export async function fetchData(url) { // eslint-disable-line no-unused-vars
-  let data;
+export function fetchData(url, timeout = 15) { // eslint-disable-line no-unused-vars
+  return new Promise((resolve, reject) => {
+    setTimeout(() => reject('timeout'), 1000 * timeout);
 
-  try {
-    const response = await fetch(url);
-
-    if (response.ok) {
-      data = await response.json();
-      data = data.data;
-    }
-  } catch (err) {
-    // TODO: properly handle this error case in the UI
-    toastr.error('Unable to load the data of the chart');
-  }
-
-  if (!data) {
-    data = [];
-  }
-
-  return data;
+    fetch(url)
+      .then((response) => {
+        if (response.ok) return response.json();
+        throw new Error('Unable to load the data of the chart');
+      })
+      .then(data => data.data)
+      .then(resolve)
+      .catch(reject);
+  });
 }
 
 /**
@@ -406,6 +400,8 @@ export function getTimeFormat(data) {
  * @returns {object[]}
  */
 export function parseRasterData(data, band, provider) {
+  if (!data.length) return data;
+
   if (provider === 'gee') {
     if (band.type === 'continuous') {
       return data[0][band.name].map(d => ({ x: d[0], y: d[1] }));
@@ -450,7 +446,16 @@ export async function getChartConfig(
   const url = await getDataURL(dataset, datasetType, tableName, band, provider, chartInfo);
 
   // We fetch the data to have clever charts
-  let data = await fetchData(url);
+  let data
+  try {
+    data = await fetchData(url);
+  } catch(err) {
+    if (err === 'timeout') {
+      throw new Error('This dataset is taking longer than expected to load. Please try again in a few minutes.');
+    } else {
+      throw new Error('The request to load the data has failed. Please try again in a few minutes.');
+    }
+  }
 
   if (datasetType === 'raster') {
     data = parseRasterData(data, band, provider);


### PR DESCRIPTION
This PR fixes issues with the raster datasets in the widget editor. Most of the issues are due to the decoupling of the editor from the app (PR #238).

Here are the other changes:
* a toastr notification that used to show a JS error doesn't display it anymore
* the toastr notification regarding the fields not loading has been removed because raster datasets don't have fields and at the time of the request, we don't know if the dataset is a raster one
* the editor is not hidden anymore when the dataset is a raster one and it doesn't have any layer
* the band selector is not hidden below the loader of the stats table anymore
* a timeout of 15s has been added to the request loading the chart's data (not only for raster datasets)

[Pivotal task](https://www.pivotaltracker.com/story/show/151393127)