### PR TITLE
Truncate the x values of the raster bar charts

### DIFF
--- a/components/widgets/editor/helpers/WidgetHelper.js
+++ b/components/widgets/editor/helpers/WidgetHelper.js
@@ -396,16 +396,28 @@ export function parseRasterData(data, band, provider) {
 
   if (provider === 'gee') {
     if (band.type === 'continuous') {
-      return data[0][band.name].map(d => ({ x: d[0], y: d[1] }));
+      return data[0][band.name].map(d => ({
+        x: get2DecimalFixedNumber(d[0]),
+        y: d[1]
+      }));
     }
 
-    return Object.keys(data[0][band.name]).map(k => ({ x: k === 'null' ? 'No data' : k, y: data[0][band.name][k] }));
+    return Object.keys(data[0][band.name]).map(k => ({
+      x: k === 'null' ? 'No data' : get2DecimalFixedNumber(k),
+      y: data[0][band.name][k]
+    }));
   } else if (provider === 'cartodb') {
     if (band.type === 'continuous') {
-      return data.map(d => ({ x: d.max, y: d.count }));
+      return data.map(d => ({
+        x: get2DecimalFixedNumber(d.max),
+        y: d.count
+      }));
     }
 
-    return data.map(d => ({ x: d.value, y: d.count }));
+    return data.map(d => ({
+      x: get2DecimalFixedNumber(d.value),
+      y: d.count
+    }));
   }
 
   return data;

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -404,16 +404,28 @@ export function parseRasterData(data, band, provider) {
 
   if (provider === 'gee') {
     if (band.type === 'continuous') {
-      return data[0][band.name].map(d => ({ x: d[0], y: d[1] }));
+      return data[0][band.name].map(d => ({
+        x: get2DecimalFixedNumber(d[0]),
+        y: d[1]
+      }));
     }
 
-    return Object.keys(data[0][band.name]).map(k => ({ x: k === 'null' ? 'No data' : k, y: data[0][band.name][k] }));
+    return Object.keys(data[0][band.name]).map(k => ({
+      x: k === 'null' ? 'No data' : get2DecimalFixedNumber(k),
+      y: data[0][band.name][k]
+    }));
   } else if (provider === 'cartodb') {
     if (band.type === 'continuous') {
-      return data.map(d => ({ x: d.max, y: d.count }));
+      return data.map(d => ({
+        x: get2DecimalFixedNumber(d.max),
+        y: d.count
+      }));
     }
 
-    return data.map(d => ({ x: d.value, y: d.count }));
+    return data.map(d => ({
+      x: get2DecimalFixedNumber(d.value),
+      y: d.count
+    }));
   }
 
   return data;


### PR DESCRIPTION
The values are truncated to 2 decimals to improve legibility. The truncation is made at parse time instead of at rendering time because the horizontal ticks are categorical and can't be treated as numbers by Vega. Moreover, it would affect all the bar charts and not only the raster ones.

[Pivotal task](https://www.pivotaltracker.com/story/show/151002429)