### PR TITLE
Editor: sync the title of the chart with the widget's name

### DIFF
--- a/components/admin/widget/form/steps/Step2.js
+++ b/components/admin/widget/form/steps/Step2.js
@@ -8,11 +8,15 @@ import Textarea from 'components/form/TextArea';
 import Checkbox from 'components/form/Checkbox';
 import WidgetEditor from 'components/widgets/editor/WidgetEditor';
 
+// Redux
+import { connect } from 'react-redux';
+import { setTitle } from 'components/widgets/editor/redux/widgetEditor';
+
 import { FORM_ELEMENTS } from 'components/admin/widget/form/constants';
 
 class Step2 extends React.Component {
   render() {
-    const { dataset } = this.props;
+    const { dataset, widgetEditor } = this.props;
 
     return (
       <fieldset className="c-field-container">
@@ -35,14 +39,15 @@ class Step2 extends React.Component {
 
         <Field
           ref={(c) => { if (c) FORM_ELEMENTS.elements.name = c; }}
-          onChange={value => this.props.onChange({ name: value })}
+          onChange={value => this.props.setTitle(value)}
           validations={['required']}
           properties={{
             name: 'name',
             label: 'Title',
             type: 'text',
-            required: true,
-            default: this.props.form.name
+            default: widgetEditor.title || '',
+            value: widgetEditor.title || '',
+            required: true
           }}
         >
           {Input}
@@ -146,7 +151,18 @@ class Step2 extends React.Component {
 Step2.propTypes = {
   form: PropTypes.object,
   dataset: PropTypes.string.isRequired,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  // REDUX
+  widgetEditor: PropTypes.object,
+  setTitle: PropTypes.func
 };
 
-export default Step2;
+const mapStateToProps = state => ({
+  widgetEditor: state.widgetEditor
+});
+
+const mapDispatchToProps = dispatch => ({
+  setTitle: title => dispatch(setTitle(title))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Step2);

--- a/components/admin/widget/form/steps/Step2.js
+++ b/components/admin/widget/form/steps/Step2.js
@@ -8,15 +8,11 @@ import Textarea from 'components/form/TextArea';
 import Checkbox from 'components/form/Checkbox';
 import WidgetEditor from 'components/widgets/editor/WidgetEditor';
 
-// Redux
-import { connect } from 'react-redux';
-import { setTitle } from 'components/widgets/editor/redux/widgetEditor';
-
 import { FORM_ELEMENTS } from 'components/admin/widget/form/constants';
 
 class Step2 extends React.Component {
   render() {
-    const { dataset, widgetEditor } = this.props;
+    const { dataset } = this.props;
 
     return (
       <fieldset className="c-field-container">
@@ -39,15 +35,14 @@ class Step2 extends React.Component {
 
         <Field
           ref={(c) => { if (c) FORM_ELEMENTS.elements.name = c; }}
-          onChange={value => this.props.setTitle(value)}
+          onChange={value => this.props.onChange({ name: value })}
           validations={['required']}
           properties={{
             name: 'name',
             label: 'Title',
             type: 'text',
-            default: widgetEditor.title || '',
-            value: widgetEditor.title || '',
-            required: true
+            required: true,
+            default: this.props.form.name
           }}
         >
           {Input}
@@ -151,18 +146,7 @@ class Step2 extends React.Component {
 Step2.propTypes = {
   form: PropTypes.object,
   dataset: PropTypes.string.isRequired,
-  onChange: PropTypes.func,
-  // REDUX
-  widgetEditor: PropTypes.object,
-  setTitle: PropTypes.func
+  onChange: PropTypes.func
 };
 
-const mapStateToProps = state => ({
-  widgetEditor: state.widgetEditor
-});
-
-const mapDispatchToProps = dispatch => ({
-  setTitle: title => dispatch(setTitle(title))
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(Step2);
+export default Step2;

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -24,7 +24,8 @@ import {
   setChartType,
   setBand,
   setVisualizationType,
-  setLayer
+  setLayer,
+  setTitle
 } from 'components/widgets/editor/redux/widgetEditor';
 
 // Constants
@@ -111,8 +112,22 @@ class WidgetsForm extends React.Component {
   onSubmit(event) {
     const { submitting, stepLength, step, form, mode } = this.state;
     const { widgetEditor } = this.props;
-    const { limit, value, category, color, size, orderBy, aggregateFunction,
-      chartType, filters, areaIntersection, visualizationType, band, layer } = widgetEditor;
+    const {
+      limit,
+      value,
+      category,
+      color,
+      size,
+      orderBy,
+      aggregateFunction,
+      chartType,
+      filters,
+      areaIntersection,
+      visualizationType,
+      band,
+      layer,
+      title
+    } = widgetEditor;
 
     event.preventDefault();
 
@@ -124,7 +139,6 @@ class WidgetsForm extends React.Component {
       // Validate all the inputs on the current step
       const validWidgetConfig = (mode === 'editor') ? this.validateWidgetConfig() : true;
       const valid = FORM_ELEMENTS.isValid(step) && validWidgetConfig;
-
       if (valid) {
         // if we are in the last step we will submit the form
         if (step === stepLength && !submitting) {
@@ -133,7 +147,9 @@ class WidgetsForm extends React.Component {
           // Start the submitting
           this.setState({ submitting: true });
 
-          let formObj = form;
+          // The name of the widget is the title property of the
+          // widgetEditor reducer
+          let formObj = Object.assign({}, form, { name: title || '' });
 
           if (mode === 'editor') {
             const newWidgetConfig = {
@@ -264,7 +280,6 @@ class WidgetsForm extends React.Component {
     }
   }
 
-
   loadWidgetIntoRedux() {
     const { paramsConfig } = this.state.form.widgetConfig;
     if (paramsConfig) {
@@ -299,6 +314,7 @@ class WidgetsForm extends React.Component {
       if (filters) this.props.setFilters(filters);
       if (limit) this.props.setLimit(limit);
       if (chartType) this.props.setChartType(chartType);
+      if (this.state.form.name) this.props.setTitle(this.state.form.name);
     }
   }
 
@@ -364,7 +380,8 @@ WidgetsForm.propTypes = {
   setChartType: PropTypes.func.isRequired,
   setVisualizationType: PropTypes.func.isRequired,
   setBand: PropTypes.func.isRequired,
-  setLayer: PropTypes.func.isRequired
+  setLayer: PropTypes.func.isRequired,
+  setTitle: PropTypes.func.isRequired
 };
 
 const mapDispatchToProps = dispatch => ({
@@ -379,6 +396,7 @@ const mapDispatchToProps = dispatch => ({
   setChartType: value => dispatch(setChartType(value)),
   setVisualizationType: vis => dispatch(setVisualizationType(vis)),
   setBand: band => dispatch(setBand(band)),
+  setTitle: title => dispatch(setTitle(title)),
   setLayer: (layerId) => {
     new LayersService()
       .fetchData({ id: layerId })

--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -7,6 +7,10 @@ import { toastr } from 'react-redux-toastr';
 // Constants
 import { FORM_ELEMENTS, CONFIG_TEMPLATE, CONFIG_TEMPLATE_OPTIONS } from 'components/admin/widgets/form/constants';
 
+// Redux
+import { connect } from 'react-redux';
+import { setTitle } from 'components/widgets/editor/redux/widgetEditor';
+
 // Components
 import Field from 'components/form/Field';
 import Input from 'components/form/Input';
@@ -62,6 +66,8 @@ class Step1 extends React.Component {
 
   render() {
     const { id } = this.state;
+    const { widgetEditor } = this.props;
+
     // Reset FORM_ELEMENTS
     FORM_ELEMENTS.elements = {};
 
@@ -98,7 +104,7 @@ class Step1 extends React.Component {
           {/* NAME */}
           <Field
             ref={(c) => { if (c) FORM_ELEMENTS.elements.name = c; }}
-            onChange={value => this.props.onChange({ name: value })}
+            onChange={value => this.props.setTitle(value)}
             validations={['required']}
             className="-fluid"
             properties={{
@@ -106,7 +112,8 @@ class Step1 extends React.Component {
               label: 'Name',
               type: 'text',
               required: true,
-              default: this.state.form.name
+              default: widgetEditor.title || '',
+              value: widgetEditor.title || ''
             }}
           >
             {Input}
@@ -250,7 +257,18 @@ Step1.propTypes = {
   mode: PropTypes.string,
   datasets: PropTypes.array,
   onChange: PropTypes.func,
-  onModeChange: PropTypes.func
+  onModeChange: PropTypes.func,
+  // REDUX
+  widgetEditor: PropTypes.object,
+  setTitle: PropTypes.func
 };
 
-export default Step1;
+const mapStateToProps = state => ({
+  widgetEditor: state.widgetEditor
+});
+
+const mapDispatchToProps = dispatch => ({
+  setTitle: title => dispatch(setTitle(title))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Step1);

--- a/components/app/myrw/widgets/pages/edit.js
+++ b/components/app/myrw/widgets/pages/edit.js
@@ -19,7 +19,8 @@ import {
   setBand,
   setVisualizationType,
   setLayer,
-  setAreaIntersection
+  setAreaIntersection,
+  setTitle
 } from 'components/widgets/editor/redux/widgetEditor';
 import { setDataset } from 'redactions/myrwdetail';
 
@@ -274,6 +275,7 @@ class WidgetsEdit extends React.Component {
     if (limit) this.props.setLimit(limit);
     if (chartType) this.props.setChartType(chartType);
     if (areaIntersection) this.props.setAreaIntersection(areaIntersection);
+    if (this.state.widget.attributes.name) this.props.setTitle(this.state.widget.attributes.name);
   }
 
   @Autobind
@@ -413,7 +415,8 @@ WidgetsEdit.propTypes = {
   setAreaIntersection: PropTypes.func.isRequired,
   setBand: PropTypes.func.isRequired,
   setLayer: PropTypes.func.isRequired,
-  setDataset: PropTypes.func.isRequired
+  setDataset: PropTypes.func.isRequired,
+  setTitle: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -434,6 +437,7 @@ const mapDispatchToProps = dispatch => ({
   setVisualizationType: vis => dispatch(setVisualizationType(vis)),
   setAreaIntersection: value => dispatch(setAreaIntersection(value)),
   setBand: band => dispatch(setBand(band)),
+  setTitle: title => dispatch(setTitle(title)),
   setLayer: (layerId) => {
     new LayersService()
       .fetchData({ id: layerId })

--- a/components/app/myrw/widgets/pages/new.js
+++ b/components/app/myrw/widgets/pages/new.js
@@ -84,7 +84,8 @@ class WidgetsNew extends React.Component {
       chartType,
       filters,
       areaIntersection,
-      layer
+      layer,
+      title
     } = widgetEditor;
 
     const dataset = datasets.find(elem => elem.value === selectedDataset);
@@ -150,7 +151,7 @@ class WidgetsNew extends React.Component {
     const widgetObj = Object.assign(
       {},
       {
-        name: widget.name,
+        name: title,
         description: widget.description,
         authors: widget.authors,
         source: widget.source,

--- a/components/app/myrw/widgets/pages/new.js
+++ b/components/app/myrw/widgets/pages/new.js
@@ -6,6 +6,7 @@ import { Router } from 'routes';
 
 // Redux
 import { connect } from 'react-redux';
+import { setTitle } from 'components/widgets/editor/redux/widgetEditor';
 
 // Services
 import WidgetService from 'services/WidgetService';
@@ -187,14 +188,16 @@ class WidgetsNew extends React.Component {
   loadDatasets() {
     this.datasetsService.fetchAllData({ filters: { published: true }, includes: 'metadata' }).then((response) => {
       this.setState({
-        datasets: [...this.state.datasets, ...response.map(dataset => {
+        datasets: [...this.state.datasets, ...response.map((dataset) => {
           const metadata = dataset.metadata[0];
           return ({
             id: dataset.id,
             type: dataset.type,
             provider: dataset.provider,
             tableName: dataset.tableName,
-            label: metadata && metadata.attributes.info ? metadata.attributes.info.name : dataset.name,
+            label: metadata && metadata.attributes.info
+              ? metadata.attributes.info.name
+              : dataset.name,
             value: dataset.id
           });
         })],
@@ -205,14 +208,16 @@ class WidgetsNew extends React.Component {
     this.datasetsService.fetchAllData(
       { filters: { userId: this.props.user.id }, includes: 'metadata' }).then((response) => {
       this.setState({
-        datasets: [...this.state.datasets, ...response.map(dataset => {
+        datasets: [...this.state.datasets, ...response.map((dataset) => {
           const metadata = dataset.metadata[0];
-          return({
+          return ({
             id: dataset.id,
             type: dataset.type,
             provider: dataset.provider,
             tableName: dataset.tableName,
-            label: metadata && metadata.attributes.info ? metadata.attributes.info.name : dataset.name,
+            label: metadata && metadata.attributes.info
+              ? metadata.attributes.info.name
+              : dataset.name,
             value: dataset.id
           });
         })],
@@ -225,6 +230,10 @@ class WidgetsNew extends React.Component {
   handleChange(value) {
     const newWidgetObj = Object.assign({}, this.state.widget, value);
     this.setState({ widget: newWidgetObj });
+
+    if (Object.keys(value).indexOf('name') !== -1) {
+      this.props.setTitle(value.name);
+    }
   }
 
   @Autobind
@@ -249,6 +258,7 @@ class WidgetsNew extends React.Component {
       loadingUserDatasets,
       loadingPublishedDatasets
     } = this.state;
+    const { widgetEditor } = this.props;
 
     return (
       <div className="c-myrw-widgets-new">
@@ -297,6 +307,8 @@ class WidgetsNew extends React.Component {
                     label: 'Title',
                     type: 'text',
                     required: true,
+                    default: widgetEditor.title || '',
+                    value: widgetEditor.title || '',
                     placeholder: 'Widget title'
                   }}
                 >
@@ -376,7 +388,9 @@ class WidgetsNew extends React.Component {
 WidgetsNew.propTypes = {
   dataset: PropTypes.string,
   // Store
-  user: PropTypes.object.isRequired
+  user: PropTypes.object.isRequired,
+  widgetEditor: PropTypes.object.isRequired,
+  setTitle: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -384,4 +398,8 @@ const mapStateToProps = state => ({
   widgetEditor: state.widgetEditor
 });
 
-export default connect(mapStateToProps, null)(WidgetsNew);
+const mapDispatchToProps = dispatch => ({
+  setTitle: title => dispatch(setTitle(title))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(WidgetsNew);

--- a/components/modal/SaveWidgetModal.js
+++ b/components/modal/SaveWidgetModal.js
@@ -6,7 +6,7 @@ import { toastr } from 'react-redux-toastr';
 
 // Redux
 import { connect } from 'react-redux';
-
+import { setTitle } from 'components/widgets/editor/redux/widgetEditor';
 import { toggleModal } from 'redactions/modal';
 
 // Components
@@ -51,9 +51,7 @@ class SaveWidgetModal extends React.Component {
       loading: false,
       saved: false,
       error: false,
-      widget: {
-        name: props.title ? props.title : ''
-      }
+      description: null // Description of the widget
     };
 
     this.widgetService = new WidgetService(null, {
@@ -69,9 +67,25 @@ class SaveWidgetModal extends React.Component {
     this.setState({
       loading: true
     });
+
+    const { description } = this.state;
     const { widgetEditor, tableName, dataset, datasetType, datasetProvider } = this.props;
-    const { limit, value, category, color, size, orderBy, aggregateFunction,
-      chartType, filters, areaIntersection, visualizationType, band, layer } = widgetEditor;
+    const {
+      limit,
+      value,
+      category,
+      color,
+      size,
+      orderBy,
+      aggregateFunction,
+      chartType,
+      filters,
+      areaIntersection,
+      visualizationType,
+      band,
+      layer,
+      title
+    } = widgetEditor;
 
     let chartConfig = {};
 
@@ -123,7 +137,14 @@ class SaveWidgetModal extends React.Component {
       )
     };
 
-    const widgetObj = Object.assign({}, this.state.widget, widgetConfig);
+    const widgetObj = Object.assign(
+      {},
+      {
+        name: title || null,
+        description
+      },
+      widgetConfig
+    );
 
     this.widgetService.saveUserWidget(widgetObj, this.props.dataset, this.props.user.token)
       .then((response) => {
@@ -141,25 +162,28 @@ class SaveWidgetModal extends React.Component {
       .then(() => this.setState({ loading: false }));
   }
 
+  /**
+   * Event handler executed when the user clicks the
+   * cancel button of the modal
+   */
   @Autobind
   handleCancel() {
     this.props.toggleModal(false);
   }
 
+  /**
+   * Event handler executed when the user clicks the
+   * "Check my widgets" button
+   */
   @Autobind
   handleGoToMyRW() {
     this.props.toggleModal(false);
     Router.pushRoute('myrw', { tab: 'widgets', subtab: 'my_widgets' });
   }
 
-  @Autobind
-  handleChange(value) {
-    const newWidgetObj = Object.assign({}, this.state.widget, value);
-    this.setState({ widget: newWidgetObj });
-  }
-
   render() {
-    const { submitting, loading, saved, error, errorMessage, widget } = this.state;
+    const { submitting, loading, saved, error, errorMessage } = this.state;
+    const { widgetEditor } = this.props;
 
     return (
       <div className="c-save-widget-modal">
@@ -184,14 +208,15 @@ class SaveWidgetModal extends React.Component {
             <fieldset className="c-field-container">
               <Field
                 ref={(c) => { if (c) FORM_ELEMENTS.elements.title = c; }}
-                onChange={value => this.handleChange({ name: value })}
+                onChange={value => this.props.setTitle(value)}
                 validations={['required']}
                 properties={{
                   title: 'title',
                   label: 'Title',
                   type: 'text',
                   required: true,
-                  value: widget.name,
+                  default: widgetEditor.title,
+                  value: widgetEditor.title,
                   placeholder: 'Widget title'
                 }}
               >
@@ -199,7 +224,7 @@ class SaveWidgetModal extends React.Component {
               </Field>
               <Field
                 ref={(c) => { if (c) FORM_ELEMENTS.elements.description = c; }}
-                onChange={value => this.handleChange({ description: value })}
+                onChange={description => this.setState({ description })}
                 properties={{
                   title: 'description',
                   label: 'Description',
@@ -235,7 +260,7 @@ class SaveWidgetModal extends React.Component {
         {saved &&
         <div>
           <div className="icon-container">
-            <img alt="" src="/static/images/components/modal/widget-saved.svg" />
+            <img alt="Widget saved" src="/static/images/components/modal/widget-saved.svg" />
           </div>
           <div className="buttons-widget-saved">
             <Button
@@ -263,10 +288,11 @@ SaveWidgetModal.propTypes = {
   tableName: PropTypes.string.isRequired,
   datasetType: PropTypes.string,
   datasetProvider: PropTypes.string,
-  title: PropTypes.string,
   // Store
   user: PropTypes.object.isRequired,
-  toggleModal: PropTypes.func.isRequired
+  widgetEditor: PropTypes.object.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+  setTitle: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -275,7 +301,8 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  toggleModal: (open) => { dispatch(toggleModal(open)); }
+  toggleModal: open => dispatch(toggleModal(open)),
+  setTitle: title => dispatch(setTitle(title))
 });
 
 

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -453,21 +453,19 @@ class WidgetEditor extends React.Component {
           visualization = (
             <div className="visualization -chart">
               <Spinner className="-light" isLoading={chartLoading} />
-              {mode === 'dataset' &&
-                <div className="chart-title">
-                  {user.id &&
-                    <AutosizeInput
-                      name="widget-title"
-                      value={widgetEditor.title || ''}
-                      placeholder="Title..."
-                      onChange={this.handleTitleChange}
-                    />
-                  }
-                  {!user.id &&
-                    <span>{widgetEditor.title}</span>
-                  }
-                </div>
-              }
+              <div className="chart-title">
+                {user.id &&
+                  <AutosizeInput
+                    name="widget-title"
+                    value={widgetEditor.title || ''}
+                    placeholder="Title..."
+                    onChange={this.handleTitleChange}
+                  />
+                }
+                {!user.id &&
+                  <span>{widgetEditor.title}</span>
+                }
+              </div>
               <VegaChart
                 reloadOnResize
                 data={this.state.chartConfig}

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -459,6 +459,7 @@ class WidgetEditor extends React.Component {
                     <AutosizeInput
                       name="widget-title"
                       value={widgetEditor.title || ''}
+                      placeholder="Title..."
                       onChange={this.handleTitleChange}
                     />
                   }

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -412,6 +412,22 @@ class WidgetEditor extends React.Component {
     const loading = (mode === 'dataset' && !layersLoaded) ||
       (!fieldsError && !jiminyLoaded);
 
+    const chartTitle = (
+      <div className="chart-title">
+        {user.id &&
+          <AutosizeInput
+            name="widget-title"
+            value={widgetEditor.title || ''}
+            placeholder="Title..."
+            onChange={this.handleTitleChange}
+          />
+        }
+        {!user.id &&
+          <span>{widgetEditor.title}</span>
+        }
+      </div>
+    );
+
     let visualization = null;
     switch (selectedVisualizationType) {
       // Vega chart
@@ -420,17 +436,20 @@ class WidgetEditor extends React.Component {
           visualization = (
             <div className="visualization -chart">
               <Spinner className="-light" isLoading={loading} />
+              {chartTitle}
             </div>
           );
         } else if (this.state.chartConfigLoading) {
           visualization = (
             <div className="visualization -chart">
               <Spinner className="-light" isLoading />
+              {chartTitle}
             </div>
           );
         } else if (this.state.chartConfigError) {
           visualization = (
             <div className="visualization -error">
+              {chartTitle}
               <div>
                 {'Unfortunately, the chart couldn\'t be rendered'}
                 <span>{this.state.chartConfigError}</span>
@@ -440,12 +459,14 @@ class WidgetEditor extends React.Component {
         } else if (!canRenderChart(widgetEditor, datasetProvider) || !this.state.chartConfig) {
           visualization = (
             <div className="visualization -chart">
+              {chartTitle}
               Select a type of chart and columns
             </div>
           );
         } else if (!getChartType(chartType)) {
           visualization = (
             <div className="visualization -chart">
+              {chartTitle}
               {'This chart can\'t be previewed'}
             </div>
           );
@@ -453,19 +474,7 @@ class WidgetEditor extends React.Component {
           visualization = (
             <div className="visualization -chart">
               <Spinner className="-light" isLoading={chartLoading} />
-              <div className="chart-title">
-                {user.id &&
-                  <AutosizeInput
-                    name="widget-title"
-                    value={widgetEditor.title || ''}
-                    placeholder="Title..."
-                    onChange={this.handleTitleChange}
-                  />
-                }
-                {!user.id &&
-                  <span>{widgetEditor.title}</span>
-                }
-              </div>
+              {chartTitle}
               <VegaChart
                 reloadOnResize
                 data={this.state.chartConfig}
@@ -482,6 +491,7 @@ class WidgetEditor extends React.Component {
         if (layer) {
           visualization = (
             <div className="visualization">
+              {chartTitle}
               <Map
                 LayerManager={LayerManager}
                 mapConfig={mapConfig}
@@ -508,6 +518,7 @@ class WidgetEditor extends React.Component {
         } else {
           visualization = (
             <div className="visualization">
+              {chartTitle}
               Select a layer
             </div>
           );
@@ -519,11 +530,13 @@ class WidgetEditor extends React.Component {
           visualization = (
             <div className="visualization -chart">
               <Spinner className="-light" isLoading />
+              {chartTitle}
             </div>
           );
         } else if (this.state.chartConfigError) {
           visualization = (
             <div className="visualization -error">
+              {chartTitle}
               <div>
                 {'Unfortunately, the chart couldn\'t be rendered'}
                 <span>{this.state.chartConfigError}</span>
@@ -533,6 +546,7 @@ class WidgetEditor extends React.Component {
         } else if (!this.state.chartConfig || !this.props.band) {
           visualization = (
             <div className="visualization -chart">
+              {chartTitle}
               Select a band
             </div>
           );
@@ -540,6 +554,7 @@ class WidgetEditor extends React.Component {
           visualization = (
             <div className="visualization -chart">
               <Spinner className="-light" isLoading={chartLoading} />
+              {chartTitle}
               <VegaChart
                 reloadOnResize
                 data={this.state.chartConfig}
@@ -556,12 +571,14 @@ class WidgetEditor extends React.Component {
         if (!canRenderChart(widgetEditor, datasetProvider)) {
           visualization = (
             <div className="visualization">
+              {chartTitle}
               Select a type of chart and columns
             </div>
           );
         } else {
           visualization = (
             <div className="visualization">
+              {chartTitle}
               <TableView
                 dataset={dataset}
                 tableName={tableName}

--- a/components/widgets/editor/chart/ChartEditor.js
+++ b/components/widgets/editor/chart/ChartEditor.js
@@ -30,15 +30,14 @@ class ChartEditor extends React.Component {
 
   @Autobind
   handleSaveWidget() {
-    const { dataset, datasetType, datasetProvider, tableName, title } = this.props;
+    const { dataset, datasetType, datasetProvider, tableName } = this.props;
     const options = {
       children: SaveWidgetModal,
       childrenProps: {
         dataset,
         datasetType,
         datasetProvider,
-        tableName,
-        title
+        tableName
       }
     };
     this.props.toggleModal(true);
@@ -189,7 +188,6 @@ ChartEditor.propTypes = {
   mode: PropTypes.oneOf(['save', 'update']).isRequired,
   tableName: PropTypes.string.isRequired,
   hasGeoInfo: PropTypes.bool.isRequired,
-  title: PropTypes.string, // Default title when saving the widget
   jiminy: PropTypes.object,
   dataset: PropTypes.string.isRequired, // Dataset ID
   datasetType: PropTypes.string,

--- a/components/widgets/editor/modal/SaveWidgetModal.js
+++ b/components/widgets/editor/modal/SaveWidgetModal.js
@@ -6,7 +6,7 @@ import { toastr } from 'react-redux-toastr';
 
 // Redux
 import { connect } from 'react-redux';
-
+import { setTitle } from 'components/widgets/editor/redux/widgetEditor';
 import { toggleModal } from 'redactions/modal';
 
 // Components
@@ -51,9 +51,7 @@ class SaveWidgetModal extends React.Component {
       loading: false,
       saved: false,
       error: false,
-      widget: {
-        name: props.title ? props.title : ''
-      }
+      description: null // Description of the widget
     };
 
     this.widgetService = new WidgetService(null, {
@@ -69,9 +67,25 @@ class SaveWidgetModal extends React.Component {
     this.setState({
       loading: true
     });
+
+    const { description } = this.state;
     const { widgetEditor, tableName, dataset, datasetType, datasetProvider } = this.props;
-    const { limit, value, category, color, size, orderBy, aggregateFunction,
-      chartType, filters, areaIntersection, visualizationType, band, layer } = widgetEditor;
+    const {
+      limit,
+      value,
+      category,
+      color,
+      size,
+      orderBy,
+      aggregateFunction,
+      chartType,
+      filters,
+      areaIntersection,
+      visualizationType,
+      band,
+      layer,
+      title
+    } = widgetEditor;
 
     let chartConfig = {};
 
@@ -123,7 +137,14 @@ class SaveWidgetModal extends React.Component {
       )
     };
 
-    const widgetObj = Object.assign({}, this.state.widget, widgetConfig);
+    const widgetObj = Object.assign(
+      {},
+      {
+        name: title || null,
+        description
+      },
+      widgetConfig
+    );
 
     this.widgetService.saveUserWidget(widgetObj, this.props.dataset, this.props.user.token)
       .then((response) => {
@@ -141,26 +162,29 @@ class SaveWidgetModal extends React.Component {
       .then(() => this.setState({ loading: false }));
   }
 
+  /**
+   * Event handler executed when the user clicks the
+   * cancel button of the modal
+   *
+   */
   @Autobind
   handleCancel() {
     this.props.toggleModal(false);
   }
 
+  /**
+   * Event handler executed when the user clicks the
+   * "Check my widgets" button
+   */
   @Autobind
   handleGoToMyRW() {
     this.props.toggleModal(false);
     Router.pushRoute('myrw', { tab: 'widgets', subtab: 'my_widgets' });
   }
 
-  @Autobind
-  handleChange(value) {
-    const newWidgetObj = Object.assign({}, this.state.widget, value);
-    this.setState({ widget: newWidgetObj });
-  }
-
   render() {
-    const { submitting, loading, saved, error, errorMessage, widget } = this.state;
-    console.log('widget.name', widget.name);
+    const { submitting, loading, saved, error, errorMessage } = this.state;
+    const { widgetEditor } = this.props;
 
     return (
       <div className="c-save-widget-modal">
@@ -185,14 +209,15 @@ class SaveWidgetModal extends React.Component {
             <fieldset className="c-field-container">
               <Field
                 ref={(c) => { if (c) FORM_ELEMENTS.elements.title = c; }}
-                onChange={value => this.handleChange({ name: value })}
+                onChange={value => this.props.setTitle(value)}
                 validations={['required']}
                 properties={{
                   title: 'title',
                   label: 'Title',
                   type: 'text',
                   required: true,
-                  default: widget.name,
+                  default: widgetEditor.title,
+                  value: widgetEditor.title,
                   placeholder: 'Widget title'
                 }}
               >
@@ -200,7 +225,7 @@ class SaveWidgetModal extends React.Component {
               </Field>
               <Field
                 ref={(c) => { if (c) FORM_ELEMENTS.elements.description = c; }}
-                onChange={value => this.handleChange({ description: value })}
+                onChange={description => this.setState({ description })}
                 properties={{
                   title: 'description',
                   label: 'Description',
@@ -236,7 +261,7 @@ class SaveWidgetModal extends React.Component {
         {saved &&
         <div>
           <div className="icon-container">
-            <img alt="" src="/static/images/components/modal/widget-saved.svg" />
+            <img alt="Widget Saved" src="/static/images/components/modal/widget-saved.svg" />
           </div>
           <div className="buttons-widget-saved">
             <Button
@@ -264,10 +289,11 @@ SaveWidgetModal.propTypes = {
   tableName: PropTypes.string.isRequired,
   datasetType: PropTypes.string,
   datasetProvider: PropTypes.string,
-  title: PropTypes.string,
   // Store
   user: PropTypes.object.isRequired,
-  toggleModal: PropTypes.func.isRequired
+  widgetEditor: PropTypes.object.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+  setTitle: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -276,7 +302,8 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  toggleModal: (open) => { dispatch(toggleModal(open)); }
+  toggleModal: open => dispatch(toggleModal(open)),
+  setTitle: title => dispatch(setTitle(title))
 });
 
 

--- a/components/widgets/editor/nexgddp/NEXGDDPEditor.js
+++ b/components/widgets/editor/nexgddp/NEXGDDPEditor.js
@@ -34,15 +34,14 @@ class NEXGDDPEditor extends React.Component {
 
   @Autobind
   handleSaveWidget() {
-    const { dataset, datasetType, datasetProvider, tableName, title } = this.props;
+    const { dataset, datasetType, datasetProvider, tableName } = this.props;
     const options = {
       children: SaveWidgetModal,
       childrenProps: {
         dataset,
         datasetType,
         datasetProvider,
-        tableName,
-        title
+        tableName
       }
     };
     this.props.toggleModal(true);
@@ -208,7 +207,6 @@ NEXGDDPEditor.propTypes = {
   mode: PropTypes.oneOf(['save', 'update']).isRequired,
   tableName: PropTypes.string.isRequired,
   hasGeoInfo: PropTypes.bool.isRequired,
-  title: PropTypes.string, // Default title when saving the widget
   jiminy: PropTypes.object,
   dataset: PropTypes.string.isRequired, // Dataset ID
   datasetType: PropTypes.string,

--- a/components/widgets/editor/raster/RasterChartEditor.js
+++ b/components/widgets/editor/raster/RasterChartEditor.js
@@ -74,15 +74,14 @@ class RasterChartEditor extends React.Component {
    */
   @Autobind
   onClickSaveWidget() {
-    const { dataset, provider, tableName, title } = this.props;
+    const { dataset, provider, tableName } = this.props;
     const options = {
       children: SaveWidgetModal,
       childrenProps: {
         dataset,
         datasetType: 'raster',
         datasetProvider: provider,
-        tableName,
-        title
+        tableName
       }
     };
 
@@ -213,7 +212,6 @@ RasterChartEditor.propTypes = {
   dataset: PropTypes.string.isRequired,
   tableName: PropTypes.string.isRequired,
   hasGeoInfo: PropTypes.bool.isRequired,
-  title: PropTypes.string, // Default title when saving the widget
   provider: PropTypes.string.isRequired,
   mode: PropTypes.oneOf(['save', 'update']),
   showSaveButton: PropTypes.bool,

--- a/components/widgets/editor/redux/widgetEditor.js
+++ b/components/widgets/editor/redux/widgetEditor.js
@@ -43,7 +43,7 @@ const initialState = {
   fields: [],
   chartType: null,
   visualizationType: null,
-  title: 'Title',
+  title: null, // Title of the widget / graph
   limit: 500,
   areaIntersection: null, // ID of the geostore object
   band: null, // Band of the raster dataset

--- a/css/components/widgets/vega_chart_legend.scss
+++ b/css/components/widgets/vega_chart_legend.scss
@@ -1,6 +1,6 @@
 .c-vega-chart-legend {
   position: absolute;
-  top: 20px;
+  top: 25px; // Aligned with the title
   right: 20px;
 
   .toggle-button {

--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -7,13 +7,10 @@
 
   .customize-visualization {
     position: relative;
-    min-height: 580px;
-    max-height: 702px;
-    min-width: 522px;
-    max-width: 522px;
-    margin-top: -20px;
-    margin-bottom: -20px;
-    flex-basis: 430px;
+    min-height: 620px;
+    max-height: 740px;
+    margin: -20px 0;
+    flex-basis: 522px;
     flex-shrink: 0;
     flex-grow: 0;
     padding: $margin-size-small;
@@ -45,7 +42,7 @@
     flex-shrink: 1;
     flex-basis: 100%;
     overflow-x: hidden;
-    padding: $margin-size-extra-small;
+    padding: #{$margin-size-extra-small + 25px} $margin-size-extra-small $margin-size-extra-small;
     padding-right: 0;
 
     &.-error {
@@ -58,13 +55,6 @@
         font-weight: $font-weight-bold;
       }
     }
-
-    // &.-chart {
-    //   margin-left: 20px;
-    //   // This padding avoids the chart to touch the top and
-    //   // the bottom of the container
-    //   padding: 20px 0;
-    // }
 
     > .c-chart {
       display: flex;
@@ -88,10 +78,21 @@
     }
 
     .chart-title {
+      width: 100%;
+      max-width: calc(100% - 150px); // Avoid the title to overlap the legend (when collapsed)
       position: absolute;
-      top: 20px;
-      display: flex;
-      justify-content: center;
+      top: 15px;
+      left: 20px;
+
+      > div { // Override a property of the library
+        display: block !important;
+      }
+
+      input {
+        max-width: 100%; // Make the input respect its container width
+        font-family: $body-font-family;
+        font-size: $font-size-big;
+      }
     }
 
     // Share button of the map

--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -82,7 +82,8 @@
       max-width: calc(100% - 150px); // Avoid the title to overlap the legend (when collapsed)
       position: absolute;
       top: 15px;
-      left: 20px;
+      left: 15px;
+      z-index: 2; // At least 2 to be on top of the map
 
       > div { // Override a property of the library
         display: block !important;


### PR DESCRIPTION
This PR makes sure the name of the widget is shown in the editor and that whenever it is updated, the title of the chart also is (the other direction is also true).

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/6073968/31343781-8931c874-ad08-11e7-9767-452016e7a1be.png">

[Pivotal task](https://www.pivotaltracker.com/story/show/151751570)