### PR TITLE
Prevent the name of a widget from leaking into a new form

### DIFF
--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -25,7 +25,8 @@ import {
   setBand,
   setVisualizationType,
   setLayer,
-  setTitle
+  setTitle,
+  resetWidgetEditor
 } from 'components/widgets/editor/redux/widgetEditor';
 
 // Constants
@@ -64,6 +65,15 @@ class WidgetsForm extends React.Component {
     this.datasetsService = new DatasetsService({
       authorization: props.authorization
     });
+  }
+
+  componentWillMount() {
+    // If the user wants to create a new widget, we make
+    // sure that the name of the previous widget the
+    // user saw is not leaking in this new form
+    if (!this.props.id) {
+      this.props.resetWidgetEditor();
+    }
   }
 
   componentDidMount() {
@@ -387,7 +397,8 @@ WidgetsForm.propTypes = {
   setVisualizationType: PropTypes.func.isRequired,
   setBand: PropTypes.func.isRequired,
   setLayer: PropTypes.func.isRequired,
-  setTitle: PropTypes.func.isRequired
+  setTitle: PropTypes.func.isRequired,
+  resetWidgetEditor: PropTypes.func.isRequired
 };
 
 const mapDispatchToProps = dispatch => ({
@@ -409,7 +420,8 @@ const mapDispatchToProps = dispatch => ({
       .then(layer => dispatch(setLayer(layer)))
       // TODO: better handling of the error
       .catch(err => toastr.error('Error', err));
-  }
+  },
+  resetWidgetEditor: () => dispatch(resetWidgetEditor())
 });
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
This PR makes sure the widget editor's store is restored when the user wants to create a new widget in the admin.

It seems that when the user was visiting an existing widget and then would go to the creation page, the name of the previous widget would be displayed until the user select a dataset.