### PR TITLE
Let the user download a widget as a PDF

### DIFF
--- a/components/widgets/list/WidgetActionsTooltip.js
+++ b/components/widgets/list/WidgetActionsTooltip.js
@@ -35,6 +35,8 @@ class WidgetActionsTooltip extends React.Component {
       case 'share_embed':
         this.props.onShareEmbed();
         break;
+      case 'download_pdf':
+        this.props.onDownloadPDF();
     }
     this.props.toggleTooltip(false);
   }
@@ -63,6 +65,11 @@ class WidgetActionsTooltip extends React.Component {
               Go to dataset
             </button>
           </li>
+          <li>
+            <button onClick={() => this.handleClick('download_pdf')}>
+              Download as PDF
+            </button>
+          </li>
         </ul>
       </div>
     );
@@ -75,7 +82,8 @@ WidgetActionsTooltip.propTypes = {
   onGoToDataset: PropTypes.func.isRequired,
   onAddToDashboard: PropTypes.func.isRequired,
   onShareEmbed: PropTypes.func.isRequired,
-  onEditWidget: PropTypes.func.isRequired
+  onEditWidget: PropTypes.func.isRequired,
+  onDownloadPDF: PropTypes.func.isRequired
 };
 
 export default WidgetActionsTooltip;

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -300,6 +300,22 @@ class WidgetCard extends React.Component {
   }
 
   @Autobind
+  handleDownloadPDF() {
+    toastr.info('Widget download', 'The file is being generated...');
+
+    const id = this.props.widget.id;
+    const type = this.props.widget.attributes.widgetConfig.type || 'widget';
+    const { protocol, hostname, port } = window.location;
+    const host = `${protocol}//${hostname}${port !== '' ? `:${port}` : port}`;
+
+    const link = document.createElement('a');
+    link.setAttribute('download', '');
+    link.href = `${process.env.CONTROL_TOWER_URL}/v1/webshot/pdf?filename=widget-${id}&width=790&height=580&url=${host}/embed/${type}/${id}`;
+
+    link.click();
+  }
+
+  @Autobind
   handleWidgetActionsClick(event) {
     const position = WidgetCard.getClickPosition(event);
     this.props.toggleTooltip(true, {
@@ -311,7 +327,8 @@ class WidgetCard extends React.Component {
         onShareEmbed: this.handleEmbed,
         onAddToDashboard: this.handleAddToDashboard,
         onGoToDataset: this.handleGoToDataset,
-        onEditWidget: this.handleEditWidget
+        onEditWidget: this.handleEditWidget,
+        onDownloadPDF: this.handleDownloadPDF
       }
     });
   }

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -313,7 +313,10 @@ class WidgetCard extends React.Component {
     link.setAttribute('download', '');
     link.href = `${process.env.CONTROL_TOWER_URL}/v1/webshot/pdf?filename=${filename}&width=790&height=580&url=${host}/embed/${type}/${id}`;
 
-    link.click();
+    // link.click() doesn't work on Firefox for some reasons
+    // so we have to create an event manually
+    const event = new MouseEvent('click');
+    link.dispatchEvent(event);
   }
 
   @Autobind

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -307,10 +307,11 @@ class WidgetCard extends React.Component {
     const type = this.props.widget.attributes.widgetConfig.type || 'widget';
     const { protocol, hostname, port } = window.location;
     const host = `${protocol}//${hostname}${port !== '' ? `:${port}` : port}`;
+    const filename = encodeURIComponent(this.props.widget.attributes.name);
 
     const link = document.createElement('a');
     link.setAttribute('download', '');
-    link.href = `${process.env.CONTROL_TOWER_URL}/v1/webshot/pdf?filename=widget-${id}&width=790&height=580&url=${host}/embed/${type}/${id}`;
+    link.href = `${process.env.CONTROL_TOWER_URL}/v1/webshot/pdf?filename=${filename}&width=790&height=580&url=${host}/embed/${type}/${id}`;
 
     link.click();
   }


### PR DESCRIPTION
Everything's in the title 😉.

<p align="center">
<img width="327" alt="Dropdown menu with a new item 'Download as PDF'" src="https://user-images.githubusercontent.com/6073968/31891492-7eb06e0e-b7fe-11e7-8f78-7603c5baf240.png">
</p>

In My RW, the user has a new action to download a PDF of the widget. The file is generated with its embed page.

[Pivotal task](https://www.pivotaltracker.com/story/show/151872468)