### PR TITLE
Fix the distorted charts in My RW > My widgets

### DIFF
--- a/css/components/widgets/widget_card.scss
+++ b/css/components/widgets/widget_card.scss
@@ -36,7 +36,13 @@
         display: flex;
 
         canvas {
-          width: 100%;
+          // NOTE:
+          // Both the width and the height can't be defined because
+          // the "self-sizing" charts will be distorted (in My RW >
+          // My widgets)
+          // Also, if the width is defined, the same charts will be
+          // distorted, so the only attribute that can be defined
+          // here is height
           height: 100%;
         }
       }


### PR DESCRIPTION
The charts would be forced to take their container's full width and height whereas the bar and pie charts determine their sizes by themselves. This would distort them.

[Pivotal task](https://www.pivotaltracker.com/story/show/151472665)