### PR TITLE
Add preproduction to fetchAllData service

### DIFF
--- a/services/DatasetsService.js
+++ b/services/DatasetsService.js
@@ -40,12 +40,13 @@ export default class DatasetsService {
     });
   }
 
-  fetchAllData({ applications = [process.env.APPLICATIONS], includes, filters } = {}) {
+  fetchAllData({ applications = [process.env.APPLICATIONS], includes, filters, env = 'preproduction,production' } = {}) {
     const qParams = {
       application: applications.join(','),
       ...!!includes && { includes },
       'page[size]': 9999999,
-      ...filters
+      ...filters,
+      env
     };
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
This PR adds by default datasets with `env=preproduction` to the response of the method `fetchAllData()` from DatasetsService.