### PR TITLE
Prevent the editor from overflowing its container in the admin

### DIFF
--- a/css/components/form/form.scss
+++ b/css/components/form/form.scss
@@ -1,3 +1,12 @@
 .c-form {
   padding: 20px 0;
+
+  // NOTE: do not remove this property without
+  // going to the widget creation in the admin
+  // and rendering a scrollable bar chart
+  // On FF, the editor should not overflow
+  // Reference: https://stackoverflow.com/a/17863685
+  fieldset {
+    min-width: 0;
+  }
 }


### PR DESCRIPTION
This PR fixes a bug that seems to only affect Firefox' users: the editor would horizontally overflow and the user wouldn't be able to use some options such as the advanced editor because it's absolutely positioned to the right of the editor.

![Previously, the editor would horizontally overflow](https://user-images.githubusercontent.com/6073968/31385102-b5e8f8f4-adb9-11e7-9a9d-ae68f1c47c84.png)