### PR TITLE
Tooltip showing the description of the columns in the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] 2017-11-14
+
+### Fixed
+
+### Added
+- Description of the fields/columns in the editor
+
+### Changed
+
 ## [1.1.0] - 2017-10-11
 
 ### Fixed

--- a/components/widgets/editor/tooltip/ColumnDetails.js
+++ b/components/widgets/editor/tooltip/ColumnDetails.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class ColumnDetails extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+  }
+
+  componentDidMount() {
+    window.addEventListener('click', this.onClick);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('click', this.onClick);
+  }
+
+  /**
+   * Event handler executed when the user clicks
+   * somewhere in the page
+   */
+  onClick() {
+    this.props.onClose();
+  }
+
+  render() {
+    return (
+      <div // eslint-disable-line jsx-a11y/no-static-element-interactions
+        // We don't need to add any accessibility feature here
+        // because the event listener is just to prevent the
+        // tooltip from being closed
+        ref={(node) => { this.el = node; }}
+        className="c-column-details"
+        onClick={e => e.stopPropagation()}
+      >
+        <h4>{this.props.name}</h4>
+        <p>{this.props.description}</p>
+      </div>
+    );
+  }
+}
+
+ColumnDetails.defaultProps = {
+  description: 'No description is available.'
+};
+
+ColumnDetails.propTypes = {
+  name: PropTypes.string,
+  description: PropTypes.string,
+  onClose: PropTypes.func.isRequired
+};
+
+export default ColumnDetails;

--- a/components/widgets/editor/ui/ColumnBox.js
+++ b/components/widgets/editor/ui/ColumnBox.js
@@ -15,6 +15,7 @@ import Icon from 'components/widgets/editor/ui/Icon';
 import FilterTooltip from 'components/widgets/editor/tooltip/FilterTooltip';
 import AggregateFunctionTooltip from 'components/widgets/editor/tooltip/AggregateFunctionTooltip';
 import OrderByTooltip from 'components/widgets/editor/tooltip/OrderByTooltip';
+import ColumnDetails from 'components/widgets/editor/tooltip/ColumnDetails';
 
 // Utils
 import { isFieldAllowed } from 'components/widgets/editor/helpers/WidgetHelper';
@@ -165,6 +166,39 @@ class ColumnBox extends React.Component {
     }
   }
 
