### PR TITLE
Replace the editor's advanced mode templates

### DIFF
--- a/components/admin/widgets/form/constants.js
+++ b/components/admin/widgets/form/constants.js
@@ -1,6 +1,6 @@
-import bar from 'utils/widgets/bar.json';
-import pie from 'utils/widgets/pie.json';
-import line from 'utils/widgets/line.json';
+import bar from 'components/widgets/editor/helpers/bar';
+import pie from 'components/widgets/editor/helpers/pie';
+import line from 'components/widgets/editor/helpers/line';
 
 
 export const STATE_DEFAULT = {
@@ -46,9 +46,9 @@ export const FORM_ELEMENTS = {
 };
 
 export const CONFIG_TEMPLATE = {
-  bar,
-  line,
-  pie
+  bar: bar({ templateMode: true }),
+  line: line({ templateMode: true }),
+  pie: pie({ templateMode: true })
 };
 
 export const CONFIG_TEMPLATE_OPTIONS = [

--- a/components/widgets/editor/helpers/bar.js
+++ b/components/widgets/editor/helpers/bar.js
@@ -171,7 +171,6 @@ const defaultChart = {
           "tickSizeEnd": 0,
           "offset": 5,
           "properties": {"axis": {"strokeWidth": {"value": 0}}},
-          "name": "Total co2 emmissions",
           "grid": "true"
         }
       ]
@@ -202,10 +201,13 @@ const defaultChart = {
  * Return the Vega chart configuration
  *
  * @export
- * @param {any} { columns, data, url, embedData, provider, band }
+ * @param {any} { columns, data, url, embedData, provider, band, templateMode }
  */
-export default function ({ columns, data, url, embedData, provider, band  }) {
+export default function ({ columns, data, url, embedData, provider, band, templateMode  }) {
   const config = deepClone(defaultChart);
+
+  // Simple template used in the advanced mode of the editor
+  if (templateMode) return config;
 
   if (embedData) {
     // We directly set the data

--- a/components/widgets/editor/helpers/line.js
+++ b/components/widgets/editor/helpers/line.js
@@ -70,10 +70,13 @@ const defaultChart = {
  * Return the Vega chart configuration
  *
  * @export
- * @param {any} { columns, data, url, embedData }
+ * @param {any} { columns, data, url, embedData, templateMode }
  */
-export default function ({ columns, data, url, embedData }) {
+export default function ({ columns, data, url, embedData, templateMode }) {
   const config = deepClone(defaultChart);
+
+  // Simple template used in the advanced mode of the editor
+  if (templateMode) return config;
 
   if (embedData) {
     // We directly set the data

--- a/components/widgets/editor/helpers/pie.js
+++ b/components/widgets/editor/helpers/pie.js
@@ -141,10 +141,13 @@ const defaultChart = {
  * Return the Vega chart configuration
  *
  * @export
- * @param {any} { columns, data, url, embedData }
+ * @param {any} { columns, data, url, embedData, templateMode }
  */
-export default function ({ columns, data, url, embedData }) {
+export default function ({ columns, data, url, embedData, templateMode }) {
   const config = deepClone(defaultChart);
+
+  // Simple template used in the advanced mode of the editor
+  if (templateMode) return config;
 
   if (embedData) {
     // We directly set the data


### PR DESCRIPTION
This PR replaces the templates of the editor's advanced mode by the basic templates used in the editor.

The two reasons behind the change are:
- having the advanced mode in sync with the generated charts
- having thumbnail-ready custom charts

This change is part of a broader task that includes more information on how to customise the charts in the advanced mode:
[Pivotal task (first point)](https://www.pivotaltracker.com/story/show/152108957)