### PR TITLE
Prevent the content of the editor from jumping

### DIFF
--- a/css/components/form/field.scss
+++ b/css/components/form/field.scss
@@ -10,8 +10,14 @@
     font-size: $font-size-small;
     color: $base-font-color;
     font-weight: 700;
+    line-height: 1.8; // Prevent style issues with inline loaders
 
     background: none;
+
+    .c-spinner {
+      vertical-align: middle; // Prevent style issues (shifting/jumping content)
+      margin-left: 5px;
+    }
   }
 
   .hint {


### PR DESCRIPTION
This could happen due to the inline loaders used for example for the area intersection filter.

[Pivotal tracker](https://www.pivotaltracker.com/story/show/150479167)