### PR TITLE
Improve the styles of the raster embeds

### DIFF
--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -24,12 +24,13 @@
 
   .band-information {
     margin-top: 10px;
+    padding: $margin-size-extra-small;
   }
 
   .c-table {
     position: relative;
     min-height: 100px;
-    margin-top: 20px;
+    margin: 20px $margin-size-extra-small;
 
     table {
       display: block;


### PR DESCRIPTION
The band information and statistical tables wouldn't be aligned like the rest of the content (and the other embeds).

Previous alignment of the embed:
<p align="center">
<img width="436" alt="Alignment issues before the changes of the PR" src="https://user-images.githubusercontent.com/6073968/31392237-a77e14c2-add0-11e7-9e90-60acef87acf8.png">
</p>

