### PR TITLE
Prevent the content of the raster editor from overflowing

### DIFF
--- a/components/widgets/editor/raster/RasterChartEditor.js
+++ b/components/widgets/editor/raster/RasterChartEditor.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Autobind } from 'es-decorators';
 import { toastr } from 'react-redux-toastr';
 import isEmpty from 'lodash/isEmpty';
+import truncate from 'lodash/truncate';
 import d3 from 'd3';
 
 // Redux
@@ -161,7 +162,7 @@ class RasterChartEditor extends React.Component {
 
     let description = band && band.description;
     const longDescription = description && description.length > 250;
-    description = longDescription ? `${description.slice(0, 250)}...` : description;
+    description = truncate(description, { length: 250, separator: /,?.* +/ });
 
     return (
       <div className="c-raster-chart-editor">

--- a/components/widgets/editor/raster/RasterChartEditor.js
+++ b/components/widgets/editor/raster/RasterChartEditor.js
@@ -99,6 +99,22 @@ class RasterChartEditor extends React.Component {
   }
 
   /**
+   * Event handler executed when the user clicks the
+   * "Read more" button
+   */
+  @Autobind
+  onClickReadMore() {
+    this.props.toggleModal(true, {
+      children: () => (
+        <div>
+          <h2>Description of the band</h2>
+          <p>{this.props.band.description}</p>
+        </div>
+      )
+    });
+  }
+
+  /**
    * Fetch the name of the bands and set it in the state
    */
   fetchBandNames() {
@@ -143,24 +159,37 @@ class RasterChartEditor extends React.Component {
     const { loading, bands, error, bandStatsInfo, bandStatsInfoLoading } = this.state;
     const { band, mode, showSaveButton, hasGeoInfo } = this.props;
 
+    let description = band && band.description;
+    const longDescription = description && description.length > 250;
+    description = longDescription ? `${description.slice(0, 250)}...` : description;
+
     return (
       <div className="c-raster-chart-editor">
         <div className="content">
-          { hasGeoInfo && <AreaIntersectionFilter /> }
-          <h5>Bands { loading && <Spinner isLoading className="-light -small -inline" /> }</h5>
-          { error && <div className="error"><span>Error:</span> {error}</div> }
-          { !error && (
-            <Select
-              properties={{
-                name: 'raster-bands',
-                default: band && band.name
-              }}
-              options={bands.map(b => ({ label: b.alias || b.name, value: b.name }))}
-              onChange={this.onChangeBand}
-            />
-          ) }
+          <div className="selectors-container">
+            <div>
+              <h5>Bands { loading && <Spinner isLoading className="-light -small -inline" /> }</h5>
+              { error && <div className="error"><span>Error:</span> {error}</div> }
+              { !error && (
+                <Select
+                  properties={{
+                    name: 'raster-bands',
+                    default: band && band.name
+                  }}
+                  options={bands.map(b => ({ label: b.alias || b.name, value: b.name }))}
+                  onChange={this.onChangeBand}
+                />
+              ) }
+            </div>
+            { hasGeoInfo && <AreaIntersectionFilter /> }
+          </div>
           { band && band.description && (
-            <p className="description">{band.description}</p>
+            <p className="description">
+              {description}
+              { longDescription &&
+                <button onClick={() => this.onClickReadMore()}>Read more</button>
+              }
+            </p>
           ) }
           <div className="c-table stats">
             <Spinner isLoading={bandStatsInfoLoading} className="-light -small" />

--- a/css/components/widgets/raster_chart_editor.scss
+++ b/css/components/widgets/raster_chart_editor.scss
@@ -8,6 +8,17 @@
   .content {
     flex-grow: 1;
 
+    .selectors-container {
+      display: flex;
+      justify-content: space-between;
+
+      > div {
+        flex-basis: calc(50% - 10px);
+        flex-grow: 0;
+        flex-shrink: 0;
+      }
+    }
+
     h5 {
       margin: 0 0 5px;
     }
@@ -17,8 +28,12 @@
     }
 
     .description {
-      margin-top: 20px;
       font-size: $font-size-normal;
+
+      button {
+        color: $color-primary;
+        cursor: pointer;
+      }
     }
 
     .stats {


### PR DESCRIPTION
This PR updates the layout of the raster editor so more content can fit and it doesn't overflow.

![Side-by-side comparison of the editor before and after the changes](https://user-images.githubusercontent.com/6073968/31382088-7208b0f8-adae-11e7-84e6-2debef762f51.png)