### PR TITLE
Improve filtering in Explore: tags + filters revamp

### DIFF
--- a/components/app/explore/DatasetList.js
+++ b/components/app/explore/DatasetList.js
@@ -28,6 +28,7 @@ const DatasetList = (props) => {
               layer={find(dataset.attributes.layer, { attributes: { default: true } })}
               mode={mode}
               showActions={showActions}
+              onTagSelected={tag => props.onTagSelected(tag)}
             />
           </div>)
         )}
@@ -39,7 +40,10 @@ const DatasetList = (props) => {
 DatasetList.propTypes = {
   list: PropTypes.array,
   mode: PropTypes.string,
-  showActions: PropTypes.bool.isRequired
+  showActions: PropTypes.bool.isRequired,
+
+  // Callbacks
+  onTagSelected: PropTypes.func
 };
 
 export default DatasetList;

--- a/components/app/explore/DatasetWidget.js
+++ b/components/app/explore/DatasetWidget.js
@@ -127,9 +127,10 @@ class DatasetWidget extends React.Component {
     });
   }
 
+  @Autobind
   handleTagClick(event) {
     const tagName = event.target.textContent;
-    console.log('Tag selected: ', tagName);
+    this.props.onTagSelected(tagName);
   }
 
   render() {
@@ -235,6 +236,9 @@ DatasetWidget.propTypes = {
   layer: PropTypes.object,
   mode: PropTypes.string,
   showActions: PropTypes.bool,
+
+  // Callbacks
+  onTagSelected: PropTypes.func,
 
   // STORE
 

--- a/css/components/app/pages/explore.scss
+++ b/css/components/app/pages/explore.scss
@@ -48,6 +48,14 @@
     }
   }
 
+  .buttons {
+    .filters-sum-up {
+      margin-left: 10px;
+      font-style: italic;
+      font-size: $font-size-small;
+    }
+  }
+
   .share-button {
     position: absolute;
     display: flex;

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -192,7 +192,7 @@ class Explore extends Page {
             return match.value;
           });
 
-          this.filters.dataTypes = dataTypesVal;
+          this.filters.dataType = dataTypesVal;
         }
 
         // Save the data types tree as a variable for later use
