### PR TITLE
Improve the position of the tooltip on the sides of the screen

### DIFF
--- a/css/components/ui/tooltip.scss
+++ b/css/components/ui/tooltip.scss
@@ -9,7 +9,7 @@
 
   &.-arrow {
     &-top {
-      &::after {
+      .tip {
         display: block;
         position: absolute;
         top: -8px;
@@ -26,7 +26,7 @@
     }
 
     &-bottom {
-      &::after {
+      .tip {
         display: block;
         position: absolute;
         bottom: -8px;


### PR DESCRIPTION
This PR improves the position of the tooltip when displayed on either side of the screen: the tooltip is not cut anymore but gets "pinned" to the side and its tip is moved proportionally to point the desired position.

This behaviour hasn't been applied to the top and the bottom of the screen because the tooltip opens in these directions. If needed, we could reverse its direction but I don't think it's currently necessary.

<p align="center">
<img width="294" alt="screen shot 2017-10-13 at 11 05 25" src="https://user-images.githubusercontent.com/6073968/31541410-72f97c2c-b006-11e7-9d32-b9b5058f3280.png">
</p>

[Pivotal task](https://www.pivotaltracker.com/story/show/151915521)