### PR TITLE
Prevent the raster embeds from fetching data infinitely

### DIFF
--- a/components/widgets/charts/VegaChart.js
+++ b/components/widgets/charts/VegaChart.js
@@ -55,10 +55,6 @@ class VegaChart extends React.Component {
     || !isEqual(nextState.vegaConfig, this.state.vegaConfig);
   }
 
-  componentDidUpdate() {
-    this.renderChart();
-  }
-
   componentWillUnmount() {
     this.mounted = false;
     window.removeEventListener('resize', this.triggerResize);


### PR DESCRIPTION
The `VegaChart` component would fetch the data each time the state or the props would be updated. This kind of code is wrong: there should be a condition to check whether updating is useful or not.

I deleted the `componentDidUpdate` method and did some tests (embed, editor, explore) and it seems nothing is affected by the change.