### PR TITLE
Improve embeds and dashboards layout

### DIFF
--- a/components/app/layout/EmbedLayout.js
+++ b/components/app/layout/EmbedLayout.js
@@ -4,26 +4,16 @@ import PropTypes from 'prop-types';
 // Redux
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { toggleModal, setModalOptions } from 'redactions/modal';
-import { toggleTooltip } from 'redactions/tooltip';
 import { updateIsLoading } from 'redactions/page';
+import { toggleTooltip } from 'redactions/tooltip';
 
 // Components
 import { Router } from 'routes';
 import Icons from 'components/app/layout/icons';
 import Tooltip from 'components/ui/Tooltip';
 import Head from 'components/app/layout/head';
-import Modal from 'components/ui/Modal';
-import Toastr from 'react-redux-toastr';
 
 class Layout extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      modalOpen: false
-    };
-  }
-
   componentWillMount() {
     // When a tooltip is shown and the router navigates to a
     // another page, the tooltip stays in place because it is
@@ -47,14 +37,8 @@ class Layout extends React.Component {
     };
   }
 
-  componentWillReceiveProps(newProps) {
-    if (this.state.modalOpen !== newProps.modal.open) {
-      this.setState({ modalOpen: newProps.modal.open });
-    }
-  }
-
   render() {
-    const { title, description, modal, className } = this.props;
+    const { title, description, className } = this.props;
 
     return (
       <div className={`l-page ${className}`}>
@@ -68,12 +52,6 @@ class Layout extends React.Component {
         {this.props.children}
 
         <Tooltip />
-
-        <Toastr
-          preventDuplicates
-          transitionIn="fadeIn"
-          transitionOut="fadeOut"
-        />
       </div>
     );
   }
@@ -85,7 +63,6 @@ Layout.propTypes = {
   description: PropTypes.string,
   className: PropTypes.string,
   // Store
-  modal: PropTypes.object,
   toggleTooltip: PropTypes.func,
   updateIsLoading: PropTypes.func
 };
@@ -97,8 +74,6 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   toggleTooltip: () => dispatch(toggleTooltip()),
-  toggleModal: open => dispatch(toggleModal(open, {}, true)),
-  setModalOptions: options => dispatch(setModalOptions(options)),
   updateIsLoading: bindActionCreators(isLoading => updateIsLoading(isLoading), dispatch)
 });
 

