### PR TITLE
Fix: navigation issue when you create layers or widgets

### DIFF
--- a/components/admin/datasets/pages/show.js
+++ b/components/admin/datasets/pages/show.js
@@ -11,7 +11,7 @@ import Aside from 'components/ui/Aside';
 import DatasetsForm from 'components/datasets/form/DatasetsForm';
 import MetadataForm from 'components/admin/metadata/form/MetadataForm';
 import TagsForm from 'components/admin/tags/TagsForm';
-import WidgetIndex from 'components/admin/widget/pages/index';
+import WidgetIndex from 'components/admin/widgets/pages/index';
 import LayersIndex from 'components/admin/layers/pages/index';
 
 // Constants

--- a/components/admin/layers/LayersTab.js
+++ b/components/admin/layers/LayersTab.js
@@ -24,7 +24,7 @@ function LayersTab(props) {
       }
 
       {user.token && id && id !== 'new' &&
-        <LayersShow tab={tab} subtab={subtab} id={id} user={user} />
+        <LayersShow tab={tab} subtab={subtab} id={id} user={user} dataset={dataset} />
       }
     </div>
   );

--- a/components/admin/layers/pages/new.js
+++ b/components/admin/layers/pages/new.js
@@ -12,7 +12,13 @@ function LayersNew(props) {
       <LayersForm
         application={[process.env.APPLICATIONS]}
         authorization={user.token}
-        onSubmit={() => Router.pushRoute('admin_data', { tab: 'layers' })}
+        onSubmit={() => {
+          if (dataset) {
+            Router.pushRoute('admin_data_detail', { tab: 'datasets', subtab: 'layers', id: dataset });
+          } else {
+            Router.pushRoute('admin_data', { tab: 'layers' });
+          }
+        }}
         dataset={dataset}
       />
     </div>

--- a/components/admin/layers/pages/show.js
+++ b/components/admin/layers/pages/show.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import LayersForm from 'components/admin/layers/form/LayersForm';
 
 function LayersShow(props) {
-  const { id, user } = props;
+  const { id, dataset, user } = props;
 
   return (
     <div className="c-layers-show">
@@ -15,7 +15,13 @@ function LayersShow(props) {
           id={id}
           application={[process.env.APPLICATIONS]}
           authorization={user.token}
-          onSubmit={() => Router.pushRoute('admin_data', { tab: 'layers' })}
+          onSubmit={() => {
+            if (dataset) {
+              Router.pushRoute('admin_data_detail', { tab: 'datasets', subtab: 'layers', id: dataset });
+            } else {
+              Router.pushRoute('admin_data', { tab: 'layers' });
+            }
+          }}
         />
       }
     </div>
@@ -24,6 +30,7 @@ function LayersShow(props) {
 
 LayersShow.propTypes = {
   id: PropTypes.string.isRequired,
+  dataset: PropTypes.string,
   // Store
   user: PropTypes.object.isRequired
 };

--- a/components/admin/layers/table/LayersTable.js
+++ b/components/admin/layers/table/LayersTable.js
@@ -67,7 +67,11 @@ class LayersTable extends React.Component {
           link={{
             label: 'New layer',
             route: 'admin_data_detail',
-            params: { tab: 'layers', id: 'new', dataset: this.props.dataset }
+            params: {
+              tab: 'layers',
+              id: 'new',
+              ...!!dataset && { dataset }
+            }
           }}
           onSearch={this.onSearch}
         />
@@ -76,7 +80,7 @@ class LayersTable extends React.Component {
         {!this.props.error && (
           <CustomTable
             columns={[
-              { label: 'Name', value: 'name', td: NameTD },
+              { label: 'Name', value: 'name', td: NameTD, tdProps: { dataset } },
               { label: 'Provider', value: 'provider' },
               { label: 'Updated at', value: 'updatedAt', td: UpdatedAtTD },
               { label: 'Ownership', value: 'userId', td: OwnershipTD, tdProps: { user } }
@@ -84,7 +88,7 @@ class LayersTable extends React.Component {
             actions={{
               show: true,
               list: [
-                { name: 'Edit', route: 'admin_data_detail', params: { tab: 'layers', subtab: 'edit', id: '{{id}}' }, show: true, component: EditAction },
+                { name: 'Edit', route: 'admin_data_detail', params: { tab: 'layers', subtab: 'edit', id: '{{id}}', ...!!dataset && { dataset } }, show: true, component: EditAction },
                 { name: 'Remove', route: 'admin_data_detail', params: { tab: 'layers', subtab: 'remove', id: '{{id}}' }, component: DeleteAction, componentProps: { authorization: this.props.authorization } },
                 { name: 'Go to dataset', route: 'admin_data_detail', params: { tab: 'datasets', subtab: 'edit', id: '{{id}}' }, component: GoToDatasetAction }
               ]

--- a/components/admin/layers/table/td/NameTD.js
+++ b/components/admin/layers/table/td/NameTD.js
@@ -5,11 +5,19 @@ import PropTypes from 'prop-types';
 import { Link } from 'routes';
 
 function NameTD(props) {
-  const { row, value, index } = props;
+  const { row, value, index, dataset } = props;
 
   return (
     <td key={index} className="main">
-      <Link route="admin_data_detail" params={{ tab: 'layers', subtab: 'edit', id: row.id }}>
+      <Link
+        route="admin_data_detail"
+        params={{
+          tab: 'layers',
+          subtab: 'edit',
+          id: row.id,
+          ...!!dataset && { dataset }
+        }}
+      >
         <a>{value}</a>
       </Link>
     </td>
@@ -19,6 +27,7 @@ function NameTD(props) {
 NameTD.propTypes = {
   row: PropTypes.object,
   value: PropTypes.string,
+  dataset: PropTypes.string,
   index: PropTypes.string
 };
 

--- a/components/admin/widgets/WidgetsTab.js
+++ b/components/admin/widgets/WidgetsTab.js
@@ -24,7 +24,7 @@ function WidgetsTab(props) {
       }
 
       {user.token && id && id !== 'new' &&
-        <WidgetsShow tab={tab} subtab={subtab} id={id} user={user} />
+        <WidgetsShow tab={tab} subtab={subtab} id={id} user={user} dataset={dataset} />
       }
     </div>
   );

--- a/components/admin/widgets/pages/new.js
+++ b/components/admin/widgets/pages/new.js
@@ -16,7 +16,13 @@ function WidgetsNew(props) {
     <div className="c-widgets-new">
       <WidgetsForm
         authorization={user.token}
-        onSubmit={() => Router.pushRoute('admin_data', { tab: 'widgets' })}
+        onSubmit={() => {
+          if (dataset) {
+            Router.pushRoute('admin_data_detail', { tab: 'datasets', subtab: 'widgets', id: dataset });
+          } else {
+            Router.pushRoute('admin_data', { tab: 'widgets' });
+          }
+        }}
         dataset={dataset}
       />
     </div>

--- a/components/admin/widgets/pages/show.js
+++ b/components/admin/widgets/pages/show.js
@@ -10,14 +10,20 @@ import { connect } from 'react-redux';
 import WidgetsForm from 'components/admin/widgets/form/WidgetsForm';
 
 function WidgetsShow(props) {
-  const { id, user } = props;
+  const { id, dataset, user } = props;
 
   return (
     <div className="c-widgets-show">
       <WidgetsForm
         id={id}
         authorization={user.token}
-        onSubmit={() => Router.pushRoute('admin_data', { tab: 'widgets' })}
+        onSubmit={() => {
+          if (dataset) {
+            Router.pushRoute('admin_data_detail', { tab: 'datasets', subtab: 'widgets', id: dataset });
+          } else {
+            Router.pushRoute('admin_data', { tab: 'widgets' });
+          }
+        }}
       />
     </div>
   );
@@ -25,6 +31,7 @@ function WidgetsShow(props) {
 
 WidgetsShow.propTypes = {
   id: PropTypes.string,
+  dataset: PropTypes.string,
   // Store
   user: PropTypes.object.isRequired
 };

--- a/components/admin/widgets/table/WidgetsTable.js
+++ b/components/admin/widgets/table/WidgetsTable.js
@@ -29,7 +29,10 @@ import OwnershipTD from './td/OwnershipTD';
 class WidgetsTable extends React.Component {
   componentDidMount() {
     this.props.setFilters([]);
-    this.props.getWidgets();
+    // TODO: get filtered widgets
+    this.props.getWidgets({
+      dataset: this.props.dataset
+    });
   }
 
   /**
@@ -59,7 +62,7 @@ class WidgetsTable extends React.Component {
   }
 
   render() {
-    const { user } = this.props;
+    const { user, dataset } = this.props;
     return (
       <div className="c-widgets-table">
         <Spinner className="-light" isLoading={this.props.loading} />
@@ -75,7 +78,11 @@ class WidgetsTable extends React.Component {
           link={{
             label: 'New widget',
             route: 'admin_data_detail',
-            params: { tab: 'widgets', id: 'new' }
+            params: {
+              tab: 'widgets',
+              id: 'new',
+              ...!!dataset && { dataset }
+            }
           }}
           onSearch={this.onSearch}
         />
@@ -83,7 +90,7 @@ class WidgetsTable extends React.Component {
         {!this.props.error && (
           <CustomTable
             columns={[
-              { label: 'Title', value: 'name', td: TitleTD },
+              { label: 'Title', value: 'name', td: TitleTD, tdProps: { dataset } },
               // { label: 'Dataset', value: 'dataset', td: DatasetTD },
               { label: 'Published', value: 'published', td: PublishedTD },
               { label: 'Ownership', value: 'userId', td: OwnershipTD, tdProps: { user } }
@@ -91,7 +98,7 @@ class WidgetsTable extends React.Component {
             actions={{
               show: true,
               list: [
-                { name: 'Edit', route: 'admin_data_detail', params: { tab: 'widgets', subtab: 'edit', id: '{{id}}' }, show: true, component: EditAction },
+                { name: 'Edit', route: 'admin_data_detail', params: { tab: 'widgets', subtab: 'edit', id: '{{id}}', ...!!dataset && { dataset } }, show: true, component: EditAction },
                 { name: 'Remove', route: 'admin_data_detail', params: { tab: 'widgets', subtab: 'remove', id: '{{id}}' }, component: DeleteAction, componentProps: { authorization: this.props.authorization } }
               ]
             }}
@@ -102,7 +109,9 @@ class WidgetsTable extends React.Component {
             filters={false}
             data={this.getFilteredWidgets()}
             pageSize={20}
-            onRowDelete={() => this.props.getWidgets()}
+            onRowDelete={() => this.props.getWidgets({
+              dataset: this.props.dataset
+            })}
             pagination={{
               enabled: true,
               pageSize: 20,
@@ -118,6 +127,7 @@ class WidgetsTable extends React.Component {
 WidgetsTable.defaultProps = {
   columns: [],
   actions: {},
+  dataset: '',
   // Store
   widgets: [],
   filteredWidgets: [],
@@ -126,6 +136,7 @@ WidgetsTable.defaultProps = {
 
 WidgetsTable.propTypes = {
   authorization: PropTypes.string,
+  dataset: PropTypes.string,
   // Store
   loading: PropTypes.bool.isRequired,
   widgets: PropTypes.array.isRequired,
@@ -146,7 +157,7 @@ const mapStateToProps = state => ({
   user: state.user
 });
 const mapDispatchToProps = dispatch => ({
-  getWidgets: () => dispatch(getWidgets()),
+  getWidgets: options => dispatch(getWidgets(options)),
   setFilters: filters => dispatch(setFilters(filters))
 });
 

--- a/components/admin/widgets/table/td/TitleTD.js
+++ b/components/admin/widgets/table/td/TitleTD.js
@@ -5,11 +5,19 @@ import PropTypes from 'prop-types';
 import { Link } from 'routes';
 
 function NameTD(props) {
-  const { row, value, index } = props;
+  const { row, value, dataset, index } = props;
 
   return (
     <td key={index} className="main">
-      <Link route="admin_data_detail" params={{ tab: 'widgets', id: row.id }}>
+      <Link
+        route="admin_data_detail"
+        params={{
+          tab: 'widgets',
+          subtab: 'edit',
+          id: row.id,
+          ...!!dataset && { dataset }
+        }}
+      >
         <a>{value}</a>
       </Link>
     </td>
@@ -19,6 +27,7 @@ function NameTD(props) {
 NameTD.propTypes = {
   row: PropTypes.object,
   value: PropTypes.string,
+  dataset: PropTypes.string,
   index: PropTypes.string
 };
 

--- a/components/app/myrw/widgets/WidgetsTab.js
+++ b/components/app/myrw/widgets/WidgetsTab.js
@@ -19,7 +19,7 @@ function WidgetsTab(props) {
       }
 
       {id && subtab === 'edit' && user.token &&
-        <WidgetsEdit tab={tab} subtab={subtab} id={id} />
+        <WidgetsEdit tab={tab} subtab={subtab} id={id} dataset={dataset} />
       }
 
       {id === 'new' && user.token &&

--- a/pages/admin/DataDetail.js
+++ b/pages/admin/DataDetail.js
@@ -121,9 +121,16 @@ class DataDetail extends Page {
             <div className="row">
               <div className="column small-12">
                 <div className="page-header-content">
-                  <Breadcrumbs
-                    items={[{ name: capitalizeFirstLetter(tab), route: 'admin_data', params: { tab } }]}
-                  />
+                  {dataset && tab !== 'datasets' &&
+                    <Breadcrumbs
+                      items={[{ name: 'Back to dataset', route: 'admin_data_detail', params: { tab: 'datasets', subtab: tab, id: dataset } }]}
+                    />
+                  }
+                  {!dataset &&
+                    <Breadcrumbs
+                      items={[{ name: capitalizeFirstLetter(tab), route: 'admin_data', params: { tab } }]}
+                    />
+                  }
                   <h1>{this.getName()}</h1>
                 </div>
               </div>

--- a/pages/admin/DataDetail.js
+++ b/pages/admin/DataDetail.js
@@ -123,7 +123,7 @@ class DataDetail extends Page {
                 <div className="page-header-content">
                   {dataset && tab !== 'datasets' &&
                     <Breadcrumbs
-                      items={[{ name: 'Back to dataset', route: 'admin_data_detail', params: { tab: 'datasets', subtab: tab, id: dataset } }]}
+                      items={[{ name: capitalizeFirstLetter(tab), route: 'admin_data_detail', params: { tab: 'datasets', subtab: tab, id: dataset } }]}
                     />
                   }
                   {!dataset &&

--- a/redactions/admin/widgets.js
+++ b/redactions/admin/widgets.js
@@ -76,11 +76,11 @@ export default function (state = initialState, action) {
  * @export
  * @param {string[]} applications Name of the applications to load the widgets from
  */
-export function getWidgets() {
+export function getWidgets(options = {}) {
   return (dispatch) => {
     dispatch({ type: GET_WIDGETS_LOADING });
 
-    service.fetchAllData({})
+    service.fetchAllData(options)
       .then((data) => {
         dispatch({ type: GET_WIDGETS_SUCCESS, payload: data });
       })


### PR DESCRIPTION
- [x] Redirect to your dataset show page when you create or edit a widget and you came from a dataset.
- [x] Otherwise, you will be redirected to widgets.
- [x] What about the link, should it change if dataset exists? 
![image](https://user-images.githubusercontent.com/8928965/31080852-40a20ce6-a78a-11e7-8dc5-1451490226b3.png)
