### PR TITLE
Update graph endpoints: search and similar datasets

### DIFF
--- a/services/DatasetService.js
+++ b/services/DatasetService.js
@@ -110,7 +110,7 @@ export default class DatasetService {
     return new Promise((resolve) => {
       this.getFields().then((fieldsData) => {
         const filteredFields = fieldsData.fields.filter(field => field.columnType === 'number' || field.columnType === 'date' || field.columnType === 'string');
-        const promises = (filteredFields || []).map(field => {
+        const promises = (filteredFields || []).map((field) => {
           if (field.columnType === 'number' || field.columnType === 'date') {
             return this.getMinAndMax(field.columnName, fieldsData.tableName);
           }
@@ -185,7 +185,7 @@ export default class DatasetService {
       fetch(`https://api.resourcewatch.org/v1/query/${this.datasetId}?sql=${query}`)
         .then(response => response.json())
         .then((jsonData) => {
-          const parsedData = (jsonData.data || []).map(data => data[columnName]);
+          const parsedData = (jsonData.data || []).map(data => data[columnName]);
           resolve(parsedData);
         });
     });
@@ -209,7 +209,7 @@ export default class DatasetService {
   }
 
   getSimilarDatasets() {
-    return fetch(`${this.opts.apiURL}/graph/query/similar-dataset/${this.datasetId}`)
+    return fetch(`${this.opts.apiURL}/graph/query/similar-dataset/${this.datasetId}?published=true&env=production,preproduction`)
       .then(response => response.json())
       .then(jsonData => jsonData.data);
   }
@@ -257,7 +257,7 @@ export default class DatasetService {
     }
 
 
-    return fetch(`${this.opts.apiURL}/graph/query/search-datasets?${querySt}`)
+    return fetch(`${this.opts.apiURL}/graph/query/search-datasets?${querySt}&published=true&env=production,preproduction`)
       .then(response => response.json())
       .then(jsonData => jsonData.data);
   }


### PR DESCRIPTION
These endpoints are now requesting `published` datasets explicitly as well as including datasets with both `production` and `preproduction` environments.