### PR TITLE
Area intersection filter changes in the widget editor

### DIFF
--- a/components/app/myrw/widgets/pages/new.js
+++ b/components/app/myrw/widgets/pages/new.js
@@ -90,7 +90,7 @@ class WidgetsNew extends React.Component {
     const dataset = datasets.find(elem => elem.value === selectedDataset);
     const { type, provider, tableName } = dataset;
 
-    if (!canRenderChart(widgetEditor)) {
+    if (!canRenderChart(widgetEditor, provider)) {
       toastr.error('Error', 'Please create a widget in order to save it');
       return;
     }

--- a/components/ui/SliderSelect.js
+++ b/components/ui/SliderSelect.js
@@ -63,6 +63,15 @@ export default class SliderSelect extends React.Component {
         pathToCurrentItemsList: [],
         pathToSelectedItem: []
       });
+    } else if (newProps.value !== this.props.value) {
+      // If the value of the select is changed via the props, we update
+      // the select item in the component
+      const selectedItem = this.props.options
+        && this.props.options.find(item => item.value === newProps.value);
+
+      if (selectedItem) {
+        this.setState({ selectedItem });
+      }
     }
   }
 

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -960,6 +960,7 @@ class WidgetEditor extends React.Component {
                         tableName={tableName}
                         provider={datasetProvider}
                         mode={chartEditorMode}
+                        hasGeoInfo={hasGeoInfo}
                         showSaveButton={showSaveButton}
                         onUpdateWidget={this.handleUpdateWidget}
                         title={title}

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -172,7 +172,8 @@ class WidgetEditor extends React.Component {
     // NOTE: this can't be moved to componentWillUpdate because
     // this.fetchChartConfig uses the store
     if (this.state.datasetInfoLoaded
-      && canRenderChart(this.props.widgetEditor)
+      && canRenderChart(this.props.widgetEditor, this.state.datasetProvider)
+      && this.props.widgetEditor.visualizationType !== 'table'
       && this.props.widgetEditor.visualizationType !== 'map'
       && (!isEqual(previousProps.widgetEditor, this.props.widgetEditor)
       || previousState.tableName !== this.state.tableName)) {
@@ -374,7 +375,8 @@ class WidgetEditor extends React.Component {
       layersLoaded,
       fieldsError,
       jiminyLoaded,
-      title
+      title,
+      datasetProvider
     } = this.state;
 
     const { widgetEditor, dataset, mode, selectedVisualizationType, user } = this.props;
@@ -409,7 +411,7 @@ class WidgetEditor extends React.Component {
               </div>
             </div>
           );
-        } else if (!canRenderChart(widgetEditor) || !this.state.chartConfig) {
+        } else if (!canRenderChart(widgetEditor, datasetProvider) || !this.state.chartConfig) {
           visualization = (
             <div className="visualization -chart">
               Select a type of chart and columns
@@ -526,14 +528,22 @@ class WidgetEditor extends React.Component {
 
       // HTML table
       case 'table':
-        visualization = (
-          <div className="visualization">
-            <TableView
-              dataset={dataset}
-              tableName={tableName}
-            />
-          </div>
-        );
+        if (!canRenderChart(widgetEditor, datasetProvider)) {
+          visualization = (
+            <div className="visualization">
+              Select a type of chart and columns
+            </div>
+          );
+        } else {
+          visualization = (
+            <div className="visualization">
+              <TableView
+                dataset={dataset}
+                tableName={tableName}
+              />
+            </div>
+          );
+        }
         break;
 
       default:

--- a/components/widgets/editor/chart/ChartEditor.js
+++ b/components/widgets/editor/chart/ChartEditor.js
@@ -3,13 +3,12 @@ import PropTypes from 'prop-types';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { Autobind } from 'es-decorators';
 import { DragDropContext } from 'react-dnd';
-import { toastr } from 'react-redux-toastr';
 
 // Redux
 import { connect } from 'react-redux';
 
 import { toggleModal, setModalOptions } from 'redactions/modal';
-import { setChartType, setAreaIntersection } from 'components/widgets/editor/redux/widgetEditor';
+import { setChartType } from 'components/widgets/editor/redux/widgetEditor';
 
 // Components
 import FilterContainer from 'components/widgets/editor/ui/FilterContainer';
@@ -17,95 +16,13 @@ import DimensionsContainer from 'components/widgets/editor/ui/DimensionsContaine
 import FieldsContainer from 'components/widgets/editor/ui/FieldsContainer';
 import SortContainer from 'components/widgets/editor/ui/SortContainer';
 import LimitContainer from 'components/widgets/editor/ui/LimitContainer';
-import CustomSelect from 'components/widgets/editor/ui/CustomSelect';
 import Select from 'components/widgets/editor/form/SelectInput';
 import SaveWidgetModal from 'components/widgets/editor/modal/SaveWidgetModal';
 import HowToWidgetEditorModal from 'components/widgets/editor/modal/HowToWidgetEditorModal';
-import UploadAreaIntersectionModal from 'components/widgets/editor/modal/UploadAreaIntersectionModal';
-import Spinner from 'components/widgets/editor/ui/Spinner';
-
-// Services
-import AreasService from 'components/widgets/editor/services/AreasService';
-import UserService from 'components/widgets/editor/services/UserService';
-
-const AREAS = [
-  {
-    label: 'Custom area',
-    value: 'custom',
-    items: [
-      {
-        label: 'Upload new area',
-        value: 'upload',
-        as: 'Custom area'
-      }
-    ]
-  }
-];
+import AreaIntersectionFilter from 'components/widgets/editor/ui/AreaIntersectionFilter';
 
 @DragDropContext(HTML5Backend)
 class ChartEditor extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      areaOptions: [],
-      loadingAreaIntersection: false,
-      loadingUserAreas: false
-    };
-
-    // Services
-    this.areasService = new AreasService({ apiURL: process.env.WRI_API_URL });
-    this.userService = new UserService({ apiURL: process.env.WRI_API_URL });
-  }
-
-  /**
-  * COMPONENT LIFECYCLE
-  * - componentDidMount
-  */
-  componentDidMount() {
-    if (this.props.hasGeoInfo) {
-      this.fetchAreas();
-      if (this.props.user.id) { // Only try to load the user areas when an user is logged in
-        this.fetchUserAreas();
-      }
-    }
-  }
-
-  /**
-   * Event handler executed when the selected area
-   * intersection is changed
-   * @param {{ label: string, value: string }} item Option of the selector
-   */
-  @Autobind
-  async onChangeAreaIntersection(item) {
-    return new Promise((resolve) => {
-      // The user unselected the option
-      if (!item) {
-        this.props.setAreaIntersection(null);
-      } else if (item.value === 'upload') {
-        this.props.toggleModal(true, {
-          children: UploadAreaIntersectionModal,
-          childrenProps: {
-            onUploadArea: (id) => {
-              // We close the modal
-              this.props.toggleModal(false, {});
-
-              // We save the ID of the area
-              this.props.setAreaIntersection(id);
-
-              resolve(true);
-            }
-          },
-          onCloseModal: () => resolve(false)
-        });
-      } else {
-        // The user selected a custom area that is not a country
-        this.props.setAreaIntersection(item.id);
-        resolve(true);
-      }
-    });
-  }
-
   @Autobind
   handleChartTypeChange(val) {
     this.props.setChartType(val);
@@ -148,54 +65,6 @@ class ChartEditor extends React.Component {
     this.props.onEmbedTable();
   }
 
-  /**
-   * Fetch the list of the areas for the area intersection
-   * filter
-   */
-  fetchAreas() {
-    this.setState({ loadingAreaIntersection: true });
-
-    // When this resolves, we'll also be able to display the countries
-    this.areasService.fetchCountries()
-      .then((data) => {
-        this.setState({
-          areaOptions: [...this.state.areaOptions, ...AREAS,
-            ...data.map(elem => ({
-              label: elem.name || '',
-              id: elem.geostoreId,
-              value: `country-${elem.geostoreId}`
-            }))]
-        });
-      })
-      // We don't really care if the countries don't load, we can still
-      // let the user use a custom area
-      .catch(err => toastr.error('Error', err))
-      .then(() => this.setState({ loadingAreaIntersection: false }));
-  }
-
-  /**
-   * Fetchs the user areas
-   */
-  fetchUserAreas() {
-    this.setState({ loadingUserAreas: true });
-    this.userService.getUserAreas(this.props.user.token)
-      .then((response) => {
-        const userAreas = response.map(val => ({
-          label: val.attributes.name,
-          id: val.attributes.geostore,
-          value: `user-area-${val.attributes.geostore}`
-        }));
-        this.setState({
-          loadingUserAreas: false,
-          areaOptions: [...this.state.areaOptions, ...userAreas]
-        });
-      })
-      .catch((err) => {
-        this.setState({ loadingUserAreas: false });
-        toastr.error('Error loading user areas', err);
-      });
-  }
-
   render() {
     const {
       dataset,
@@ -211,8 +80,7 @@ class ChartEditor extends React.Component {
       showLimitContainer,
       showOrderByContainer
     } = this.props;
-    const { chartType, fields, category, value, areaIntersection } = widgetEditor;
-    const { areaOptions, loadingAreaIntersection } = this.state;
+    const { chartType, fields, category, value } = widgetEditor;
     const showSaveButtonFlag =
       chartType && category && value && user && user.token && showSaveButton;
     const showUpdateButton = showSaveButtonFlag;
@@ -221,11 +89,6 @@ class ChartEditor extends React.Component {
       && jiminy.general
       && jiminy.general.map(val => ({ label: val, value: val }))
     ) || [];
-
-    const areaToBeSelected = areaIntersection && !loadingAreaIntersection &&
-     areaOptions.find(opt => opt.id === areaIntersection);
-
-    const areaValue = areaToBeSelected && areaToBeSelected.value;
 
     return (
       <div className="c-chart-editor">
@@ -249,24 +112,7 @@ class ChartEditor extends React.Component {
               </div>
             </div>
           }
-          {hasGeoInfo &&
-            <div className="area-intersection">
-              <div className="c-field">
-                <label htmlFor="area-intersection-select">
-                  Area intersection { loadingAreaIntersection && <Spinner isLoading className="-light -small -inline" /> }
-                </label>
-                <CustomSelect
-                  id="area-intersection-select"
-                  placeholder="Select area"
-                  options={areaOptions}
-                  value={areaValue}
-                  onValueChange={this.onChangeAreaIntersection}
-                  allowNonLeafSelection={false}
-                  waitForChangeConfirmation
-                />
-              </div>
-            </div>
-          }
+          { hasGeoInfo && <AreaIntersectionFilter /> }
         </div>
         <p>Drag and drop elements from the list to the boxes:</p>
         <div className="actions-div">
@@ -359,7 +205,6 @@ ChartEditor.propTypes = {
   setChartType: PropTypes.func.isRequired,
   toggleModal: PropTypes.func.isRequired,
   setModalOptions: PropTypes.func.isRequired,
-  setAreaIntersection: PropTypes.func.isRequired,
   // Callback
   onUpdateWidget: PropTypes.func,
   onEmbedTable: PropTypes.func
@@ -371,8 +216,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(setChartType(type));
   },
   toggleModal: (open, opts) => { dispatch(toggleModal(open, opts)); },
-  setModalOptions: (options) => { dispatch(setModalOptions(options)); },
-  setAreaIntersection: id => dispatch(setAreaIntersection(id))
+  setModalOptions: (options) => { dispatch(setModalOptions(options)); }
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ChartEditor);

--- a/components/widgets/editor/helpers/WidgetHelper.js
+++ b/components/widgets/editor/helpers/WidgetHelper.js
@@ -110,10 +110,19 @@ export function getChartType(type) {
  * state of the WidgetEditor in the store
  * @export
  * @param {object} widgetEditor - Store's state of the WidgetEditor
+ * @param {string} datasetProvider - Provider of the dataset
  * @returns {boolean}
  */
-export function canRenderChart(widgetEditor) {
-  const { visualizationType, category, value, chartType, band, layer } = widgetEditor;
+export function canRenderChart(widgetEditor, datasetProvider) {
+  const {
+    visualizationType,
+    category,
+    value,
+    chartType,
+    band,
+    layer,
+    areaIntersection
+  } = widgetEditor;
 
   const chart = visualizationType === 'chart'
     && !!(chartType
@@ -126,14 +135,17 @@ export function canRenderChart(widgetEditor) {
         )
         || !isBidimensionalChart(widgetEditor.chartType)
       )
+      && (datasetProvider !== 'nexgddp' || areaIntersection)
     );
 
   const rasterChart = visualizationType === 'raster_chart' && !!band;
 
   const map = visualizationType === 'map' && !!layer;
 
+  const table = visualizationType === 'table' && (datasetProvider !== 'nexgddp' || areaIntersection);
+
   // Standard chart
-  return chart || rasterChart || map;
+  return chart || rasterChart || map || table;
 }
 
 /**

--- a/components/widgets/editor/helpers/WidgetHelper.js
+++ b/components/widgets/editor/helpers/WidgetHelper.js
@@ -147,7 +147,7 @@ export function canRenderChart(widgetEditor) {
  */
 export function getChartInfo(dataset, datasetType, datasetProvider, widgetEditor) {
   // If the dataset is a raster one, the chart info is always the same
-  if (datasetType === 'raster') return RasterService.getChartInfo();
+  if (datasetType === 'raster') return RasterService.getChartInfo(widgetEditor);
 
   const {
     chartType,
@@ -217,9 +217,10 @@ export function getChartInfo(dataset, datasetType, datasetProvider, widgetEditor
  * @param {{ name: string, type: string, alias: string, description: string }} band
  * Band (in case of a raster dataset)
  * @param {string} provider - Name of the provider
+ * @param {ChartInfo} chartInfo
  * @return {string}
  */
-export async function getRasterDataURL(dataset, datasetType, tableName, band, provider) {
+export async function getRasterDataURL(dataset, datasetType, tableName, band, provider, chartInfo) {
   const bandType = band.type || 'categorical';
 
   let query;
@@ -237,7 +238,9 @@ export async function getRasterDataURL(dataset, datasetType, tableName, band, pr
     }
   }
 
-  return `${process.env.WRI_API_URL}/query/${dataset}?sql=${query}`;
+  const geostore = chartInfo.areaIntersection ? `&geostore=${chartInfo.areaIntersection}` : '';
+
+  return `${process.env.WRI_API_URL}/query/${dataset}?sql=${query}${geostore}`;
 }
 
 /**
@@ -258,7 +261,7 @@ export async function getDataURL(dataset, datasetType, tableName, band, provider
   // If the dataset is a raster one, the behaviour is totally different
   if (datasetType === 'raster') {
     if (!band) return '';
-    return await getRasterDataURL(dataset, datasetType, tableName, band, provider);
+    return getRasterDataURL(dataset, datasetType, tableName, band, provider, chartInfo);
   }
 
   let isBidimensional = false;

--- a/components/widgets/editor/nexgddp/NEXGDDPEditor.js
+++ b/components/widgets/editor/nexgddp/NEXGDDPEditor.js
@@ -21,6 +21,8 @@ import SaveWidgetModal from 'components/widgets/editor/modal/SaveWidgetModal';
 import HowToWidgetEditorModal from 'components/widgets/editor/modal/HowToWidgetEditorModal';
 import AreaIntersectionFilter from 'components/widgets/editor/ui/AreaIntersectionFilter';
 
+// NOTE: if you change this array, also update
+// the condition of the variable showRequiredTooltip
 const CHARTS = ['line', 'bar'];
 
 @DragDropContext(HTML5Backend)
@@ -82,7 +84,13 @@ class NEXGDDPEditor extends React.Component {
       showLimitContainer,
       showOrderByContainer
     } = this.props;
-    const { chartType, fields, category, value } = widgetEditor;
+    const {
+      chartType,
+      fields,
+      category,
+      value,
+      areaIntersection
+    } = widgetEditor;
     const showSaveButtonFlag =
       chartType && category && value && user && user.token && showSaveButton;
     const showUpdateButton = showSaveButtonFlag;
@@ -118,31 +126,36 @@ class NEXGDDPEditor extends React.Component {
               </div>
             </div>
           }
-          { hasGeoInfo && <AreaIntersectionFilter /> }
+          { hasGeoInfo
+              && <AreaIntersectionFilter required /> }
         </div>
-        <p>Drag and drop elements from the list to the boxes:</p>
-        <div className="actions-div">
-          {fields &&
-            <FieldsContainer
-              dataset={dataset}
-              tableName={tableName}
-              fields={fields}
-            />
-          }
-          <div className="arrow-container">
-            <img alt="" src="/static/images/components/widgets/Arrow.svg" />
-          </div>
-          <div className="customization-container">
-            <DimensionsContainer />
-            <FilterContainer />
-            {showOrderByContainer &&
-              <SortContainer />
+        { !areaIntersection
+            && <p>Please select both a chart style and an area intersection to proceed.</p> }
+        { areaIntersection && <p>Drag and drop elements from the list to the boxes:</p> }
+        { areaIntersection && (
+          <div className="actions-div">
+            {fields &&
+              <FieldsContainer
+                dataset={dataset}
+                tableName={tableName}
+                fields={fields}
+              />
             }
-            {showLimitContainer &&
-              <LimitContainer />
-            }
+            <div className="arrow-container">
+              <img alt="" src="/static/images/components/widgets/Arrow.svg" />
+            </div>
+            <div className="customization-container">
+              <DimensionsContainer />
+              <FilterContainer />
+              {showOrderByContainer &&
+                <SortContainer />
+              }
+              {showLimitContainer &&
+                <LimitContainer />
+              }
+            </div>
           </div>
-        </div>
+        ) }
         <div className="save-widget-container">
           <button
             type="button"
@@ -171,7 +184,7 @@ class NEXGDDPEditor extends React.Component {
             Save widget
           </a>
           }
-          {tableViewMode && showEmbedTable &&
+          {tableViewMode && showEmbedTable && areaIntersection &&
             <a
               role="button"
               className="c-button -primary"

--- a/components/widgets/editor/nexgddp/NEXGDDPEditor.js
+++ b/components/widgets/editor/nexgddp/NEXGDDPEditor.js
@@ -3,13 +3,12 @@ import PropTypes from 'prop-types';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { Autobind } from 'es-decorators';
 import { DragDropContext } from 'react-dnd';
-import { toastr } from 'react-redux-toastr';
 
 // Redux
 import { connect } from 'react-redux';
 
 import { toggleModal, setModalOptions } from 'redactions/modal';
-import { setChartType, setAreaIntersection } from 'components/widgets/editor/redux/widgetEditor';
+import { setChartType } from 'components/widgets/editor/redux/widgetEditor';
 
 // Components
 import FilterContainer from 'components/widgets/editor/ui/FilterContainer';
@@ -17,97 +16,15 @@ import DimensionsContainer from 'components/widgets/editor/ui/DimensionsContaine
 import FieldsContainer from 'components/widgets/editor/ui/FieldsContainer';
 import SortContainer from 'components/widgets/editor/ui/SortContainer';
 import LimitContainer from 'components/widgets/editor/ui/LimitContainer';
-import CustomSelect from 'components/widgets/editor/ui/CustomSelect';
 import Select from 'components/widgets/editor/form/SelectInput';
 import SaveWidgetModal from 'components/widgets/editor/modal/SaveWidgetModal';
 import HowToWidgetEditorModal from 'components/widgets/editor/modal/HowToWidgetEditorModal';
-import UploadAreaIntersectionModal from 'components/widgets/editor/modal/UploadAreaIntersectionModal';
-import Spinner from 'components/widgets/editor/ui/Spinner';
-
-// Services
-import AreasService from 'components/widgets/editor/services/AreasService';
-import UserService from 'components/widgets/editor/services/UserService';
-
-const AREAS = [
-  {
-    label: 'Custom area',
-    value: 'custom',
-    items: [
-      {
-        label: 'Upload new area',
-        value: 'upload',
-        as: 'Custom area'
-      }
-    ]
-  }
-];
+import AreaIntersectionFilter from 'components/widgets/editor/ui/AreaIntersectionFilter';
 
 const CHARTS = ['line', 'bar'];
 
 @DragDropContext(HTML5Backend)
 class NEXGDDPEditor extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      areaOptions: [],
-      loadingAreaIntersection: false,
-      loadingUserAreas: false
-    };
-
-    // Services
-    this.areasService = new AreasService({ apiURL: process.env.WRI_API_URL });
-    this.userService = new UserService({ apiURL: process.env.WRI_API_URL });
-  }
-
-  /**
-  * COMPONENT LIFECYCLE
-  * - componentDidMount
-  */
-  componentDidMount() {
-    if (this.props.hasGeoInfo) {
-      this.fetchAreas();
-      if (this.props.user.id) { // Only try to load the user areas when an user is logged in
-        this.fetchUserAreas();
-      }
-    }
-  }
-
-  /**
-   * Event handler executed when the selected area
-   * intersection is changed
-   * @param {{ label: string, value: string }} item Option of the selector
-   */
-  @Autobind
-  async onChangeAreaIntersection(item) {
-    return new Promise((resolve) => {
-      // The user unselected the option
-      if (!item) {
-        this.props.setAreaIntersection(null);
-      } else if (item.value === 'upload') {
-        this.props.toggleModal(true, {
-          children: UploadAreaIntersectionModal,
-          childrenProps: {
-            onUploadArea: (id) => {
-              // We close the modal
-              this.props.toggleModal(false, {});
-
-              // We save the ID of the area
-              this.props.setAreaIntersection(id);
-
-              resolve(true);
-            }
-          },
-          onCloseModal: () => resolve(false)
-        });
-      } else {
-        // The user selected a custom area that is not a country
-        this.props.setAreaIntersection(item.id);
-        resolve(true);
-      }
-    });
-  }
-
   @Autobind
   handleChartTypeChange(val) {
     this.props.setChartType(val);
@@ -150,54 +67,6 @@ class NEXGDDPEditor extends React.Component {
     this.props.onEmbedTable();
   }
 
-  /**
-   * Fetch the list of the areas for the area intersection
-   * filter
-  */
-  fetchAreas() {
-    this.setState({ loadingAreaIntersection: true });
-
-    // When this resolves, we'll also be able to display the countries
-    this.areasService.fetchCountries()
-      .then((data) => {
-        this.setState({
-          areaOptions: [...this.state.areaOptions, ...AREAS,
-            ...data.map(elem => ({
-              label: elem.name || '',
-              id: elem.geostoreId,
-              value: `country-${elem.geostoreId}`
-            }))]
-        });
-      })
-      // We don't really care if the countries don't load, we can still
-      // let the user use a custom area
-      .catch(err => toastr.error('Error', err))
-      .then(() => this.setState({ loadingAreaIntersection: false }));
-  }
-
-  /**
-   * Fetchs the user areas
-   */
-  fetchUserAreas() {
-    this.setState({ loadingUserAreas: true });
-    this.userService.getUserAreas(this.props.user.token)
-      .then((response) => {
-        const userAreas = response.map(val => ({
-          label: val.attributes.name,
-          id: val.attributes.geostore,
-          value: `user-area-${val.attributes.geostore}`
-        }));
-        this.setState({
-          loadingUserAreas: false,
-          areaOptions: [...this.state.areaOptions, ...userAreas]
-        });
-      })
-      .catch((err) => {
-        this.setState({ loadingUserAreas: false });
-        toastr.error('Error loading user areas', err);
-      });
-  }
-
   render() {
     const {
       dataset,
@@ -213,8 +82,7 @@ class NEXGDDPEditor extends React.Component {
       showLimitContainer,
       showOrderByContainer
     } = this.props;
-    const { chartType, fields, category, value, areaIntersection } = widgetEditor;
-    const { areaOptions, loadingAreaIntersection } = this.state;
+    const { chartType, fields, category, value } = widgetEditor;
     const showSaveButtonFlag =
       chartType && category && value && user && user.token && showSaveButton;
     const showUpdateButton = showSaveButtonFlag;
@@ -227,11 +95,6 @@ class NEXGDDPEditor extends React.Component {
       && jiminy.general.map(val => ({ label: val, value: val }))
         .filter(c => CHARTS.includes(c.value))
     ) || [];
-
-    const areaToBeSelected = areaIntersection && !loadingAreaIntersection &&
-     areaOptions.find(opt => opt.id === areaIntersection);
-
-    const areaValue = areaToBeSelected && areaToBeSelected.value;
 
     return (
       <div className="c-chart-editor">
@@ -255,24 +118,7 @@ class NEXGDDPEditor extends React.Component {
               </div>
             </div>
           }
-          {hasGeoInfo &&
-            <div className="area-intersection">
-              <div className="c-field">
-                <label htmlFor="area-intersection-select">
-                  Area intersection { loadingAreaIntersection && <Spinner isLoading className="-light -small -inline" /> }
-                </label>
-                <CustomSelect
-                  id="area-intersection-select"
-                  placeholder="Select area"
-                  options={areaOptions}
-                  value={areaValue}
-                  onValueChange={this.onChangeAreaIntersection}
-                  allowNonLeafSelection={false}
-                  waitForChangeConfirmation
-                />
-              </div>
-            </div>
-          }
+          { hasGeoInfo && <AreaIntersectionFilter /> }
         </div>
         <p>Drag and drop elements from the list to the boxes:</p>
         <div className="actions-div">
@@ -365,7 +211,6 @@ NEXGDDPEditor.propTypes = {
   setChartType: PropTypes.func.isRequired,
   toggleModal: PropTypes.func.isRequired,
   setModalOptions: PropTypes.func.isRequired,
-  setAreaIntersection: PropTypes.func.isRequired,
   // Callback
   onUpdateWidget: PropTypes.func,
   onEmbedTable: PropTypes.func
@@ -377,8 +222,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(setChartType(type));
   },
   toggleModal: (open, opts) => { dispatch(toggleModal(open, opts)); },
-  setModalOptions: (options) => { dispatch(setModalOptions(options)); },
-  setAreaIntersection: id => dispatch(setAreaIntersection(id))
+  setModalOptions: (options) => { dispatch(setModalOptions(options)); }
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NEXGDDPEditor);

--- a/components/widgets/editor/raster/RasterChartEditor.js
+++ b/components/widgets/editor/raster/RasterChartEditor.js
@@ -14,6 +14,7 @@ import { toggleModal } from 'redactions/modal';
 import Select from 'components/widgets/editor/form/SelectInput';
 import Spinner from 'components/widgets/editor/ui/Spinner';
 import SaveWidgetModal from 'components/widgets/editor/modal/SaveWidgetModal';
+import AreaIntersectionFilter from 'components/widgets/editor/ui/AreaIntersectionFilter';
 
 // Services
 import RasterService from 'components/widgets/editor/services/RasterService';
@@ -140,11 +141,12 @@ class RasterChartEditor extends React.Component {
 
   render() {
     const { loading, bands, error, bandStatsInfo, bandStatsInfoLoading } = this.state;
-    const { band, mode, showSaveButton } = this.props;
+    const { band, mode, showSaveButton, hasGeoInfo } = this.props;
 
     return (
       <div className="c-raster-chart-editor">
         <div className="content">
+          { hasGeoInfo && <AreaIntersectionFilter /> }
           <h5>Bands { loading && <Spinner isLoading className="-light -small -inline" /> }</h5>
           { error && <div className="error"><span>Error:</span> {error}</div> }
           { !error && (
@@ -210,6 +212,7 @@ class RasterChartEditor extends React.Component {
 RasterChartEditor.propTypes = {
   dataset: PropTypes.string.isRequired,
   tableName: PropTypes.string.isRequired,
+  hasGeoInfo: PropTypes.bool.isRequired,
   title: PropTypes.string, // Default title when saving the widget
   provider: PropTypes.string.isRequired,
   mode: PropTypes.oneOf(['save', 'update']),

--- a/components/widgets/editor/services/RasterService.js
+++ b/components/widgets/editor/services/RasterService.js
@@ -89,15 +89,18 @@ export default class RasterService {
   /**
    * Return the ChartInfo object for a raster chart
    * @static
+   * @param {object} widgetEditor - Store object
    * @returns {ChartInfo}
    */
-  static getChartInfo() {
+  static getChartInfo(widgetEditor) {
+    const { areaIntersection } = widgetEditor;
+
     return {
       chartType: 'bar',
       limit: 500,
       order: null,
       filters: [],
-      areaIntersection: null,
+      areaIntersection,
       x: {
         type: null,
         name: 'x',

--- a/components/widgets/editor/ui/AreaIntersectionFilter.js
+++ b/components/widgets/editor/ui/AreaIntersectionFilter.js
@@ -1,0 +1,181 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { toastr } from 'react-redux-toastr';
+import { Autobind } from 'es-decorators';
+
+// Components
+import CustomSelect from 'components/widgets/editor/ui/CustomSelect';
+import Spinner from 'components/widgets/editor/ui/Spinner';
+import UploadAreaIntersectionModal from 'components/widgets/editor/modal/UploadAreaIntersectionModal';
+
+// Redux
+import { toggleModal } from 'redactions/modal';
+import { setAreaIntersection } from 'components/widgets/editor/redux/widgetEditor';
+
+// Services
+import AreasService from 'components/widgets/editor/services/AreasService';
+import UserService from 'components/widgets/editor/services/UserService';
+
+const AREAS = [
+  {
+    label: 'Custom area',
+    value: 'custom',
+    items: [
+      {
+        label: 'Upload new area',
+        value: 'upload',
+        as: 'Custom area'
+      }
+    ]
+  }
+];
+
+class AreaIntersectionFilter extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      areaOptions: [],
+      loading: true
+    };
+
+    // Services
+    this.areasService = new AreasService({ apiURL: process.env.WRI_API_URL });
+    this.userService = new UserService({ apiURL: process.env.WRI_API_URL });
+  }
+
+  componentDidMount() {
+    let error = false;
+
+    this.fetchAreas()
+      .catch(() => { error = true; })
+      .then(() => (this.props.user.id ? this.fetchUserAreas() : null))
+      .catch(() => { error = true; })
+      .then(() => this.setState({ loading: false }))
+      .then(() => {
+        if (error) {
+          toastr.error('Area intersection', 'Some of the options of the "Area intersection" filter failed to load. You might want to reload the page to try to load them again.');
+        }
+      });
+  }
+
+  /**
+   * Callback handler executed when the selected area
+   * intersection is changed
+   * @param {{ label: string, value: string }} item Option of the selector
+   * @return {Promise<boolean>}
+   */
+  @Autobind
+  async onChangeAreaIntersection(item) {
+    return new Promise((resolve) => {
+      // The user unselected the option
+      if (!item) {
+        this.props.setAreaIntersection(null);
+      } else if (item.value === 'upload') {
+        this.props.toggleModal(true, {
+          children: UploadAreaIntersectionModal,
+          childrenProps: {
+            onUploadArea: (id) => {
+              // We close the modal
+              this.props.toggleModal(false, {});
+
+              // We save the ID of the area
+              this.props.setAreaIntersection(id);
+
+              resolve(true);
+            }
+          },
+          onCloseModal: () => resolve(false)
+        });
+      } else {
+        // The user selected a custom area that is not a country
+        this.props.setAreaIntersection(item.id);
+        resolve(true);
+      }
+    });
+  }
+
+  /**
+   * Fetch the list of the areas for the area intersection
+   * filter
+  */
+  fetchAreas() {
+    return this.areasService.fetchCountries()
+      .then((data) => {
+        this.setState({
+          areaOptions: [...this.state.areaOptions, ...AREAS,
+            ...data.map(elem => ({
+              label: elem.name || '',
+              id: elem.geostoreId,
+              value: `country-${elem.geostoreId}`
+            }))]
+        });
+      });
+  }
+
+  /**
+   * Fetch the areas of the logged user
+   */
+  fetchUserAreas() {
+    return this.userService.getUserAreas(this.props.user.token)
+      .then((response) => {
+        const userAreas = response.map(val => ({
+          label: val.attributes.name,
+          id: val.attributes.geostore,
+          value: `user-area-${val.attributes.geostore}`
+        }));
+        this.setState({
+          loadingUserAreas: false,
+          areaOptions: [...this.state.areaOptions, ...userAreas]
+        });
+      });
+  }
+
+  render() {
+    const { widgetEditor } = this.props;
+    const { loading, areaOptions } = this.state;
+    const { areaIntersection } = widgetEditor;
+
+    // We retrieve the selected option
+    let selectedArea = areaIntersection && !loading
+      && areaOptions.find(opt => opt.id === areaIntersection);
+    selectedArea = selectedArea && selectedArea.value;
+
+    return (
+      <div className="area-intersection">
+        <div className="c-field">
+          <label htmlFor="area-intersection-select">
+            Area intersection { loading && <Spinner isLoading className="-light -small -inline" /> }
+          </label>
+          <CustomSelect
+            id="area-intersection-select"
+            placeholder="Select area"
+            options={areaOptions}
+            value={selectedArea}
+            onValueChange={this.onChangeAreaIntersection}
+            allowNonLeafSelection={false}
+            waitForChangeConfirmation
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+AreaIntersectionFilter.propTypes = {
+  // Store
+  widgetEditor: PropTypes.object.isRequired,
+  user: PropTypes.object.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+  setAreaIntersection: PropTypes.func.isRequired
+};
+
+const mapStateToProps = ({ widgetEditor, user }) => ({ widgetEditor, user });
+
+const mapDispatchToProps = dispatch => ({
+  toggleModal: (open, opts) => { dispatch(toggleModal(open, opts)); },
+  setAreaIntersection: id => dispatch(setAreaIntersection(id))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(AreaIntersectionFilter);

--- a/components/widgets/editor/ui/AreaIntersectionFilter.js
+++ b/components/widgets/editor/ui/AreaIntersectionFilter.js
@@ -133,7 +133,7 @@ class AreaIntersectionFilter extends React.Component {
   }
 
   render() {
-    const { widgetEditor } = this.props;
+    const { widgetEditor, required } = this.props;
     const { loading, areaOptions } = this.state;
     const { areaIntersection } = widgetEditor;
 
@@ -144,9 +144,9 @@ class AreaIntersectionFilter extends React.Component {
 
     return (
       <div className="area-intersection">
-        <div className="c-field">
+        <div className="c-field" ref={(node) => { this.el = node; }}>
           <label htmlFor="area-intersection-select">
-            Area intersection { loading && <Spinner isLoading className="-light -small -inline" /> }
+            Area intersection { required ? '*' : '' } { loading && <Spinner isLoading className="-light -small -inline" /> }
           </label>
           <CustomSelect
             id="area-intersection-select"
@@ -163,7 +163,14 @@ class AreaIntersectionFilter extends React.Component {
   }
 }
 
+AreaIntersectionFilter.defaultProps = {
+  required: false,
+  showRequiredTooltip: false
+};
+
 AreaIntersectionFilter.propTypes = {
+  // Add a visual clue the field is mandatory
+  required: PropTypes.bool,
   // Store
   widgetEditor: PropTypes.object.isRequired,
   user: PropTypes.object.isRequired,

--- a/components/widgets/editor/ui/SliderSelect.js
+++ b/components/widgets/editor/ui/SliderSelect.js
@@ -63,6 +63,15 @@ export default class SliderSelect extends React.Component {
         pathToCurrentItemsList: [],
         pathToSelectedItem: []
       });
+    } else if (newProps.value !== this.props.value) {
+      // If the value of the select is changed via the props, we update
+      // the select item in the component
+      const selectedItem = this.props.options
+        && this.props.options.find(item => item.value === newProps.value);
+
+      if (selectedItem) {
+        this.setState({ selectedItem });
+      }
     }
   }
 

--- a/services/RasterService.js
+++ b/services/RasterService.js
@@ -89,15 +89,18 @@ export default class RasterService {
   /**
    * Return the ChartInfo object for a raster chart
    * @static
+   * @param {object} widgetEditor - Store object
    * @returns {ChartInfo}
    */
-  static getChartInfo() {
+  static getChartInfo(widgetEditor) {
+    const { areaIntersection } = widgetEditor;
+
     return {
       chartType: 'bar',
       limit: 500,
       order: null,
       filters: [],
-      areaIntersection: null,
+      areaIntersection,
       x: {
         type: null,
         name: 'x',

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -109,10 +109,19 @@ export function getChartType(type) {
  * state of the WidgetEditor in the store
  * @export
  * @param {object} widgetEditor - Store's state of the WidgetEditor
+ * @param {string} datasetProvider - Provider of the dataset
  * @returns {boolean}
  */
-export function canRenderChart(widgetEditor) {
-  const { visualizationType, category, value, chartType, band, layer } = widgetEditor;
+export function canRenderChart(widgetEditor, datasetProvider) {
+  const {
+    visualizationType,
+    category,
+    value,
+    chartType,
+    band,
+    layer,
+    areaIntersection
+  } = widgetEditor;
 
   const chart = visualizationType === 'chart'
     && !!(chartType
@@ -125,14 +134,17 @@ export function canRenderChart(widgetEditor) {
         )
         || !isBidimensionalChart(widgetEditor.chartType)
       )
+      && (datasetProvider !== 'nexgddp' || areaIntersection)
     );
 
   const rasterChart = visualizationType === 'raster_chart' && !!band;
 
   const map = visualizationType === 'map' && !!layer;
 
+  const table = visualizationType === 'table' && (datasetProvider !== 'nexgddp' || areaIntersection);
+
   // Standard chart
-  return chart || rasterChart || map;
+  return chart || rasterChart || map || table;
 }
 
 /**

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -1,6 +1,5 @@
 import 'isomorphic-fetch';
 import { format } from 'd3';
-import { toastr } from 'react-redux-toastr';
 
 // Components
 import BarChart from 'utils/widgets/bar';
@@ -147,7 +146,7 @@ export function canRenderChart(widgetEditor) {
  */
 export function getChartInfo(dataset, datasetType, datasetProvider, widgetEditor) {
   // If the dataset is a raster one, the chart info is always the same
-  if (datasetType === 'raster') return RasterService.getChartInfo();
+  if (datasetType === 'raster') return RasterService.getChartInfo(widgetEditor);
 
   const {
     chartType,
@@ -217,9 +216,10 @@ export function getChartInfo(dataset, datasetType, datasetProvider, widgetEditor
  * @param {{ name: string, type: string, alias: string, description: string }} band
  * Band (in case of a raster dataset)
  * @param {string} provider - Name of the provider
+ * @param {ChartInfo} chartInfo
  * @return {string}
  */
-export async function getRasterDataURL(dataset, datasetType, tableName, band, provider) {
+export async function getRasterDataURL(dataset, datasetType, tableName, band, provider, chartInfo) {
   const bandType = band.type || 'categorical';
 
   let query;
@@ -237,7 +237,9 @@ export async function getRasterDataURL(dataset, datasetType, tableName, band, pr
     }
   }
 
-  return `${process.env.WRI_API_URL}/query/${dataset}?sql=${query}`;
+  const geostore = chartInfo.areaIntersection ? `&geostore=${chartInfo.areaIntersection}` : '';
+
+  return `${process.env.WRI_API_URL}/query/${dataset}?sql=${query}${geostore}`;
 }
 
 /**
@@ -258,7 +260,7 @@ export async function getDataURL(dataset, datasetType, tableName, band, provider
   // If the dataset is a raster one, the behaviour is totally different
   if (datasetType === 'raster') {
     if (!band) return '';
-    return await getRasterDataURL(dataset, datasetType, tableName, band, provider);
+    return getRasterDataURL(dataset, datasetType, tableName, band, provider, chartInfo);
   }
 
   let isBidimensional = false;


### PR DESCRIPTION
This PR makes changes to the area intersection filter of the widget editor:
* the component is now decoupled from each individual editor (standard, nexgddp, etc.)
* the component has been added to the editor of the raster datasets
* the user must use it to render a chart or the table of a nexgddp dataset
* an issue has been fixed where, in certain cases, the filter wouldn't be restored

You can try to use it with this raster dataset (`8ecf07f5-3cae-4275-adfe-918d04439a1a`) or this nexgddp one (`5e11f2ae-77e8-4f1a-bd28-ad9e4ec97f01`).