### PR TITLE
Fix a bug where the editor would generate a malformed query

### DIFF
--- a/components/widgets/editor/helpers/WidgetHelper.js
+++ b/components/widgets/editor/helpers/WidgetHelper.js
@@ -321,7 +321,8 @@ export async function getDataURL(dataset, datasetType, tableName, band, provider
     columns.push(sizeColumn);
   }
 
-  const orderByColumn = chartInfo.order ? [chartInfo.order] : [];
+  // NOTE: we need to copy chartInfo.order to avoid mutating the store
+  const orderByColumn = chartInfo.order ? [Object.assign({}, chartInfo.order)] : [];
 
   // If the visualization is a line chart and the user doesn't sort
   // the data, by default we sort it with the category column

--- a/components/widgets/editor/ui/ColumnBox.js
+++ b/components/widgets/editor/ui/ColumnBox.js
@@ -167,8 +167,7 @@ class ColumnBox extends React.Component {
 
   @Autobind
   triggerClose() {
-    const { isA, widgetEditor } = this.props;
-    const { aggregateFunction, orderBy, value } = widgetEditor;
+    const { isA } = this.props;
     switch (isA) {
       case 'color':
         this.props.removeColor({ name: this.props.name });
@@ -183,16 +182,6 @@ class ColumnBox extends React.Component {
         this.props.removeCategory();
         break;
       case 'value':
-        if (aggregateFunction && orderBy) {
-          let orderByNameNoAggFunc = orderBy.name;
-          orderByNameNoAggFunc = orderByNameNoAggFunc.replace(aggregateFunction, '');
-          orderByNameNoAggFunc = orderByNameNoAggFunc.replace('(', '').replace(')', '');
-          if (orderByNameNoAggFunc === value.name) {
-            const newOrderBy = orderBy;
-            newOrderBy.name = value.name;
-            this.props.setOrderBy(newOrderBy);
-          }
-        }
         this.props.removeValue();
         break;
       case 'orderBy':


### PR DESCRIPTION
The method that computes the query would inadvertently mutate the store and change the name of the column used to sort the data, when adding and then removing an aggregation function on the "value" column.

The issue has been fixed by copying the store's object that was being mutated.

You can reproduce the issue following these steps:
1. Choose whatever dataset you'd like.
2. Make a pie chart of it.
3. Sort the data with the field used in the "value" column.
4. Add an aggregation to the "value" column.
5. Remove the aggregation (choose the option "none").
6. Voila, the chart doesn't render because the query is wrong (look at the `GROUP BY` part).