### PR TITLE
Save the position and zoom of the Explore + editor + embeds maps

### DIFF
--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -26,7 +26,9 @@ import {
   setVisualizationType,
   setLayer,
   setTitle,
-  resetWidgetEditor
+  resetWidgetEditor,
+  setZoom,
+  setLatLng
 } from 'components/widgets/editor/redux/widgetEditor';
 
 // Constants
@@ -136,7 +138,9 @@ class WidgetsForm extends React.Component {
       visualizationType,
       band,
       layer,
-      title
+      title,
+      zoom,
+      latLng
     } = widgetEditor;
 
     event.preventDefault();
@@ -166,10 +170,14 @@ class WidgetsForm extends React.Component {
               widgetConfig: Object.assign(
                 {},
                 formObj.widgetConfig,
-                // If the widget is different from chart, we want to add the type
+                // If the widget is a map, we want to add some extra info
+                // in widgetConfig so the widget is compatible with other
+                // apps that use the same API
+                // The type and layer_id are not necessary for the editor
+                // because it is already saved in widgetConfig.paramsConfig
                 (
-                  visualizationType !== 'chart'
-                    ? { type: visualizationType }
+                  visualizationType === 'map'
+                    ? { type: 'map', layer_id: layer && layer.id, zoom, ...latLng }
                     : {}
                 ),
                 {
@@ -297,7 +305,8 @@ class WidgetsForm extends React.Component {
   }
 
   loadWidgetIntoRedux() {
-    const { paramsConfig } = this.state.form.widgetConfig;
+    const { widgetConfig, name } = this.state.form;
+    const { paramsConfig, zoom, lat, lng } = widgetConfig;
     if (paramsConfig) {
       const {
         visualizationType,
@@ -330,7 +339,9 @@ class WidgetsForm extends React.Component {
       if (filters) this.props.setFilters(filters);
       if (limit) this.props.setLimit(limit);
       if (chartType) this.props.setChartType(chartType);
-      if (this.state.form.name) this.props.setTitle(this.state.form.name);
+      if (name) this.props.setTitle(name);
+      if (zoom) this.props.setZoom(zoom);
+      if (lat && lng) this.props.setLatLng({ lat, lng });
     }
   }
 
@@ -398,7 +409,9 @@ WidgetsForm.propTypes = {
   setBand: PropTypes.func.isRequired,
   setLayer: PropTypes.func.isRequired,
   setTitle: PropTypes.func.isRequired,
-  resetWidgetEditor: PropTypes.func.isRequired
+  resetWidgetEditor: PropTypes.func.isRequired,
+  setZoom: PropTypes.func.isRequired,
+  setLatLng: PropTypes.func.isRequired
 };
 
 const mapDispatchToProps = dispatch => ({
@@ -421,7 +434,9 @@ const mapDispatchToProps = dispatch => ({
       // TODO: better handling of the error
       .catch(err => toastr.error('Error', err));
   },
-  resetWidgetEditor: () => dispatch(resetWidgetEditor())
+  resetWidgetEditor: () => dispatch(resetWidgetEditor()),
+  setZoom: zoom => dispatch(setZoom(zoom)),
+  setLatLng: latLng => dispatch(setLatLng(latLng))
 });
 
 const mapStateToProps = state => ({

--- a/components/app/layout/Sidebar.js
+++ b/components/app/layout/Sidebar.js
@@ -22,6 +22,7 @@ class Sidebar extends React.Component {
     };
 
     this.triggerToggle = this.triggerToggle.bind(this);
+    this.triggerResize = debounce(this.triggerResize.bind(this), 500);
     this.handleScroll = debounce(this.handleScroll.bind(this), 30);
   }
 
@@ -31,10 +32,20 @@ class Sidebar extends React.Component {
       open: true
     };
     this.props.setSidebar(options);
+
+    window.addEventListener('resize', this.triggerResize);
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState({ open: nextProps.sidebar.open });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.triggerResize);
+  }
+
+  triggerResize() {
+    this.props.setSidebar({ width: this.sidebarNode.offsetWidth });
   }
 
   /**

--- a/components/app/myrw/widgets/pages/edit.js
+++ b/components/app/myrw/widgets/pages/edit.js
@@ -20,7 +20,9 @@ import {
   setVisualizationType,
   setLayer,
   setAreaIntersection,
-  setTitle
+  setTitle,
+  setZoom,
+  setLatLng
 } from 'components/widgets/editor/redux/widgetEditor';
 import { setDataset } from 'redactions/myrwdetail';
 
@@ -241,7 +243,8 @@ class WidgetsEdit extends React.Component {
   }
 
   loadWidgetIntoRedux() {
-    const { paramsConfig } = this.state.widget.attributes.widgetConfig;
+    const { widgetConfig, name } = this.state.widget.attributes;
+    const { paramsConfig, zoom, lat, lng } = widgetConfig;
     const {
       visualizationType,
       band,
@@ -275,7 +278,9 @@ class WidgetsEdit extends React.Component {
     if (limit) this.props.setLimit(limit);
     if (chartType) this.props.setChartType(chartType);
     if (areaIntersection) this.props.setAreaIntersection(areaIntersection);
-    if (this.state.widget.attributes.name) this.props.setTitle(this.state.widget.attributes.name);
+    if (name) this.props.setTitle(name);
+    if (zoom) this.props.setZoom(zoom);
+    if (lat && lng) this.props.setLatLng({ lat, lng });
   }
 
   @Autobind
@@ -416,7 +421,9 @@ WidgetsEdit.propTypes = {
   setBand: PropTypes.func.isRequired,
   setLayer: PropTypes.func.isRequired,
   setDataset: PropTypes.func.isRequired,
-  setTitle: PropTypes.func.isRequired
+  setTitle: PropTypes.func.isRequired,
+  setZoom: PropTypes.func.isRequired,
+  setLatLng: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -445,7 +452,9 @@ const mapDispatchToProps = dispatch => ({
       // TODO: better handling of the error
       .catch(err => toastr.error('Error', err));
   },
-  setDataset: dataset => dispatch(setDataset(dataset))
+  setDataset: dataset => dispatch(setDataset(dataset)),
+  setZoom: zoom => dispatch(setZoom(zoom)),
+  setLatLng: latLng => dispatch(setLatLng(latLng))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(WidgetsEdit);

--- a/components/app/myrw/widgets/pages/new.js
+++ b/components/app/myrw/widgets/pages/new.js
@@ -86,7 +86,9 @@ class WidgetsNew extends React.Component {
       filters,
       areaIntersection,
       layer,
-      title
+      title,
+      zoom,
+      latLng
     } = widgetEditor;
 
     const dataset = datasets.find(elem => elem.value === selectedDataset);
@@ -131,11 +133,11 @@ class WidgetsNew extends React.Component {
         // If the widget is a map, we want to add some extra info
         // in widgetConfig so the widget is compatible with other
         // apps that use the same API
-        // This info is not necessary for the editor because it is
-        // already saved in widgetConfig.paramsConfig
+        // The type and layer_id are not necessary for the editor
+        // because it is already saved in widgetConfig.paramsConfig
         (
           visualizationType === 'map'
-            ? { type: 'map', layer_id: layer && layer.id }
+            ? { type: 'map', layer_id: layer && layer.id, zoom, ...latLng }
             : {}
         ),
         {

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -15,7 +15,9 @@ import {
   setFields,
   setBandsInfo,
   setVisualizationType,
-  setTitle
+  setTitle,
+  setZoom,
+  setLatLng
 } from 'components/widgets/editor/redux/widgetEditor';
 import { toggleModal } from 'redactions/modal';
 
@@ -72,14 +74,6 @@ const ALL_CHART_TYPES = {
     'pie',
     'scatter'
   ]
-};
-
-const mapConfig = {
-  zoom: 3,
-  latLng: {
-    lat: 0,
-    lng: 0
-  }
 };
 
 const DEFAULT_STATE = {
@@ -406,7 +400,7 @@ class WidgetEditor extends React.Component {
     } = this.state;
 
     const { widgetEditor, dataset, mode, selectedVisualizationType, user } = this.props;
-    const { chartType, layer } = widgetEditor;
+    const { chartType, layer, zoom, latLng } = widgetEditor;
 
     // Whether we are still waiting for some info
     const loading = (mode === 'dataset' && !layersLoaded) ||
@@ -489,6 +483,11 @@ class WidgetEditor extends React.Component {
       // Leaflet map
       case 'map':
         if (layer) {
+          const mapConfig = {
+            zoom,
+            latLng
+          };
+
           visualization = (
             <div className="visualization">
               {chartTitle}
@@ -496,6 +495,7 @@ class WidgetEditor extends React.Component {
                 LayerManager={LayerManager}
                 mapConfig={mapConfig}
                 layerGroups={this.state.layerGroups}
+                setMapParams={params => this.props.setMapParams(params)}
               />
 
               <MapControls>
@@ -1044,7 +1044,11 @@ const mapDispatchToProps = dispatch => ({
   setBandsInfo: bands => dispatch(setBandsInfo(bands)),
   setVisualizationType: vis => dispatch(setVisualizationType(vis)),
   toggleModal: (open, options) => dispatch(toggleModal(open, options)),
-  setTitle: title => dispatch(setTitle(title))
+  setTitle: title => dispatch(setTitle(title)),
+  setMapParams: (params) => {
+    dispatch(setZoom(params.zoom));
+    dispatch(setLatLng(params.latLng));
+  }
 });
 
 WidgetEditor.defaultProps = {
@@ -1075,7 +1079,8 @@ WidgetEditor.propTypes = {
   selectedVisualizationType: PropTypes.string,
   toggleModal: PropTypes.func,
   setBandsInfo: PropTypes.func,
-  setTitle: PropTypes.func
+  setTitle: PropTypes.func,
+  setMapParams: PropTypes.func
 };
 
 WidgetEditor.defaultProps = {

--- a/components/widgets/editor/map/Map.js
+++ b/components/widgets/editor/map/Map.js
@@ -46,6 +46,10 @@ class Map extends React.Component {
 
     this.map = L.map(this.mapNode, mapOptions);
 
+    if (this.props.setMapInstance) {
+      this.props.setMapInstance(this.map);
+    }
+
     if (this.props.mapConfig && this.props.mapConfig.bounds) {
       this.fitBounds(this.props.mapConfig.bounds.geometry);
     }
@@ -286,6 +290,7 @@ Map.defaultProps = {
 
 Map.propTypes = {
   interactionEnabled: PropTypes.bool.isRequired,
+  setMapInstance: PropTypes.func,
   // STORE
   basemap: PropTypes.object,
   labels: PropTypes.bool,

--- a/components/widgets/editor/modal/SaveWidgetModal.js
+++ b/components/widgets/editor/modal/SaveWidgetModal.js
@@ -84,7 +84,9 @@ class SaveWidgetModal extends React.Component {
       visualizationType,
       band,
       layer,
-      title
+      title,
+      zoom,
+      latLng
     } = widgetEditor;
 
     let chartConfig = {};
@@ -119,11 +121,11 @@ class SaveWidgetModal extends React.Component {
         // If the widget is a map, we want to add some extra info
         // in widgetConfig so the widget is compatible with other
         // apps that use the same API
-        // This info is not necessary for the editor because it is
-        // already saved in widgetConfig.paramsConfig
+        // The type and layer_id are not necessary for the editor
+        // because it is already saved in widgetConfig.paramsConfig
         (
           visualizationType === 'map'
-            ? { type: 'map', layer_id: layer && layer.id }
+            ? { type: 'map', layer_id: layer && layer.id, zoom, ...latLng }
             : {}
         ),
         {

--- a/components/widgets/editor/modal/ShareModalExplore.js
+++ b/components/widgets/editor/modal/ShareModalExplore.js
@@ -26,10 +26,20 @@ class ShareModal extends React.Component {
   }
 
   render() {
-    const { url, layerGroups } = this.props;
+    const { url, layerGroups, zoom, latLng } = this.props;
     const showEmbed = layerGroups && layerGroups.length > 0;
     const { protocol, hostname, port } = window && window.location ? window.location : {};
     const embedHost = window && window.location ? `${protocol}//${hostname}${port !== '' ? `:${port}` : port}` : '';
+
+    const embedParams = {
+      layers: JSON.stringify(layerGroups),
+      zoom,
+      latLng: JSON.stringify(latLng)
+    };
+
+    const embedSerializedParams = Object.keys(embedParams)
+      .map(k => `${k}=${encodeURIComponent(embedParams[k])}`)
+      .join('&');
 
     return (
       <div className="c-share-modal-explore">
@@ -71,7 +81,7 @@ class ShareModal extends React.Component {
                 <input
                   id="embed-url"
                   ref={(n) => { this.embedInput = n; }}
-                  value={`<iframe src="${embedHost}/embed/layers/?layers=${encodeURIComponent(JSON.stringify(layerGroups))}" width="100%" height="474px" frameBorder="0"></iframe>`}
+                  value={`<iframe src="${embedHost}/embed/layers/?${embedSerializedParams}" width="100%" height="474px" frameBorder="0"></iframe>`}
                   className="url"
                   readOnly
                 />
@@ -97,6 +107,11 @@ class ShareModal extends React.Component {
 ShareModal.propTypes = {
   url: PropTypes.string.isRequired,
   layerGroups: PropTypes.array,
+  zoom: PropTypes.number,
+  latLng: PropTypes.shape({
+    lat: PropTypes.number.isRequired,
+    lng: PropTypes.number.isRequired
+  }),
   toggleModal: PropTypes.func.isRequired
 };
 

--- a/components/widgets/editor/redux/widgetEditor.js
+++ b/components/widgets/editor/redux/widgetEditor.js
@@ -27,6 +27,8 @@ const SET_BAND = 'widgetEditor/SET_BAND';
 const SET_LAYER = 'widgetEditor/SET_LAYER';
 const SET_TITLE = 'widgetEditor/SET_TITLE';
 const SET_BANDS_INFO = 'widgetEditor/SET_BANDS_INFO';
+const SET_ZOOM = 'widgetEditor/SET_ZOOM';
+const SET_LATLNG = 'widgetEditor/SET_LATLNG';
 
 /**
  * REDUCER
@@ -48,7 +50,9 @@ const initialState = {
   areaIntersection: null, // ID of the geostore object
   band: null, // Band of the raster dataset
   /** @type {{ [name: string]: { type: string, alias: string, description: string } }} */
-  bandsInfo: {} // Information of the raster bands
+  bandsInfo: {}, // Information of the raster bands
+  zoom: 3,
+  latLng: { lat: 0, lng: 0 }
 };
 
 export default function (state = initialState, action) {
@@ -232,6 +236,18 @@ export default function (state = initialState, action) {
       });
     }
 
+    case SET_ZOOM: {
+      return Object.assign({}, state, {
+        zoom: action.payload
+      });
+    }
+
+    case SET_LATLNG: {
+      return Object.assign({}, state, {
+        latLng: action.payload
+      });
+    }
+
     default:
       return state;
   }
@@ -354,4 +370,12 @@ export function setLayer(layer) {
 
 export function setTitle(title) {
   return dispatch => dispatch({ type: SET_TITLE, payload: title });
+}
+
+export function setZoom(zoom) {
+  return dispatch => dispatch({ type: SET_ZOOM, payload: zoom });
+}
+
+export function setLatLng(latLng) {
+  return dispatch => dispatch({ type: SET_LATLNG, payload: latLng });
 }

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -430,6 +430,27 @@ class Explore extends Page {
     });
   }
 
+  /**
+   * Return the center of the map as the user sees it
+   * (if the sidebar is opened, the center is displaced)
+   * @returns { lat: number, lng: number }
+   */
+  getPerceivedMapCenter() {
+    const { explore } = this.props;
+
+    const isOpenedSidebar = explore.sidebar.open;
+    if (!isOpenedSidebar || !this.map) {
+      return explore.latLng;
+    }
+
+    const { latLng, sidebar } = explore;
+    const sidebarWidth = sidebar.width;
+    const center = this.map.latLngToContainerPoint([latLng.lat, latLng.lng]);
+    const newCenter = [center.x + sidebarWidth / 2, center.y];
+
+    return this.map.containerPointToLatLng(newCenter);
+  }
+
   render() {
     // It will render a list of links for AddSearch Bot
     if (this.props.botUserAgent) {
@@ -483,7 +504,7 @@ class Explore extends Page {
       >
         <div className="p-explore">
           <div className="c-page -dark">
-            <Sidebar>
+            <Sidebar ref={(node) => { this.sidebar = node; }}>
               <div className="row collapse">
                 <div className="column small-12">
                   <h1>Explore</h1>
@@ -618,12 +639,13 @@ class Explore extends Page {
                   mapConfig={{ zoom, latLng }}
                   layerGroups={this.props.layerGroups}
                   setMapParams={params => this.props.setMapParams(params)}
+                  setMapInstance={(map) => { this.map = map; }}
                 />
 
                 <MapControls>
                   <ShareControl
                     zoom={zoom}
-                    latLng={latLng}
+                    latLng={this.getPerceivedMapCenter()}
                     layerGroups={this.props.rawLayerGroups}
                   />
                   <BasemapControl />

--- a/pages/app/embed/EmbedLayer.js
+++ b/pages/app/embed/EmbedLayer.js
@@ -28,15 +28,16 @@ import { getLayerGroups } from 'selectors/explore/layersExplore';
 // Utils
 import LayerManager from 'components/widgets/editor/helpers/LayerManager';
 
-const mapConfig = {
-  zoom: 3,
-  latLng: {
-    lat: 0,
-    lng: 0
-  }
-};
-
 class EmbedLayer extends Page {
+  static async getInitialProps(...params) {
+    const props = await super.getInitialProps(...params);
+
+    if (props.url.query.zoom) props.zoom = +props.url.query.zoom;
+    if (props.url.query.latLng) props.latLng = JSON.parse(props.url.query.latLng);
+
+    return props;
+  }
+
   constructor(props) {
     super(props);
 
@@ -137,6 +138,8 @@ class EmbedLayer extends Page {
   }
 
   render() {
+    const { zoom, latLng } = this.props;
+
     return (
       <div className="c-embed-layer">
         <Head
@@ -159,7 +162,7 @@ class EmbedLayer extends Page {
             <div className="map-container">
               <Map
                 LayerManager={LayerManager}
-                mapConfig={mapConfig}
+                mapConfig={{ zoom, latLng }}
                 layerGroups={this.state.layerGroups}
               />
               <Legend
@@ -208,8 +211,18 @@ class EmbedLayer extends Page {
   }
 }
 
+EmbedLayer.defaultProps = {
+  zoom: 3,
+  latLng: { lat: 0, lng: 0 }
+};
+
 EmbedLayer.propTypes = {
   url: PropTypes.object.isRequired,
+  zoom: PropTypes.number,
+  latLng: PropTypes.shape({
+    lat: PropTypes.number.isRequired,
+    lng: PropTypes.number.isRequired
+  }),
 
   // Store
   modal: PropTypes.object,

--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -65,7 +65,7 @@ class EmbedMap extends Page {
   }
 
   render() {
-    const { widget, loading, layerGroups, error } = this.props;
+    const { widget, loading, layerGroups, error, zoom, latLng } = this.props;
     const { modalOpened } = this.state;
 
     if (loading) {
@@ -112,8 +112,6 @@ class EmbedMap extends Page {
       );
     }
 
-    const mapConfig = { zoom: 3, latLng: { lat: 0, lng: 0 } };
-
     return (
       <EmbedLayout
         title={`${widget.attributes.name}`}
@@ -135,7 +133,7 @@ class EmbedMap extends Page {
           <div className={classnames('widget-content', { '-external': this.isLoadedExternally() })}>
             <Map
               LayerManager={LayerManager}
-              mapConfig={mapConfig}
+              mapConfig={{ zoom, latLng }}
               layerGroups={layerGroups}
             />
 
@@ -177,7 +175,9 @@ EmbedMap.propTypes = {
   toggleLayerGroupVisibility: PropTypes.func,
   loading: PropTypes.bool,
   layerGroups: PropTypes.array,
-  error: PropTypes.string
+  error: PropTypes.string,
+  zoom: PropTypes.number,
+  latLng: PropTypes.object
 };
 
 EmbedMap.defaultProps = {
@@ -188,7 +188,9 @@ const mapStateToProps = state => ({
   widget: state.widget.data,
   loading: state.widget.loading,
   error: state.widget.error,
-  layerGroups: state.widget.layerGroups
+  layerGroups: state.widget.layerGroups,
+  zoom: state.widget.zoom,
+  latLng: state.widget.latLng
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/redactions/explore.js
+++ b/redactions/explore.js
@@ -35,6 +35,8 @@ const SET_TOPICS_TREE = 'explore/SET_TOPICS_TREE';
 const SET_DATA_TYPE_TREE = 'explore/SET_DATA_TYPE_TREE';
 const SET_GEOGRAPHIES_TREE = 'explore/SET_GEOGRAPHIES_TREE';
 
+const SET_ZOOM = 'explore/SET_ZOOM';
+const SET_LATLNG = 'explore/SET_LATLNG';
 const SET_BASEMAP = 'explore/SET_BASEMAP';
 const SET_LABELS = 'explore/SET_LABELS';
 
@@ -90,6 +92,8 @@ const initialState = {
     open: true,
     width: 0
   },
+  zoom: 3,
+  latLng: { lat: 0, lng: 0 },
   basemap: BASEMAPS.dark,
   basemapControl: {
     basemaps: BASEMAPS
@@ -277,6 +281,18 @@ export default function (state = initialState, action) {
       });
     }
 
+    case SET_ZOOM: {
+      return Object.assign({}, state, {
+        zoom: action.payload
+      });
+    }
+
+    case SET_LATLNG: {
+      return Object.assign({}, state, {
+        latLng: action.payload
+      });
+    }
+
     default:
       return state;
   }
@@ -288,6 +304,7 @@ export function setUrlParams() {
   return (dispatch, getState) => {
     const { explore } = getState();
     const layerGroups = explore.layers;
+    const { zoom, latLng } = explore;
     const { page } = explore.datasets;
     const { search, topics, dataType, geographies } = explore.filters;
 
@@ -323,6 +340,14 @@ export function setUrlParams() {
       } else {
         delete query.geographies;
       }
+    }
+
+    if (zoom) {
+      query.zoom = zoom;
+    }
+
+    if (latLng) {
+      query.latLng = JSON.stringify(latLng);
     }
 
     Router.replaceRoute('explore', query);
@@ -592,5 +617,24 @@ export function setLabels(labelEnabled) {
   return {
     type: SET_LABELS,
     payload: labelEnabled
+  };
+}
+
+
+export function setZoom(zoom, updateUrl = true) {
+  return (dispatch) => {
+    dispatch({ type: SET_ZOOM, payload: zoom });
+
+    // We also update the URL
+    if (updateUrl && typeof window !== 'undefined') dispatch(setUrlParams());
+  };
+}
+
+export function setLatLng(latLng, updateUrl = true) {
+  return (dispatch) => {
+    dispatch({ type: SET_LATLNG, payload: latLng });
+
+    // We also update the URL
+    if (updateUrl && typeof window !== 'undefined') dispatch(setUrlParams());
   };
 }

--- a/redactions/explore.js
+++ b/redactions/explore.js
@@ -247,7 +247,7 @@ export default function (state = initialState, action) {
 
     case SET_SIDEBAR: {
       return Object.assign({}, state, {
-        sidebar: action.payload
+        sidebar: Object.assign({}, state.sidebar, action.payload)
       });
     }
 

--- a/redactions/widget.js
+++ b/redactions/widget.js
@@ -18,6 +18,8 @@ const SET_WIDGET_DATASET = 'SET_WIDGET_DATASET';
 const SET_WIDGET_BAND_DESCRIPTION = 'SET_WIDGET_BAND_DESCRIPTION';
 const SET_WIDGET_BAND_STATS = 'SET_WIDGET_BAND_STATS';
 const SET_WIDGET_LAYERGROUPS = 'SET_WIDGET_LAYERGROUPS';
+const SET_WIDGET_ZOOM = 'SET_WIDGET_ZOOM';
+const SET_WIDGET_LATLNG = 'SET_WIDGET_LATLNG';
 
 /**
  * STORE
@@ -28,6 +30,8 @@ const initialState = {
   bandDescription: null, // Description of the band if a raster widget
   bandStats: {}, // Stats about the band if a raster widget
   layerGroups: [], // LayerGroups for the map widgets
+  zoom: 3,
+  latLng: { lat: 0, lng: 0 },
   loading: true, // Are we loading the data?
   error: null // An error was produced while loading the data
 };
@@ -94,6 +98,14 @@ export default function (state = initialState, action) {
         layerGroups: action.payload
       };
       return Object.assign({}, state, widget);
+    }
+
+    case SET_WIDGET_ZOOM: {
+      return Object.assign({}, state, { zoom: action.payload });
+    }
+
+    case SET_WIDGET_LATLNG: {
+      return Object.assign({}, state, { latLng: action.payload });
     }
 
     default:
@@ -182,6 +194,14 @@ function fetchLayer(datasetId, layerId) {
     });
 }
 
+export function setZoom(zoom) {
+  return dispatch => dispatch({ type: SET_WIDGET_ZOOM, payload: zoom });
+}
+
+export function setLatLng(latLng) {
+  return dispatch => dispatch({ type: SET_WIDGET_LATLNG, payload: latLng });
+}
+
 /**
  * Retrieve the list of widgets
  * @param {string} widgetId
@@ -211,6 +231,13 @@ export function getWidget(widgetId) {
         if (isMap) {
           const datasetId = data.attributes.dataset;
           const layerId = widgetConfig.paramsConfig && widgetConfig.paramsConfig.layer;
+          const zoom = widgetConfig.zoom;
+          const latLng = widgetConfig.lat && widgetConfig.lng
+            && { lat: widgetConfig.lat, lng: widgetConfig.lng };
+
+          if (zoom) dispatch(setZoom(zoom));
+          if (latLng) dispatch(setLatLng(latLng));
+
           return dispatch(fetchLayer(datasetId, layerId));
         }
 


### PR DESCRIPTION
This PR does a few things:
* it saves the position and zoom of the map in the editor so it is correctly restored when editing a widget or in the map embed
* it saves (and restores) the position and zoom of the Explore map in the URL
* it saves (and restores) the position and zoom of the Explore map when embedded

The last commit might be difficult to understand without context: in Explore, when the sidebar is opened and the user centres the map on Madrid, we want to be able to create an embedded map effectively centred on Madrid. Nevertheless, as the sidebar is on top of the map, the real centre is somewhere in the ocean (there's an horizontal offset). The commit adds a bit of code to compute the "perceived" centre of the map so, when shared, the map is centred on Madrid.

[Pivotal task](https://www.pivotaltracker.com/story/show/151950741)