@@ -412,6 +412,14 @@ class Explore extends Page {
     const { explore, totalDatasets, filteredDatasets } = this.props;
     const { search } = explore.filters;
     const { showFilters } = this.state;
+    const { topics, geographies, dataType } = this.filters;
+
+    const topicsSt = topics && topics.length > 0 ? ` topics (${topics.length})` : '';
+    const geographiesSt = geographies && geographies.length > 0 ? ` geographies (${geographies.length})` : '';
+    const dataTypesSt = dataType && dataType.length > 0 ? ` data type (${dataType.length})` : '';
+    const filtersAppliedText = (geographiesSt !== '' || topicsSt !== '' || dataTypesSt !== '') ?
+      `${topicsSt} ${geographiesSt} ${dataTypesSt}` : '';
+    const filtersSumUp = !showFilters ? filtersAppliedText : '';
 
     const buttonFilterContent = showFilters ? 'Hide filters' : 'Show filters';
     const filterContainerClass = classnames('filters-container', {
@@ -451,7 +459,7 @@ class Explore extends Page {
                       className="c-button"
                       onClick={() => this.toggleFilters()}
                     >
-                      {buttonFilterContent}
+                      {buttonFilterContent}<span className="filters-sum-up">{filtersSumUp}</span>
                     </button>
                   </div>
                   <div className={filterContainerClass}>

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -167,7 +167,7 @@ class Explore extends Page {
       .then(response => response.json())
       .then((data) => {
         if (topics) {
-          data.forEach(child => this.selectElementsFromTree(child, topics));
+          data.forEach(child => this.selectElementsFromTree(child, JSON.parse(topics)));
 
           const topicsVal = JSON.parse(topics).map((type) => {
             const match = data.find(d => d.value === type) || {};
@@ -186,7 +186,7 @@ class Explore extends Page {
       .then(response => response.json())
       .then((data) => {
         if (dataType) {
-          data.forEach(child => this.selectElementsFromTree(child, dataType));
+          data.forEach(child => this.selectElementsFromTree(child, JSON.parse(dataType)));
           const dataTypesVal = JSON.parse(dataType).map((type) => {
             const match = data.find(d => d.value === type) || {};
             return match.value;
@@ -204,7 +204,7 @@ class Explore extends Page {
       .then(response => response.json())
       .then((data) => {
         if (geographies) {
-          data.forEach(child => this.selectElementsFromTree(child, geographies));
+          data.forEach(child => this.selectElementsFromTree(child, JSON.parse(geographies)));
           const geographiesVal = [];
 
           const searchFunction = (item) => {
@@ -249,7 +249,14 @@ class Explore extends Page {
    * @param {Object[]} elements Contains values to be selected in the data tree.
    */
   selectElementsFromTree(tree = {}, elements = []) { // eslint-disable-line class-methods-use-this
-    tree.checked = elements.includes(tree.value); // eslint-disable-line no-param-reassign
+    let found = false; // We're using this loop because indexOf was finding elements
+    // that were substrings, e.g. "co" and "economic" when only "economic" should have been found
+    for (let i = 0; i < elements.length && !found; i++) {
+      if (elements[i] === tree.value) {
+        found = true;
+      }
+    }
+    tree.checked = found; // eslint-disable-line no-param-reassign
 
     (tree.children || []).forEach((child) => {
       if (tree.checked) {
@@ -380,15 +387,15 @@ class Explore extends Page {
 
     if (page !== 1) this.props.setDatasetsPage(1);
 
-    // // updates URL
-    // this.props.setDatasetsTopicsFilter(topics);
-    // this.props.setDatasetsGeographiesFilter(geographies);
-    // this.props.setDatasetsDataTypeFilter(dataType);
-    //
-    // if (!hasValues) {
-    //   this.props.setDatasetsFilteredByConcepts([]);
-    //   return;
-    // }
+    // updates URL
+    this.props.setDatasetsTopicsFilter(topics);
+    this.props.setDatasetsGeographiesFilter(geographies);
+    this.props.setDatasetsDataTypeFilter(dataType);
+
+    if (!hasValues) {
+      this.props.setDatasetsFilteredByConcepts([]);
+      return;
+    }
 
     this.props.setFiltersLoading(true);
     this.datasetService.searchDatasetsByConcepts(

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -249,16 +249,13 @@ class Explore extends Page {
    * @param {Object[]} elements Contains values to be selected in the data tree.
    */
   selectElementsFromTree(tree = {}, elements = [], deselect = false) {
-    console.log('deselect', deselect, 'elements', elements, 'tree', tree);
     let found = false; // We're using this loop because indexOf was finding elements
     // that were substrings, e.g. "co" and "economic" when only "economic" should have been found
     for (let i = 0; i < elements.length && !found; i++) {
       if (elements[i] === tree.value) {
         tree.checked = !deselect; // eslint-disable-line no-param-reassign
         found = true;
-        console.log('lalala');
       }
-      console.log('oooo');
     }
 
     (tree.children || []).forEach((child) => {
@@ -472,7 +469,14 @@ class Explore extends Page {
                               data={this.topicsTree}
                               onChange={(currentNode, selectedNodes) => {
                                 this.filters.topics = selectedNodes.map(val => val.value);
-                                this.selectElementsFromTree(this.topicsTree, this.filters.topics, !selectedNodes.includes(currentNode));
+                                const deselect = !selectedNodes.includes(currentNode);
+                                if (deselect) {
+                                  this.topicsTree.forEach(child => this.selectElementsFromTree(
+                                    child, [currentNode.value], deselect));
+                                } else {
+                                  this.topicsTree.forEach(child => this.selectElementsFromTree(
+                                    child, this.filters.topics, deselect));
+                                }
                               }}
                             />
                           }
@@ -486,8 +490,14 @@ class Explore extends Page {
                               placeholderText="Geographies"
                               onChange={(currentNode, selectedNodes) => {
                                 this.filters.geographies = selectedNodes.map(val => val.value);
-                                this.selectElementsFromTree(this.geographiesTree,
-                                  this.filters.geographies, !selectedNodes.includes(currentNode));
+                                const deselect = !selectedNodes.includes(currentNode);
+                                if (deselect) {
+                                  this.geographiesTree.forEach(child => this.selectElementsFromTree(
+                                    child, [currentNode.value], deselect));
+                                } else {
+                                  this.geographiesTree.forEach(child => this.selectElementsFromTree(
+                                    child, this.filters.geographies, deselect));
+                                }
                               }}
                             />
                           }
@@ -509,7 +519,6 @@ class Explore extends Page {
                                   this.dataTypesTree.forEach(child => this.selectElementsFromTree(
                                     child, this.filters.dataType, deselect));
                                 }
-                                console.log('this.dataTypesTree', this.dataTypesTree);
                               }}
                             />
                           }

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -249,15 +249,14 @@ class Explore extends Page {
    * @param {Object[]} elements Contains values to be selected in the data tree.
    */
   selectElementsFromTree(tree = {}, elements = []) { // eslint-disable-line class-methods-use-this
-    if (elements.includes(tree.value)) {
-      tree.checked = true; // eslint-disable-line no-param-reassign
-    }
-    (tree.children || []).forEach(child => {
+    tree.checked = elements.includes(tree.value); // eslint-disable-line no-param-reassign
+
+    (tree.children || []).forEach((child) => {
       if (tree.checked) {
-        child.checked = tree.checked;
+        child.checked = tree.checked; // eslint-disable-line no-param-reassign
       } else {
-        this.selectElementsFromTree(child, elements)
-      };
+        this.selectElementsFromTree(child, elements);
+      }
     });
   }
 
@@ -360,12 +359,15 @@ class Explore extends Page {
   @Autobind
   handleTagSelected(tag) {
     if (this.topicsTree.find(elem => elem.value === tag)) {
+      this.topicsTree.forEach(child => this.selectElementsFromTree(child, [tag]));
       this.filters = { topics: [tag], geographies: [], dataType: [] };
       this.applyFilters();
     } else if (this.geographiesTree.find(elem => elem.value === tag)) {
+      this.geographiesTree.forEach(child => this.selectElementsFromTree(child, [tag]));
       this.filters = { topics: [], geographies: [tag], dataType: [] };
       this.applyFilters();
     } else if (this.dataTypesTree.find(elem => elem.value === tag)) {
+      this.dataTypesTree.forEach(child => this.selectElementsFromTree(child, [tag]));
       this.filters = { topics: [], geographies: [], dataType: [tag] };
       this.applyFilters();
     }
@@ -378,15 +380,15 @@ class Explore extends Page {
 
     if (page !== 1) this.props.setDatasetsPage(1);
 
-    // updates URL
-    this.props.setDatasetsTopicsFilter(topics);
-    this.props.setDatasetsGeographiesFilter(geographies);
-    this.props.setDatasetsDataTypeFilter(dataType);
-
-    if (!hasValues) {
-      this.props.setDatasetsFilteredByConcepts([]);
-      return;
-    }
+    // // updates URL
+    // this.props.setDatasetsTopicsFilter(topics);
+    // this.props.setDatasetsGeographiesFilter(geographies);
+    // this.props.setDatasetsDataTypeFilter(dataType);
+    //
+    // if (!hasValues) {
+    //   this.props.setDatasetsFilteredByConcepts([]);
+    //   return;
+    // }
 
     this.props.setFiltersLoading(true);
     this.datasetService.searchDatasetsByConcepts(
@@ -460,6 +462,7 @@ class Explore extends Page {
                               data={this.topicsTree}
                               onChange={(currentNode, selectedNodes) => {
                                 this.filters.topics = selectedNodes.map(val => val.value);
+                                this.selectElementsFromTree(this.topicsTree, this.filters.topics);
                               }}
                             />
                           }
@@ -473,6 +476,8 @@ class Explore extends Page {
                               placeholderText="Geographies"
                               onChange={(currentNode, selectedNodes) => {
                                 this.filters.geographies = selectedNodes.map(val => val.value);
+                                this.selectElementsFromTree(this.geographiesTree,
+                                  this.filters.geographies);
                               }}
                             />
                           }
@@ -486,6 +491,8 @@ class Explore extends Page {
                               placeholderText="Data types"
                               onChange={(currentNode, selectedNodes) => {
                                 this.filters.dataType = selectedNodes.map(val => val.value);
+                                this.selectElementsFromTree(this.dataTypesTree,
+                                  this.filters.dataType);
                               }}
                             />
                           }

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -248,15 +248,18 @@ class Explore extends Page {
    * @param {Object} tree used to populate selectors. Contains all options available.
    * @param {Object[]} elements Contains values to be selected in the data tree.
    */
-  selectElementsFromTree(tree = {}, elements = []) { // eslint-disable-line class-methods-use-this
+  selectElementsFromTree(tree = {}, elements = [], deselect = false) {
+    console.log('deselect', deselect, 'elements', elements, 'tree', tree);
     let found = false; // We're using this loop because indexOf was finding elements
     // that were substrings, e.g. "co" and "economic" when only "economic" should have been found
     for (let i = 0; i < elements.length && !found; i++) {
       if (elements[i] === tree.value) {
+        tree.checked = !deselect; // eslint-disable-line no-param-reassign
         found = true;
+        console.log('lalala');
       }
+      console.log('oooo');
     }
-    tree.checked = found; // eslint-disable-line no-param-reassign
 
     (tree.children || []).forEach((child) => {
       if (tree.checked) {
@@ -469,7 +472,7 @@ class Explore extends Page {
                               data={this.topicsTree}
                               onChange={(currentNode, selectedNodes) => {
                                 this.filters.topics = selectedNodes.map(val => val.value);
-                                this.selectElementsFromTree(this.topicsTree, this.filters.topics);
+                                this.selectElementsFromTree(this.topicsTree, this.filters.topics, !selectedNodes.includes(currentNode));
                               }}
                             />
                           }
@@ -484,7 +487,7 @@ class Explore extends Page {
                               onChange={(currentNode, selectedNodes) => {
                                 this.filters.geographies = selectedNodes.map(val => val.value);
                                 this.selectElementsFromTree(this.geographiesTree,
-                                  this.filters.geographies);
+                                  this.filters.geographies, !selectedNodes.includes(currentNode));
                               }}
                             />
                           }
@@ -498,8 +501,15 @@ class Explore extends Page {
                               placeholderText="Data types"
                               onChange={(currentNode, selectedNodes) => {
                                 this.filters.dataType = selectedNodes.map(val => val.value);
-                                this.selectElementsFromTree(this.dataTypesTree,
-                                  this.filters.dataType);
+                                const deselect = !selectedNodes.includes(currentNode);
+                                if (deselect) {
+                                  this.dataTypesTree.forEach(child => this.selectElementsFromTree(
+                                    child, [currentNode.value], deselect));
+                                } else {
+                                  this.dataTypesTree.forEach(child => this.selectElementsFromTree(
+                                    child, this.filters.dataType, deselect));
+                                }
+                                console.log('this.dataTypesTree', this.dataTypesTree);
                               }}
                             />
                           }

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -262,7 +262,7 @@ class Explore extends Page {
       if (tree.checked) {
         child.checked = tree.checked; // eslint-disable-line no-param-reassign
       } else {
-        this.selectElementsFromTree(child, elements);
+        this.selectElementsFromTree(child, elements, deselect);
       }
     });
   }

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -259,11 +259,7 @@ class Explore extends Page {
     }
 
     (tree.children || []).forEach((child) => {
-      if (tree.checked) {
-        child.checked = tree.checked; // eslint-disable-line no-param-reassign
-      } else {
-        this.selectElementsFromTree(child, elements, deselect);
-      }
+      this.selectElementsFromTree(child, elements, deselect);
     });
   }
 


### PR DESCRIPTION
This pull requests includes:
- Allow users to filter by the dataset tags by clicking on them in the tags tooltip
- Sum up of the filters applied when the filters selectors are hidden
- Filters section is open on page load when filters are specified in the URL

![image](https://user-images.githubusercontent.com/545342/31078496-ad3b8196-a782-11e7-9b52-b274b02bfb58.png)
![image](https://user-images.githubusercontent.com/545342/31078515-b7efe7c6-a782-11e7-9f01-073c0acb93c8.png)
