### PR TITLE
Prevent the app from crashing when the URL contains a non-existing dataset

### DIFF
--- a/selectors/explore/layersExplore.js
+++ b/selectors/explore/layersExplore.js
@@ -14,6 +14,11 @@ export const getLayerGroups = (datasets, layerGroups) => {
   if (!datasets.length) return [];
   return layerGroups.map((layerGroup, index) => {
     const dataset = datasets.find(d => d.id === layerGroup.dataset);
+
+    // If for some reason the dataset is not found,
+    // we skip it
+    if (!dataset) return null;
+
     const layers = [...layerGroup.layers].map((layer) => {
       const layerData = dataset.attributes.layer.find(l => l.id === layer.id);
       return {
@@ -23,7 +28,7 @@ export const getLayerGroups = (datasets, layerGroups) => {
       };
     });
     return Object.assign({}, layerGroup, { layers });
-  });
+  }).filter(layerGroup => layerGroup !== null);
 };
 
 const datasets = ({ explore }) => explore.datasets.list;


### PR DESCRIPTION
For some reason, someone was accessing the explore page with a layer that comes from a non-existing dataset (probably because it was removed). Because of that, the app would crash.

You can replicate the issues by going to [this URL](https://staging.resourcewatch.org/data/explore?page=1&layers=%255B%257B%2522dataset%2522%253A%252232213dbc-2ec1-4579-a9c8-21afa2793bb6%2522%252C%2522visible%2522%253Atrue%252C%2522layers%2522%253A%255B%257B%2522id%2522%253A%25226f1f8b5d-a6ba-436f-a7bf-b6812d0f3a20%2522%252C%2522active%2522%253Atrue%257D%255D%257D%255D&search=drou).

This PR makes sure that if the dataset is not found, we just skip it.

[Opbeat error](https://opbeat.com/vizzuality/resource-watch/errors/116/)