--- a/css/components/app/pages/dashboards.scss
+++ b/css/components/app/pages/dashboards.scss
@@ -127,11 +127,14 @@
   .user-content {
     margin-top: 30px;
 
+    .widget-layout {
+      margin: map-get($grid-column-gutter, 'small') 0;
+    }
+
     iframe {
       display: block;
       width: 100%;
       height: 383px;
-      border: 1px solid $border-color-1;
     }
 
     img {

--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -59,6 +59,12 @@
     padding: $margin-size-extra-small;
     overflow: hidden;
 
+    &.-external {
+      .c-map {
+        height: calc(100% + #{$margin-size-extra-small});
+      }
+    }
+
     .c-chart {
       height: 100%;
       display: flex;
@@ -82,6 +88,20 @@
       }
     }
 
+    .c-map {
+      position: relative;
+      top: -$margin-size-extra-small;
+      left: -$margin-size-extra-small;
+      height: calc(100% + #{2 * $margin-size-extra-small});
+      width: calc(100% + #{2 * $margin-size-extra-small});
+
+      // Without this property, the legend is hidden behind
+      // the map
+      .leaflet-pane {
+        z-index: 1;
+      }
+    }
+
     .widget-modal {
       position: absolute;
       top: 0;
@@ -89,7 +109,7 @@
       width: 100%;
       height: 100%;
       padding: $margin-size-extra-small;
-      z-index: 1;
+      z-index: 3;
       background-color: $white;
       overflow-x: hidden;
       overflow-y: auto;
@@ -132,17 +152,6 @@
         display: inline-block;
         width: calc(100% / 6);
       }
-    }
-  }
-
-  .c-map {
-    height: 300px;
-    position: relative;
-
-    // Without this property, the legend is hidden behind
-    // the map
-    .leaflet-pane {
-      z-index: 1;
     }
   }
 }

--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -1,36 +1,122 @@
+/*
+  This is the general layout of a widget:
+
+  +----------------------------------+
+  |      .widget-title (auto ↕)      |
+  +----------------------------------+
+  |                                  |
+  |     .widget-content (grow ↕)     |
+  |                                  |
+  +----------------------------------+
+  |     .widget-footer (auto ↕)      |
+  +----------------------------------+
+
+*/
+
+
 .c-embed-widget {
   position: relative; // Limit the scope of the map and spinner
+
+  // We use all the space available of the
+  // iframe and prevent any scroll
   width: 100%;
-  height: 100%;
-  min-height: 150px;
+  height: 100vh;
+  overflow: hidden;
+
+  // We share the vertical space between
+  // the title and the widget
+  display: flex;
+  flex-direction: column;
+
+  border: 1px solid $border-color-1;
+  border-radius: 4px;
 
   .widget-title {
+    position: relative;
+    flex-shrink: 0;
     padding: $margin-size-extra-small;
     border-bottom: 1px solid $border-color-1;
 
-    h1, h2, h3, h4, p {
+    h1, h2, h3, h4 {
+      display: inline-block;
       margin-bottom: 0;
+      padding-right: 20px;
+    }
+
+    button {
+      position: absolute;
+      top: #{$margin-size-extra-small + 4px};
+      right: $margin-size-extra-small;
+      margin: 0;
+      padding: 0;
+      cursor: pointer;
     }
   }
 
   .widget-content {
-    position: relative; // Needed to position the legend of the map
-    margin: $margin-size-extra-small;
+    position: relative;
+    flex-grow: 1;
+    padding: $margin-size-extra-small;
+    overflow: hidden;
+
+    .c-chart {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      // In case of a bar chart with scrolling, we need
+      // to use an overflow
+      overflow-x: auto;
+      max-width: 100%;
+
+      .chart {
+        height: 100%;
+
+        .vega {
+          height: 100%;
+
+          canvas {
+            display: block; // Prevent a UA margin
+            margin: 0 auto;
+          }
+        }
+      }
+    }
+
+    .widget-modal {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      padding: $margin-size-extra-small;
+      z-index: 1;
+      background-color: $white;
+      overflow-x: hidden;
+      overflow-y: auto;
+
+      > div {
+        margin-bottom: $margin-size-extra-small;
+      }
+
+      h4 {
+        color: $base-font-color;
+      }
+    }
   }
 
-  .widget-description {
-    padding: $margin-size-extra-small;
-  }
+  .widget-footer {
+    flex-shrink: 0;
+    padding: 0 $margin-size-extra-small $margin-size-extra-small;
 
-  .band-information {
-    margin-top: 10px;
-    padding: $margin-size-extra-small;
+    .embed-logo {
+      display: block;
+      height: 21px;
+    }
   }
 
   .c-table {
     position: relative;
     min-height: 100px;
-    margin: 20px $margin-size-extra-small;
 
     table {
       display: block;
@@ -49,26 +135,6 @@
     }
   }
 
-  // > div > .info { // Without that much specificity, we break the legend
-  //   margin-top: 20px;
-
-  //   .widget-title {
-  //     display: flex;
-  //     justify-content: center;
-  //     align-items: center;
-  //   }
-
-  //   .widget-description {
-  //     display: flex;
-  //     justify-content: center;
-  //     align-items: center;
-  //   }
-
-  //   a {
-  //     text-decoration: none;
-  //   }
-  // }
-
   .c-map {
     height: 300px;
     position: relative;
@@ -77,45 +143,6 @@
     // the map
     .leaflet-pane {
       z-index: 1;
-    }
-  }
-
-  .embed-logo {
-    margin: $margin-size-extra-small;
-  }
-
-  .c-chart {
-    // The pie and bar chart will overflow without
-    // this property because they auto determine the
-    // space they need
-    height: auto;
-    // For the other charts, we need a minimum height
-    // and to make the container "flex" so we force the
-    // chart to use at least the min-height
-    min-height: 300px;
-    display: flex;
-    flex-direction: column;
-    // In case of a bar chart with scrolling, we need
-    // to use an overflow
-    overflow-x: auto;
-    max-width: 100%;
-
-    .chart {
-      // For smaller charts than the 300px, we center them
-      // both vertically and horizontally
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-
-      // This is needed for the scatter and 1d_* charts
-      // in order to take the whole 300px vertically
-      flex-basis: 100%;
-      flex-grow: 1;
-
-      .vega {
-        text-align: center;
-        height: 300px;
-      }
     }
   }
 }

--- a/css/components/map/map.scss
+++ b/css/components/map/map.scss
@@ -21,6 +21,10 @@
     margin-right: 30px !important;
     border-width: 1px;
     border-color: $border-color-2;
+
+    .c-embed-widget & {
+      margin-right: $margin-size-extra-small !important;
+    }
   }
 
   .leaflet-control-zoom-in,

--- a/css/components/ui/legend.scss
+++ b/css/components/ui/legend.scss
@@ -8,6 +8,10 @@
   z-index: 2;
   border-radius: 4px;
 
+  .c-embed-widget & {
+    right: $margin-size-extra-small;
+  }
+
   @media screen and (min-width: $grid-row-width) {
     width: 100%;
     min-width: 400px;

--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -65,7 +65,7 @@ class EmbedMap extends Page {
   }
 
   render() {
-    const { widget, loading, layerGroups } = this.props;
+    const { widget, loading, layerGroups, error } = this.props;
     const { modalOpened } = this.state;
 
     if (loading) {
@@ -75,6 +75,37 @@ class EmbedMap extends Page {
           description={''}
         >
           <Spinner isLoading={loading} className="-light" />
+        </EmbedLayout>
+      );
+    }
+
+    if (error) {
+      return (
+        <EmbedLayout
+          title={'Resource Watch'}
+          description={''}
+        >
+          <div className="c-embed-widget">
+            <div className="widget-title">
+              <h4>–</h4>
+            </div>
+
+            <div className="widget-content">
+              <p>{'Sorry, the widget couldn\'t be loaded'}</p>
+            </div>
+
+            { this.isLoadedExternally() && (
+              <div className="widget-footer">
+                <a href="/" target="_blank" rel="noopener noreferrer">
+                  <img
+                    className="embed-logo"
+                    src={'/static/images/logo-embed.png'}
+                    alt="Resource Watch"
+                  />
+                </a>
+              </div>
+            ) }
+          </div>
         </EmbedLayout>
       );
     }
@@ -143,7 +174,8 @@ EmbedMap.propTypes = {
   getWidget: PropTypes.func,
   toggleLayerGroupVisibility: PropTypes.func,
   loading: PropTypes.bool,
-  layerGroups: PropTypes.array
+  layerGroups: PropTypes.array,
+  error: PropTypes.string
 };
 
 EmbedMap.defaultProps = {
@@ -153,6 +185,7 @@ EmbedMap.defaultProps = {
 const mapStateToProps = state => ({
   widget: state.widget.data,
   loading: state.widget.loading,
+  error: state.widget.error,
   layerGroups: state.widget.layerGroups
 });
 

--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -74,7 +74,9 @@ class EmbedMap extends Page {
           title={'Loading widget...'}
           description={''}
         >
-          <Spinner isLoading={loading} className="-light" />
+          <div className="c-embed-widget">
+            <Spinner isLoading={loading} className="-light" />
+          </div>
         </EmbedLayout>
       );
     }

--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 // Redux
 import withRedux from 'next-redux-wrapper';
@@ -15,6 +16,7 @@ import EmbedLayout from 'components/app/layout/EmbedLayout';
 import Spinner from 'components/widgets/editor/ui/Spinner';
 import Map from 'components/widgets/editor/map/Map';
 import Legend from 'components/widgets/editor/ui/Legend';
+import Icon from 'components/widgets/editor/ui/Icon';
 
 // Utils
 import LayerManager from 'components/widgets/editor/helpers/LayerManager';
@@ -33,12 +35,38 @@ class EmbedMap extends Page {
     return !/localhost|staging.resourcewatch.org/.test(this.props.referer);
   }
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      modalOpened: false
+    };
+  }
+
   componentDidMount() {
     this.props.getWidget(this.props.url.query.id);
   }
 
+  getModal() {
+    const { widget } = this.props;
+    return (
+      <div className="widget-modal">
+        { !widget.attributes.description &&
+          <p>No additional information is available</p>
+        }
+
+        { widget.attributes.description && (
+          <div>
+            <h4>Description</h4>
+            <p>{widget.attributes.description}</p>
+          </div>
+        ) }
+      </div>
+    );
+  }
+
   render() {
     const { widget, loading, layerGroups } = this.props;
+    const { modalOpened } = this.state;
 
     if (loading) {
       return (
@@ -59,41 +87,50 @@ class EmbedMap extends Page {
         description={`${widget.attributes.description || ''}`}
       >
         <div className="c-embed-widget">
-          <div className="visualization">
-            <div className="widget-title">
+          <div className="widget-title">
+            <a href={`/data/explore/${widget.attributes.dataset}`} target="_blank" rel="noopener noreferrer">
               <h4>{widget.attributes.name}</h4>
-            </div>
-            <div className="widget-content">
-              <Map
-                LayerManager={LayerManager}
-                mapConfig={mapConfig}
-                layerGroups={layerGroups}
-              />
-
-              <Legend
-                layerGroups={layerGroups}
-                className={{ color: '-dark' }}
-                toggleLayerGroupVisibility={
-                  layerGroup => this.props.toggleLayerGroupVisibility(layerGroup)
-                }
-                setLayerGroupsOrder={() => {}}
-                setLayerGroupActiveLayer={() => {}}
-                interactionDisabled
-                expanded={false}
-              />
-            </div>
-            <p className="widget-description">
-              {widget.attributes.description}
-            </p>
+            </a>
+            <button
+              aria-label={`${modalOpened ? 'Close' : 'Open'} information modal`}
+              onClick={() => this.setState({ modalOpened: !modalOpened })}
+            >
+              <Icon name={`icon-${modalOpened ? 'cross' : 'info'}`} className="c-icon -small" />
+            </button>
           </div>
-          { this.isLoadedExternally() &&
-            <img
-              className="embed-logo"
-              height={21}
-              width={129}
-              src={'/static/images/logo-embed.png'}
-              alt="Resource Watch"
-            /> }
+
+          <div className={classnames('widget-content', { '-external': this.isLoadedExternally() })}>
+            <Map
+              LayerManager={LayerManager}
+              mapConfig={mapConfig}
+              layerGroups={layerGroups}
+            />
+
+            <Legend
+              layerGroups={layerGroups}
+              className={{ color: '-dark' }}
+              toggleLayerGroupVisibility={
+                layerGroup => this.props.toggleLayerGroupVisibility(layerGroup)
+              }
+              setLayerGroupsOrder={() => {}}
+              setLayerGroupActiveLayer={() => {}}
+              interactionDisabled
+              expanded={false}
+            />
+
+            { modalOpened && this.getModal() }
+          </div>
+          { this.isLoadedExternally() && (
+            <div className="widget-footer">
+              <a href="/" target="_blank" rel="noopener noreferrer">
+                <img
+                  className="embed-logo"
+                  src={'/static/images/logo-embed.png'}
+                  alt="Resource Watch"
+                />
+              </a>
+            </div>
+          ) }
         </div>
       </EmbedLayout>
     );

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -96,7 +96,7 @@ class EmbedWidget extends Page {
   }
 
   render() {
-    const { widget, loading } = this.props;
+    const { widget, loading, error } = this.props;
     const { isLoading, modalOpened } = this.state;
 
     if (loading) {
@@ -106,6 +106,37 @@ class EmbedWidget extends Page {
           description={''}
         >
           <Spinner isLoading className="-light" />
+        </EmbedLayout>
+      );
+    }
+
+    if (error) {
+      return (
+        <EmbedLayout
+          title={'Resource Watch'}
+          description={''}
+        >
+          <div className="c-embed-widget">
+            <div className="widget-title">
+              <h4>–</h4>
+            </div>
+
+            <div className="widget-content">
+              <p>{'Sorry, the widget couldn\'t be loaded'}</p>
+            </div>
+
+            { this.isLoadedExternally() && (
+              <div className="widget-footer">
+                <a href="/" target="_blank" rel="noopener noreferrer">
+                  <img
+                    className="embed-logo"
+                    src={'/static/images/logo-embed.png'}
+                    alt="Resource Watch"
+                  />
+                </a>
+              </div>
+            ) }
+          </div>
         </EmbedLayout>
       );
     }
@@ -159,7 +190,8 @@ EmbedWidget.propTypes = {
   getWidget: PropTypes.func,
   bandDescription: PropTypes.string,
   bandStats: PropTypes.object,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  error: PropTypes.string
 };
 
 EmbedWidget.defaultProps = {
@@ -169,6 +201,7 @@ EmbedWidget.defaultProps = {
 const mapStateToProps = state => ({
   widget: state.widget.data,
   loading: state.widget.loading,
+  error: state.widget.error,
   bandDescription: state.widget.bandDescription,
   bandStats: state.widget.bandStats
 });

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -105,7 +105,9 @@ class EmbedWidget extends Page {
           title={'Loading widget...'}
           description={''}
         >
-          <Spinner isLoading className="-light" />
+          <div className="c-embed-widget">
+            <Spinner isLoading className="-light" />
+          </div>
         </EmbedLayout>
       );
     }

--- a/services/WidgetService.js
+++ b/services/WidgetService.js
@@ -11,7 +11,17 @@ export default class WidgetService {
 
   fetchData(includes = '') {
     return fetch(`${this.opts.apiURL}/widget/${this.widgetId}?includes=${includes}&page[size]=999`)
-      .then(response => response.json())
+      .then(async (response) => {
+        const data = await response.json();
+
+        if (!response.ok) {
+          const error = (data && data.errors && data.errors.length && data.errors[0].detail)
+            || 'Failed to load the data';
+          throw new Error(error);
+        }
+
+        return data;
+      })
       .then(jsonData => jsonData.data);
   }
 


### PR DESCRIPTION
This PR improves the layout of the widget (vega) and map embeds as well as the dashboards.

<p align="center">
<img width="1082" alt="Grid of embedded widgets in a dashboard" src="https://user-images.githubusercontent.com/6073968/31492393-ad639d80-af42-11e7-870e-314dcd8cc22c.png">
</p>

The table and layer embeds haven't been changed for the following reasons:
* The table one misses a lot of information and context (it's just a table for now) so it might need further changes. Instead of spending time on its layout, let's improve what's displayed first.
* The layer embed needs deeper changes because the legend can open a modal (this is a shared component). The embed won't be able to properly display it so we need to think about the best option.

@pablopareja do you mind creating tasks for these two types of embed so we don't forget to check them later?

Finally, note that some of the widgets of the dashboards still have vertical scrolling. This is because either the widgets were created through the editor at a time where the templates weren't responsive or  because the widgets were manually created and weren't made responsive. Alicia and I can probably work on that.

[Pivotal task 1](https://www.pivotaltracker.com/story/show/151873751)
[Pivotal task 2](https://www.pivotaltracker.com/story/show/151870821)