### PR TITLE
Fix an issue where bars could overlap the x axis

### DIFF
--- a/components/widgets/editor/helpers/bar.js
+++ b/components/widgets/editor/helpers/bar.js
@@ -117,7 +117,7 @@ const defaultChart = {
           "rangeMax": 0,
           domain: { data: 'table', field: 'y' },
           nice: true,
-          zero: false
+          zero: true
         }
       ],
       axes: [

--- a/utils/widgets/bar.js
+++ b/utils/widgets/bar.js
@@ -117,7 +117,7 @@ const defaultChart = {
           "rangeMax": 0,
           domain: { data: 'table', field: 'y' },
           nice: true,
-          zero: false
+          zero: true
         }
       ],
       axes: [


### PR DESCRIPTION
It actually seems to be a bug from Vega: the null values are computed as "0" but don't count in the calculation of the y scale. That causes the bar to overlap the x axis when the the option "zero" is set to false in the vega configuration. After talking with Alicia, the vertical scale should always start with 0, so the problem is easily fixed.

[Pivotal task](https://www.pivotaltracker.com/story/show/151603686)