### PR TITLE
Display the aliases of the fields in the editor whenever possible

### DIFF
--- a/components/widgets/charts/VegaChartLegend.js
+++ b/components/widgets/charts/VegaChartLegend.js
@@ -67,9 +67,14 @@ class VegaChartLegend extends React.Component {
     // Kind of a trick, if there's something better, use it
     const uniqueId = config.values.slice(0, 5).map(v => v.label).join('');
 
+    const label = config.label
+      ? config.label[0].toUpperCase()
+          + config.label.slice(1, config.label.length)
+      : null;
+
     return (
       <div className="legend -size" key={uniqueId}>
-        { config.label && <Title className="-default">{config.label}</Title> }
+        { label && <Title className="-default">{label}</Title> }
         <div className="items">
           { config.values.map(value => (
             <div className="item" key={value.label}>

--- a/components/widgets/editor/helpers/1d_scatter.js
+++ b/components/widgets/editor/helpers/1d_scatter.js
@@ -65,7 +65,7 @@ export default function ({ columns, data, url, embedData }) {
 
   // We add the name of the axis
   const xAxis = config.axes.find(a => a.type === 'x');
-  xAxis.name = columns.x.name;
+  xAxis.name = columns.x.alias || columns.x.name;
 
   if (columns.color.present) {
     // We add the color scale

--- a/components/widgets/editor/helpers/1d_tick.js
+++ b/components/widgets/editor/helpers/1d_tick.js
@@ -66,7 +66,7 @@ export default function ({ columns, data, url, embedData }) {
 
   // We add the name of the axis
   const xAxis = config.axes.find(a => a.type === 'x');
-  xAxis.name = columns.x.name;
+  xAxis.name = columns.x.alias || columns.x.name;
 
   if (columns.color.present) {
     // We add the color scale

--- a/components/widgets/editor/helpers/WidgetHelper.js
+++ b/components/widgets/editor/helpers/WidgetHelper.js
@@ -489,12 +489,18 @@ export async function getChartConfig(
         type: chartInfo.x.type,
         name: xLabel,
         alias: chartInfo.x.alias
+          ? chartInfo.x.alias[0].toUpperCase()
+              + chartInfo.x.alias.slice(1, chartInfo.x.alias.length)
+          : null
       },
       y: {
         present: !!chartInfo.y,
         type: chartInfo.y && chartInfo.y.type,
         name: yLabel,
         alias: chartInfo.y && chartInfo.y.alias
+          ? chartInfo.y.alias[0].toUpperCase()
+            + chartInfo.y.alias.slice(1, chartInfo.y.alias.length)
+          : null
       },
       color: {
         present: !!chartInfo.color,

--- a/components/widgets/editor/helpers/bar.js
+++ b/components/widgets/editor/helpers/bar.js
@@ -189,8 +189,8 @@ export default function ({ columns, data, url, embedData, provider, band  }) {
   {
     const xAxis = config.axes.find(a => a.type === 'x');
     const yAxis = config.axes.find(a => a.type === 'y');
-    xAxis.name = columns.x.name;
-    yAxis.name = columns.y.name;
+    xAxis.name = columns.x.alias || columns.x.name;
+    yAxis.name = columns.y.alias || columns.y.name;
   }
 
   if (columns.color.present) {

--- a/components/widgets/editor/helpers/line.js
+++ b/components/widgets/editor/helpers/line.js
@@ -71,8 +71,8 @@ export default function ({ columns, data, url, embedData }) {
   // We add the name of the axis
   const xAxis = config.axes.find(a => a.type === 'x');
   const yAxis = config.axes.find(a => a.type === 'y');
-  xAxis.name = columns.x.name;
-  yAxis.name = columns.y.name;
+  xAxis.name = columns.x.alias || columns.x.name;
+  yAxis.name = columns.y.alias || columns.y.name;
 
   // If the x column is a date, we need to use a
   // temporal x scale and parse the x column as a date

--- a/components/widgets/editor/helpers/pie.js
+++ b/components/widgets/editor/helpers/pie.js
@@ -123,8 +123,8 @@ export default function ({ columns, data, url, embedData }) {
   // chart but we use them for the tooltip
   const xAxis = config.axes.find(a => a.type === 'x');
   const yAxis = config.axes.find(a => a.type === 'y');
-  xAxis.name = columns.x.name;
-  yAxis.name = columns.y.name;
+  xAxis.name = columns.x.alias || columns.x.name;
+  yAxis.name = columns.y.alias || columns.y.name;
 
   if (columns.color.present) {
     const colorScale = config.scales.find(scale => scale.name === 'c');

--- a/components/widgets/editor/helpers/scatter.js
+++ b/components/widgets/editor/helpers/scatter.js
@@ -69,8 +69,8 @@ export default function ({ columns, data, url, embedData }) {
   // We add the name of the axis
   const xAxis = config.axes.find(a => a.type === 'x');
   const yAxis = config.axes.find(a => a.type === 'y');
-  xAxis.name = columns.x.name;
-  yAxis.name = columns.y.name;
+  xAxis.name = columns.x.alias || columns.x.name;
+  yAxis.name = columns.y.alias || columns.y.name;
 
   if (columns.color.present) {
     // We add the color scale

--- a/components/widgets/editor/table/TableView.js
+++ b/components/widgets/editor/table/TableView.js
@@ -86,7 +86,20 @@ class TableView extends React.Component {
 
   render() {
     const { loading, data } = this.state;
-    const header = data && data.length > 0 && Object.keys(data[0]);
+    const { fields } = this.props.widgetEditor;
+
+    let header = data && data.length > 0
+      ? Object.keys(data[0])
+      : [];
+
+    // We check if we have an alias for the column name
+    // and update the headers accordingly
+    header = header.map((value) => {
+      const field = fields.find(field => field.columnName === value);
+      if (field) return field.alias || value;
+      return value;
+    })
+
     return (
       <div className="c-table-view c-table">
         <Spinner
@@ -96,7 +109,7 @@ class TableView extends React.Component {
         <table>
           <thead>
             <tr>
-              {header && header.map(val => (
+              {header.map(val => (
                 <th
                   key={`header_${val}`}
                 >

--- a/components/widgets/editor/ui/CategoryContainer.js
+++ b/components/widgets/editor/ui/CategoryContainer.js
@@ -51,6 +51,7 @@ class CategoryContainer extends React.Component {
           {category &&
             <ColumnBox
               name={category.name}
+              alias={category.alias}
               type={category.type}
               closable
               configurable={category.type === 'number'}

--- a/components/widgets/editor/ui/ColorContainer.js
+++ b/components/widgets/editor/ui/ColorContainer.js
@@ -56,6 +56,7 @@ class ColorContainer extends React.Component {
           {color &&
             <ColumnBox
               name={color.name}
+              alias={color.alias}
               type={color.type}
               closable
               configurable

--- a/components/widgets/editor/ui/ColumnBox.js
+++ b/components/widgets/editor/ui/ColumnBox.js
@@ -28,6 +28,7 @@ const columnBoxSource = {
   beginDrag(props) {
     return {
       name: props.name,
+      alias: props.alias,
       type: props.type,
       datasetID: props.datasetID,
       tableName: props.tableName
@@ -305,7 +306,7 @@ class ColumnBox extends React.Component {
 
   render() {
     const { aggregateFunction, aggregateFunctionSize, aggregateFunctionColor } = this.state;
-    const { isDragging, connectDragSource, name, type, closable, configurable,
+    const { isDragging, connectDragSource, name, alias, type, closable, configurable,
       isA, widgetEditor } = this.props;
     const { orderBy } = widgetEditor;
 
@@ -331,13 +332,13 @@ class ColumnBox extends React.Component {
     return connectDragSource(
       <div
         className={classNames({ 'c-columnbox': true, '-dimmed': isDragging })}
-        title={name}
+        title={alias || name}
       >
         <Icon
           name={iconName}
           className="-smaller"
         />
-        { (name.length > NAME_MAX_LENGTH) ? `${name.substr(0, NAME_MAX_LENGTH - 1)}...` : name }
+        { ((alias || name).length > NAME_MAX_LENGTH) ? `${(alias || name).substr(0, NAME_MAX_LENGTH - 1)}...` : (alias || name) }
         {isA === 'value' && aggregateFunction &&
           <div className="aggregate-function">
             {aggregateFunction}
@@ -392,6 +393,7 @@ ColumnBox.propTypes = {
   tableName: PropTypes.string,
   datasetID: PropTypes.string,
   name: PropTypes.string,
+  alias: PropTypes.string,
   type: PropTypes.string,
   isA: PropTypes.string,
   closable: PropTypes.bool,

--- a/components/widgets/editor/ui/FieldsContainer.js
+++ b/components/widgets/editor/ui/FieldsContainer.js
@@ -12,6 +12,7 @@ const FieldsContainer = (props) => {
             <ColumnBox
               key={val.columnName}
               name={val.columnName}
+              alias={val.alias}
               type={val.columnType}
               datasetID={dataset}
               tableName={tableName}

--- a/components/widgets/editor/ui/FilterContainer.js
+++ b/components/widgets/editor/ui/FilterContainer.js
@@ -56,6 +56,7 @@ class FilterContainer extends React.Component {
             <ColumnBox
               key={val.name}
               name={val.name}
+              alias={val.alias}
               type={val.type}
               datasetID={val.datasetID}
               tableName={val.tableName}

--- a/components/widgets/editor/ui/SizeContainer.js
+++ b/components/widgets/editor/ui/SizeContainer.js
@@ -60,6 +60,7 @@ class SizeContainer extends React.Component {
           {size &&
             <ColumnBox
               name={size.name}
+              alias={size.alias}
               type={size.type}
               closable
               configurable

--- a/components/widgets/editor/ui/SortContainer.js
+++ b/components/widgets/editor/ui/SortContainer.js
@@ -52,6 +52,7 @@ class SortContainer extends React.Component {
           {orderBy &&
             <ColumnBox
               name={orderBy.name}
+              alias={orderBy.alias}
               type={orderBy.type}
               closable
               configurable

--- a/components/widgets/editor/ui/ValueContainer.js
+++ b/components/widgets/editor/ui/ValueContainer.js
@@ -67,6 +67,7 @@ class DimensionYContainer extends React.Component {
           {value &&
             <ColumnBox
               name={value.name}
+              alias={value.alias}
               type={value.type}
               closable
               configurable

--- a/utils/widgets/1d_scatter.js
+++ b/utils/widgets/1d_scatter.js
@@ -65,7 +65,7 @@ export default function ({ columns, data, url, embedData }) {
 
   // We add the name of the axis
   const xAxis = config.axes.find(a => a.type === 'x');
-  xAxis.name = columns.x.name;
+  xAxis.name = columns.x.alias || columns.x.name;
 
   if (columns.color.present) {
     // We add the color scale

--- a/utils/widgets/1d_tick.js
+++ b/utils/widgets/1d_tick.js
@@ -66,7 +66,7 @@ export default function ({ columns, data, url, embedData }) {
 
   // We add the name of the axis
   const xAxis = config.axes.find(a => a.type === 'x');
-  xAxis.name = columns.x.name;
+  xAxis.name = columns.x.alias || columns.x.name;
 
   if (columns.color.present) {
     // We add the color scale

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -498,12 +498,18 @@ export async function getChartConfig(
         type: chartInfo.x.type,
         name: xLabel,
         alias: chartInfo.x.alias
+          ? chartInfo.x.alias[0].toUpperCase()
+              + chartInfo.x.alias.slice(1, chartInfo.x.alias.length)
+          : null
       },
       y: {
         present: !!chartInfo.y,
         type: chartInfo.y && chartInfo.y.type,
         name: yLabel,
         alias: chartInfo.y && chartInfo.y.alias
+          ? chartInfo.y.alias[0].toUpperCase()
+            + chartInfo.y.alias.slice(1, chartInfo.y.alias.length)
+          : null
       },
       color: {
         present: !!chartInfo.color,

--- a/utils/widgets/bar.js
+++ b/utils/widgets/bar.js
@@ -189,8 +189,8 @@ export default function ({ columns, data, url, embedData, provider, band  }) {
   {
     const xAxis = config.axes.find(a => a.type === 'x');
     const yAxis = config.axes.find(a => a.type === 'y');
-    xAxis.name = columns.x.name;
-    yAxis.name = columns.y.name;
+    xAxis.name = columns.x.alias || columns.x.name;
+    yAxis.name = columns.y.alias || columns.y.name;
   }
 
   if (columns.color.present) {

--- a/utils/widgets/line.js
+++ b/utils/widgets/line.js
@@ -71,8 +71,8 @@ export default function ({ columns, data, url, embedData }) {
   // We add the name of the axis
   const xAxis = config.axes.find(a => a.type === 'x');
   const yAxis = config.axes.find(a => a.type === 'y');
-  xAxis.name = columns.x.name;
-  yAxis.name = columns.y.name;
+  xAxis.name = columns.x.alias || columns.x.name;
+  yAxis.name = columns.y.alias || columns.y.name;
 
   // If the x column is a date, we need to use a
   // temporal x scale and parse the x column as a date

--- a/utils/widgets/pie.js
+++ b/utils/widgets/pie.js
@@ -123,8 +123,8 @@ export default function ({ columns, data, url, embedData }) {
   // chart but we use them for the tooltip
   const xAxis = config.axes.find(a => a.type === 'x');
   const yAxis = config.axes.find(a => a.type === 'y');
-  xAxis.name = columns.x.name;
-  yAxis.name = columns.y.name;
+  xAxis.name = columns.x.alias || columns.x.name;
+  yAxis.name = columns.y.alias || columns.y.name;
 
   if (columns.color.present) {
     const colorScale = config.scales.find(scale => scale.name === 'c');

--- a/utils/widgets/scatter.js
+++ b/utils/widgets/scatter.js
@@ -69,8 +69,8 @@ export default function ({ columns, data, url, embedData }) {
   // We add the name of the axis
   const xAxis = config.axes.find(a => a.type === 'x');
   const yAxis = config.axes.find(a => a.type === 'y');
-  xAxis.name = columns.x.name;
-  yAxis.name = columns.y.name;
+  xAxis.name = columns.x.alias || columns.x.name;
+  yAxis.name = columns.y.alias || columns.y.name;
 
   if (columns.color.present) {
     // We add the color scale


### PR DESCRIPTION
This PR displays the aliases of the fields when present in the widget editor. The aliases can be seen for the "Chart" visualisation type and for the table as well.

You can test the feature with this dataset: `f2fe7588-6d1b-400e-b79c-0c86bf1273ea `.