### PR TITLE
Prevent the app to crash due to the content of the tooltip

### DIFF
--- a/redactions/tooltip.js
+++ b/redactions/tooltip.js
@@ -47,7 +47,19 @@ export function setTooltipChildren(children) {
 }
 
 export function toggleTooltip(opened, opts = {}) {
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    const { tooltip } = getState();
+
+    // This code makes sure that if a tooltip is already opened
+    // and we try to open another with a different "children", then
+    // we have the time to also update the "childrenProps" before
+    // rendering the component
+    // What we want to avoid is that a different "children" is rendered
+    // with the props that belong to a previous one
+    if (opts.children && tooltip.opened && tooltip.children !== opts.children) {
+      dispatch({ type: TOOLTIP_TOGGLE, payload: false });
+    }
+
     if (opened) {
       if (opts.children) {
         dispatch({ type: TOOLTIP_SET_CHILDREN, payload: opts.children });


### PR DESCRIPTION
This PR fixes a tricky bug that would crash the app: a tooltip could render with the props of a previous one if it's still opened.

What exactly happens is that when we toggle a tooltip, we throw several `dispatch` sequentially. The first one is to change the component that renders inside of the tooltip. Immediately after firing the action with `dispatch`, react would render the content, but with the old props because the action to update the props is fired right after.

Changing the order of the `dispatch` isn't a proper solution because that means the older content could render with props that belongs to the new tooltip. Instead, what we can do is close the tooltip, dispatch all what we need and open it again so the new content only renders when we're sure the props have been updated.