### PR TITLE
Planet Pulse improvements

### DIFF
--- a/components/app/pulse/LayerCard.js
+++ b/components/app/pulse/LayerCard.js
@@ -1,11 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Legend from 'components/app/pulse/Legend';
+
 import { Link } from 'routes';
 
+// Redux
+import { connect } from 'react-redux';
+
+// Components
+import Legend from 'components/app/pulse/Legend';
+
 function LayerCard(props) {
-  const { layerActive } = props;
+  const { layerActive, layerPoints } = props.pulse;
 
   const className = classNames({
     'c-layer-card': true,
@@ -18,6 +24,9 @@ function LayerCard(props) {
     <div className={className}>
       <h2>{layerActive && layerActive.attributes.name}</h2>
       <p>{layerActive && layerActive.attributes.description}</p>
+      {layerPoints && layerPoints.length > 0 &&
+        <p>Number of objects: {layerPoints.length}</p>
+      }
       <Legend
         layerActive={layerActive}
         className={{ color: '-dark' }}
@@ -36,7 +45,11 @@ function LayerCard(props) {
 
 LayerCard.propTypes = {
   // PROPS
-  layerActive: PropTypes.object
+  pulse: PropTypes.object
 };
 
-export default LayerCard;
+const mapStateToProps = state => ({
+  pulse: state.pulse
+});
+
+export default connect(mapStateToProps, null)(LayerCard);

--- a/pages/app/Pulse.js
+++ b/pages/app/Pulse.js
@@ -6,7 +6,7 @@ import { toastr } from 'react-redux-toastr';
 // Redux
 import withRedux from 'next-redux-wrapper';
 import { initStore } from 'store';
-import { getLayers, getLayerPoints } from 'redactions/pulse';
+import { getLayers, getLayerPoints, toggleActiveLayer } from 'redactions/pulse';
 import getLayersGroupPulse from 'selectors/pulse/layersGroupPulse';
 import getActiveLayersPulse from 'selectors/pulse/layersActivePulse';
 import { toggleTooltip } from 'redactions/tooltip';
@@ -114,6 +114,7 @@ class Pulse extends Page {
   componentWillUnmount() {
     document.removeEventListener('click', this.triggerMouseDown);
     this.props.toggleTooltip(false);
+    this.props.toggleActiveLayer(null);
     this.mounted = false;
   }
 
@@ -277,9 +278,10 @@ Pulse.propTypes = {
   // STORE
   layersGroup: PropTypes.array,
   layerActive: PropTypes.object,
-  getLayers: PropTypes.func,
-  getLayerPoints: PropTypes.func,
-  toggleTooltip: PropTypes.func
+  getLayers: PropTypes.func.isRequired,
+  getLayerPoints: PropTypes.func.isRequired,
+  toggleTooltip: PropTypes.func.isRequired,
+  toggleActiveLayer: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -297,6 +299,9 @@ const mapDispatchToProps = dispatch => ({
   },
   getLayerPoints: (id, tableName) => {
     dispatch(getLayerPoints(id, tableName));
+  },
+  toggleActiveLayer: (id, threedimensional, markerType) => {
+    dispatch(toggleActiveLayer(id, threedimensional, markerType));
   }
 });
 

--- a/redactions/pulse.js
+++ b/redactions/pulse.js
@@ -74,27 +74,34 @@ export function getLayers() {
 
 export function toggleActiveLayer(id, threedimensional, markerType) {
   return (dispatch) => {
-    fetch(new Request(`${process.env.WRI_API_URL}/layer/${id}`))
-      .then((response) => {
-        if (response.ok) return response.json();
-        throw new Error(response.statusText);
-      })
-      .then((response) => {
-        const layer = response.data;
-        layer.threedimensional = threedimensional;
-        layer.markerType = markerType;
-        dispatch({
-          type: SET_ACTIVE_LAYER,
-          payload: layer
+    if (id) {
+      fetch(new Request(`${process.env.WRI_API_URL}/layer/${id}`))
+        .then((response) => {
+          if (response.ok) return response.json();
+          throw new Error(response.statusText);
+        })
+        .then((response) => {
+          const layer = response.data;
+          layer.threedimensional = threedimensional;
+          layer.markerType = markerType;
+          dispatch({
+            type: SET_ACTIVE_LAYER,
+            payload: layer
+          });
+        })
+        .catch(() => {
+          // Fetch from server ko -> Dispatch error
+          dispatch({
+            type: SET_ACTIVE_LAYER,
+            payload: null
+          });
         });
-      })
-      .catch(() => {
-        // Fetch from server ko -> Dispatch error
-        dispatch({
-          type: SET_ACTIVE_LAYER,
-          payload: null
-        });
+    } else {
+      dispatch({
+        type: SET_ACTIVE_LAYER,
+        payload: null
       });
+    }
   };
 }
 


### PR DESCRIPTION
- Bug fixed: state was not reset when leaving the page and thus the layer card of the last active layer stayed there when clicking on the 'Back' button of the browser.
- Lights test: The layers for Volcanos has now a red light for every Volcano object
- Number of 3D objects: The layer card includes now the number of 3D objects that are present on the globe

![image](https://user-images.githubusercontent.com/545342/30962667-ecd87dee-a44a-11e7-928e-cb6018b5b276.png)