+  /**
+   * Event handler executed when the user clicks
+   * on the root element
+   * @param {MouseEvent} e - Event
+   * @returns
+   */
+  onClickColumn(e) {
+    if (!this.el || this.props.isA) return;
+
+    // Prevent the tooltip from automatically
+    // closing right after opening it
+    e.stopPropagation();
+
+    const rects = this.el.getBoundingClientRect();
+
+    const position = {
+      x: window.scrollX + rects.x + (rects.width / 2),
+      y: window.scrollY + rects.y + (rects.height / 2)
+    };
+
+    this.props.toggleTooltip(true, {
+      follow: false,
+      position,
+      direction: 'top',
+      children: ColumnDetails,
+      childrenProps: {
+        name: this.props.alias || this.props.name,
+        description: this.props.description,
+        onClose: () => this.props.toggleTooltip(false)
+      }
+    });
+  }
+
   @Autobind
   triggerClose() {
     const { isA } = this.props;
@@ -295,8 +329,17 @@ class ColumnBox extends React.Component {
 
   render() {
     const { aggregateFunction, aggregateFunctionSize, aggregateFunctionColor } = this.state;
-    const { isDragging, connectDragSource, name, alias, type, closable, configurable,
-      isA, widgetEditor } = this.props;
+    const {
+      isDragging,
+      connectDragSource,
+      name,
+      alias,
+      type,
+      closable,
+      configurable,
+      isA,
+      widgetEditor
+    } = this.props;
     const { orderBy } = widgetEditor;
 
     const orderType = orderBy ? orderBy.orderType : null;
@@ -319,9 +362,12 @@ class ColumnBox extends React.Component {
       (isA === 'orderBy');
 
     return connectDragSource(
-      <div
+      <div // eslint-disable-line jsx-a11y/no-static-element-interactions
+        // FIXME: which role to assign to the element to make it accessible?
         className={classNames({ 'c-columnbox': true, '-dimmed': isDragging })}
         title={alias || name}
+        onClick={e => this.onClickColumn(e)}
+        ref={(node) => { this.el = node; }}
       >
         <Icon
           name={iconName}
@@ -383,6 +429,7 @@ ColumnBox.propTypes = {
   datasetID: PropTypes.string,
   name: PropTypes.string,
   alias: PropTypes.string,
+  description: PropTypes.string,
   type: PropTypes.string,
   isA: PropTypes.string,
   closable: PropTypes.bool,

--- a/components/widgets/editor/ui/ColumnBox.js
+++ b/components/widgets/editor/ui/ColumnBox.js
@@ -177,11 +177,46 @@ class ColumnBox extends React.Component {
    * @param {MouseEvent} [e] - Event
    */
   onClickColumn(e) {
-    if (!this.el) return;
-
     // Prevent the tooltip from automatically
     // closing right after opening it
     if (e) e.stopPropagation();
+
+    this.detailsTooltipCloseOnMouseOut = false;
+    this.openDetailsTooltip();
+  }
+
+  /**
+   * Event handler executed when the user puts the
+   * cursor on top of the root element
+   */
+  onMouseOverColumn() {
+    this.detailsTooltipTimer = setTimeout(() => {
+      this.detailsTooltipCloseOnMouseOut = true;
+      this.openDetailsTooltip();
+    }, 1500);
+  }
+
+  /**
+   * Event handler executed when the user moves the
+   * cursor away from the root element
+   */
+  onMouseOutColumn() {
+    if (this.detailsTooltipTimer) {
+      clearTimeout(this.detailsTooltipTimer);
+      this.detailsTooltipTimer = null;
+    }
+
+    if (this.detailsTooltipCloseOnMouseOut) {
+      this.detailsTooltipCloseOnMouseOut = false;
+      this.closeDetailsTooltip();
+    }
+  }
+
+  /**
+   * Open the details tooltip
+   */
+  openDetailsTooltip() {
+    if (!this.el) return;
 
     const rects = this.el.getBoundingClientRect();
 
@@ -198,28 +233,16 @@ class ColumnBox extends React.Component {
       childrenProps: {
         name: this.props.alias || this.props.name,
         description: this.props.description,
-        onClose: () => this.props.toggleTooltip(false)
+        onClose: () => this.closeDetailsTooltip()
       }
     });
   }
 
   /**
-   * Event handler executed when the user puts the
-   * cursor on top of the root element
+   * Close the details tooltip
    */
-  onMouseOverColumn() {
-    this.detailsTooltipTimer = setTimeout(() => this.onClickColumn(), 1500);
-  }
-
-  /**
-   * Event handler executed when the user moves the
-   * cursor away from the root element
-   */
-  onMouseOutColumn() {
-    if (this.detailsTooltipTimer) {
-      clearTimeout(this.detailsTooltipTimer);
-      this.detailsTooltipTimer = null;
-    }
+  closeDetailsTooltip() {
+    this.props.toggleTooltip(false);
   }
 
   @Autobind

--- a/components/widgets/editor/ui/FieldsContainer.js
+++ b/components/widgets/editor/ui/FieldsContainer.js
@@ -16,6 +16,7 @@ const FieldsContainer = (props) => {
               type={val.columnType}
               datasetID={dataset}
               tableName={tableName}
+              description={val.description}
             />
           )
         )

--- a/css/components/widgets/column_details.scss
+++ b/css/components/widgets/column_details.scss
@@ -1,0 +1,14 @@
+.c-column-details {
+  width: 220px;
+
+  h4 {
+    margin-bottom: 5px;
+    line-height: 1.3;
+  }
+
+  p {
+    font-size: $font-size-normal;
+    line-height: 1.125;
+    color: $dove-grey;
+  }
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -125,6 +125,7 @@
 @import "./components/widgets/widget_editor";
 @import "./components/widgets/columnbox";
 @import "./components/widgets/column_container";
+@import "./components/widgets/column_details";
 @import "./components/widgets/dimensions_container";
 @import "./components/widgets/filter_container";
 @import "./components/widgets/filter_tooltip";


### PR DESCRIPTION
This PR lets the users click the columns of the editor to get some information about them. The tooltip is only shown when the user clicks the columns outside of the containers "Category," "Value", "Filters", etc. to avoid too much interaction in a tiny space.

<p align="center">
<img width="551" alt="A tooltip is shown below the column with its description inside" src="https://user-images.githubusercontent.com/6073968/31766366-435157f2-b4bf-11e7-9c99-5928de9aeb13.png">
</p>

You can test the feature with the following datasets:
- `c465b42e-8c22-4dcb-9838-f6447393e28d`
- `d02df2f6-d80c-4274-bb6f-f062061655c4`

[Pivotal task](https://www.pivotaltracker.com/story/show/150545675)