### PR TITLE
Let the user sort the datasets in Explore

### DIFF
--- a/components/app/explore/DatasetListHeader.js
+++ b/components/app/explore/DatasetListHeader.js
@@ -1,10 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
+// Components
 import Button from 'components/ui/Button';
 import Icon from 'components/ui/Icon';
-import { connect } from 'react-redux';
+import SelectInput from 'components/widgets/editor/form/SelectInput';
 
-import { setDatasetsMode } from 'redactions/explore';
+// Redux
+import { connect } from 'react-redux';
+import { setDatasetsMode, setDatasetsSorting } from 'redactions/explore';
+
+const SORTING_OPTIONS = [
+  { value: 'modified', label: 'Last modified' },
+  { value: 'viewed', label: 'Most viewed' },
+  { value: 'favorited', label: 'Most favorited' }
+];
 
 class DatasetListHeader extends React.Component {
   constructor(props) {
@@ -38,6 +48,7 @@ class DatasetListHeader extends React.Component {
 
   render() {
     const { mode, list } = this.state;
+    const { sortingOrder } = this.props;
 
     return (
       <div className="c-dataset-list-header">
@@ -45,6 +56,19 @@ class DatasetListHeader extends React.Component {
           {list.length} datasets
         </div>
         <div className="actions">
+          <div className="sorting-container">
+            <SelectInput
+              id="explore-sorting"
+              properties={{
+                name: 'explore-sorting',
+                value: sortingOrder,
+                default: sortingOrder,
+                clearable: false
+              }}
+              options={SORTING_OPTIONS}
+              onChange={sorting => this.props.setDatasetsSorting(sorting)}
+            />
+          </div>
           <div className="mode-container">
             <Button
               properties={{
@@ -78,14 +102,19 @@ DatasetListHeader.propTypes = {
   // STATE
   mode: PropTypes.string,
   list: PropTypes.array,
+  sortingOrder: PropTypes.string,
   // ACTIONS
-  setDatasetsMode: PropTypes.func
+  setDatasetsMode: PropTypes.func,
+  setDatasetsSorting: PropTypes.func
 };
 
-const mapDispatchToProps = dispatch => ({
-  setDatasetsMode: (mode) => {
-    dispatch(setDatasetsMode(mode));
-  }
+const mapStateToProps = ({ explore }) => ({
+  sortingOrder: explore.sorting.order
 });
 
-export default connect(null, mapDispatchToProps)(DatasetListHeader);
+const mapDispatchToProps = dispatch => ({
+  setDatasetsMode: mode => dispatch(setDatasetsMode(mode)),
+  setDatasetsSorting: sorting => dispatch(setDatasetsSorting(sorting))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(DatasetListHeader);

--- a/css/components/app/explore/dataset_list_header.scss
+++ b/css/components/app/explore/dataset_list_header.scss
@@ -1,28 +1,27 @@
 .c-dataset-list-header {
-  margin: $space-1 * 2 0 0;
+  margin: $space-1 * 2 0 $space-1;
   display: flex;
+  align-items: flex-end;
   justify-content: space-between;
-
-  .total {
-    margin: 13px 0 0 6px;
-  }
 
   .actions {
     display: flex;
-    justify-content: flex-start;
-  }
+    align-items: center;
 
-  button{
+    button {
+      fill: $color-grey;
 
-    fill: $color-grey;
+      &:hover {
+        fill: $color-black;
+      }
 
-    &:hover {
-      fill: $color-black;
+      &.-active {
+        fill: $color-black;
+      }
     }
 
-    &.-active {
-      fill: $color-black;
+    .sorting-container {
+      margin-right: $space-1;
     }
-
   }
 }

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -31,7 +31,8 @@ import {
   setGeographiesTree,
   setDataTypeTree,
   setZoom,
-  setLatLng
+  setLatLng,
+  setDatasetsSorting
 } from 'redactions/explore';
 import { redirectTo } from 'redactions/common';
 import { toggleModal, setModalOptions } from 'redactions/modal';
@@ -155,6 +156,10 @@ class Explore extends Page {
 
     if (query.dataType) {
       this.props.setDatasetsDataTypeFilter(JSON.parse(query.dataType));
+    }
+
+    if (query.sort) {
+      this.props.setDatasetsSorting(query.sort);
     }
 
     this.props.getDatasets({});
@@ -701,6 +706,7 @@ Explore.propTypes = {
   setTopicsTree: PropTypes.func.isRequired,
   setDataTypeTree: PropTypes.func.isRequired,
   setGeographiesTree: PropTypes.func.isRequired,
+  setDatasetsSorting: PropTypes.func.isRequired,
 
   // Toggle the visibility of a layer group based on the layer passed as argument
   toggleLayerGroupVisibility: PropTypes.func.isRequired,
@@ -757,7 +763,8 @@ const mapDispatchToProps = dispatch => ({
   setMapParams: debounce((params) => { // Debounce for performance reasons
     dispatch(setZoom(params.zoom));
     dispatch(setLatLng(params.latLng));
-  }, 1000)
+  }, 1000),
+  setDatasetsSorting: sorting => dispatch(setDatasetsSorting(sorting))
 });
 
 export default withRedux(initStore, mapStateToProps, mapDispatchToProps)(Explore);

--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -102,6 +102,7 @@ class ExploreDetail extends Page {
     this.getSimilarDatasets();
     this.getFavoriteDatasets();
     this.loadTopicsTree();
+    this.countView(this.props.url.query.id);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -119,6 +120,8 @@ class ExploreDetail extends Page {
         this.getDataset();
         this.getSimilarDatasets();
       });
+
+      this.countView(nextProps.url.query.id);
     }
   }
 
@@ -255,6 +258,14 @@ class ExploreDetail extends Page {
       if (chartType) this.props.setChartType(chartType);
       if (name) this.props.setTitle(name);
     }
+  }
+
+  /**
+   * Gather the number of views of this dataset
+   * @param {string} datasetId Dataset ID
+   */
+  countView(datasetId) {
+    this.graphService.countDatasetView(datasetId, this.props.user.token);
   }
 
   /**

--- a/redactions/explore.js
+++ b/redactions/explore.js
@@ -1,9 +1,11 @@
 /* global config */
 import 'isomorphic-fetch';
 import { Router } from 'routes';
+import { toastr } from 'react-redux-toastr';
 
 // Services
 import UserService from 'services/UserService';
+import GraphService from 'services/GraphService';
 
 import { BASEMAPS } from 'components/widgets/editor/map/constants';
 
@@ -27,6 +29,10 @@ const SET_DATASETS_TOPICS_FILTER = 'explore/SET_DATASETS_TOPICS_FILTER';
 const SET_DATASETS_DATA_TYPE_FILTER = 'explore/SET_DATASETS_DATA_TYPE_FILTER';
 const SET_DATASETS_GEOGRAPHIES_FILTER = 'explore/SET_DATASETS_GEOGRAPHIES_FILTER';
 const SET_FILTERS_LOADING = 'explore/SET_FILTERS_LOADING';
+
+const SET_SORTING_ORDER = 'explore/SET_SORTING_ORDER';
+const SET_SORTING_DATASETS = 'explore/SET_SORTING_DATASETS';
+const SET_SORTING_LOADING = 'explore/SET_SORTING_LOADING';
 
 const SET_DATASETS_FILTERED_BY_CONCEPTS = 'explore/SET_DATASETS_FILTERED_BY_CONCEPTS';
 
@@ -112,7 +118,16 @@ const initialState = {
   geographiesTree: null,
   topicsTree: null,
   dataTypeTree: null,
-  labels: false
+  labels: false,
+  sorting: {
+    /** @type {'modified'|'viewed'|'favorited'} order */
+    order: 'modified',
+    // The list of datasets below is not the actual list of sorted
+    // datasets, it is the list of the sorted ids
+    /** @type {string[]} */
+    datasets: [],
+    loading: false
+  }
 };
 
 export default function (state = initialState, action) {
@@ -342,6 +357,24 @@ export default function (state = initialState, action) {
     case SET_LATLNG: {
       return Object.assign({}, state, {
         latLng: action.payload
+      });
+    }
+
+    case SET_SORTING_ORDER: {
+      return Object.assign({}, state, {
+        sorting: Object.assign({}, state.sorting, { order: action.payload })
+      });
+    }
+
+    case SET_SORTING_DATASETS: {
+      return Object.assign({}, state, {
+        sorting: Object.assign({}, state.sorting, { datasets: action.payload })
+      });
+    }
+
+    case SET_SORTING_LOADING: {
+      return Object.assign({}, state, {
+        sorting: Object.assign({}, state.sorting, { loading: action.payload })
       });
     }
 
@@ -658,6 +691,46 @@ export function setDatasetsMode(mode) {
   return {
     type: SET_DATASETS_MODE,
     payload: mode
+  };
+}
+
+/**
+ * Set the sorting order of the datasets
+ * @param {'modified'|'viewed'|'favorited'} sorting
+ */
+export function setDatasetsSorting(sorting) {
+  return (dispatch) => {
+    const graphService = new GraphService({ apiURL: process.env.WRI_API_URL });
+
+    let promise = null;
+    switch (sorting) {
+      case 'viewed':
+        promise = graphService.getMostViewedDatasets();
+        break;
+
+      case 'favorited':
+        promise = graphService.getMostFavoritedDatasets();
+        break;
+
+      default:
+        break;
+    }
+
+    if (!promise) {
+      dispatch({ type: SET_SORTING_ORDER, payload: sorting });
+      dispatch({ type: SET_SORTING_DATASETS, payload: [] });
+    } else {
+      dispatch({ type: SET_SORTING_LOADING, payload: true });
+      dispatch({ type: SET_SORTING_ORDER, payload: sorting });
+
+      promise
+        .then(datasets => dispatch({ type: SET_SORTING_DATASETS, payload: datasets }))
+        .catch((err) => {
+          toastr.error('Dataset sorting', 'The datasets couldn\'t be sorted properly');
+          console.error(err);
+        })
+        .then(() => dispatch({ type: SET_SORTING_LOADING, payload: false }));
+    }
   };
 }
 

--- a/redactions/explore.js
+++ b/redactions/explore.js
@@ -389,7 +389,7 @@ export function setUrlParams() {
   return (dispatch, getState) => {
     const { explore } = getState();
     const layerGroups = explore.layers;
-    const { zoom, latLng } = explore;
+    const { zoom, latLng, sorting } = explore;
     const { page } = explore.datasets;
     const { search, topics, dataType, geographies } = explore.filters;
 
@@ -433,6 +433,10 @@ export function setUrlParams() {
 
     if (latLng) {
       query.latLng = JSON.stringify(latLng);
+    }
+
+    if (sorting) {
+      query.sort = sorting.order;
     }
 
     Router.replaceRoute('explore', query);
@@ -731,6 +735,9 @@ export function setDatasetsSorting(sorting) {
         })
         .then(() => dispatch({ type: SET_SORTING_LOADING, payload: false }));
     }
+
+    // We also update the URL
+    if (typeof window !== 'undefined') dispatch(setUrlParams());
   };
 }
 

--- a/selectors/explore/filterDatasets.js
+++ b/selectors/explore/filterDatasets.js
@@ -24,7 +24,7 @@ const getSortedDatasets = (datasets, sorting) => {
     return datasets;
   }
 
-  return datasets.sort((a, b) => {
+  return [...datasets].sort((a, b) => {
     const aPos = sorting.datasets.indexOf(a.id);
     const bPos = sorting.datasets.indexOf(b.id);
 

--- a/selectors/explore/filterDatasets.js
+++ b/selectors/explore/filterDatasets.js
@@ -25,8 +25,8 @@ const getSortedDatasets = (datasets, sorting) => {
   }
 
   return datasets.sort((a, b) => {
-    const aPos = sorting.datasets.indexOf(a);
-    const bPos = sorting.datasets.indexOf(b);
+    const aPos = sorting.datasets.indexOf(a.id);
+    const bPos = sorting.datasets.indexOf(b.id);
 
     if (aPos === -1 && bPos === -1) return 0;
     if (aPos === -1 && bPos !== -1) return 1;

--- a/services/GraphService.js
+++ b/services/GraphService.js
@@ -73,4 +73,30 @@ export default class GraphService {
     })
       .then(res => res.json());
   }
+
+  /**
+   * Get the list of most viewed datasets
+   * @returns {Promise<string[]>} List of sorted ids
+   */
+  getMostViewedDatasets() {
+    return fetch(`${this.opts.apiURL}/graph/query/most-viewed`)
+      .then((res) => {
+        if (res.ok) return res.json();
+        throw new Error('Unable to fetch the most viewed datasets');
+      })
+      .then(res => res.data.map(d => d.dataset));
+  }
+
+  /**
+   * Get the list of most favorited datasets
+   * @returns {Promise<string[]>} List of sorted ids
+   */
+  getMostFavoritedDatasets() {
+    return fetch(`${this.opts.apiURL}/graph/query/most-liked-datasets`)
+      .then((res) => {
+        if (res.ok) return res.json();
+        throw new Error('Unable to fetch the most favorited datasets');
+      })
+      .then(res => res.data.map(d => d.id));
+  }
 }

--- a/services/GraphService.js
+++ b/services/GraphService.js
@@ -53,4 +53,24 @@ export default class GraphService {
       .then(response => response.json())
       .then(jsonData => jsonData.data);
   }
+
+  /**
+   * Send a request to count a view to the dataset
+   * @param {string} datasetId Dataset ID
+   * @param {string} [token] User token
+   * @returns {Promise<void>}
+   */
+  countDatasetView(datasetId, token) {
+    const headers = {};
+
+    if (token) {
+      headers.Authorization = token;
+    }
+
+    return fetch(`${this.opts.apiURL}/graph/dataset/${datasetId}/visited`, {
+      method: 'POST',
+      headers
+    })
+      .then(res => res.json());
+  }
 }


### PR DESCRIPTION
This PR lets the user sort the datasets in Explore by last modified date (default), most viewed or most favourited. Anytime the user changes the sorting order, the URL is updated so it can be restored later.

In addition, every time a user visits the Explore details page, a query is made to count a view to the dataset.

<img width="821" alt="Filters of the datasets with a selector for the sorting order" src="https://user-images.githubusercontent.com/6073968/32492533-87a6280e-c3b2-11e7-8a88-f4690eafb590.png">

While testing, I noted that the endpoints used to get the order of the datasets are returning a small number of datasets which aren't displayed in Explore, so changing the sorting order won't actually change the cards order.

@pablopareja Any idea why we don't get useful answers?

[Pivotal task 1](https://www.pivotaltracker.com/story/show/152429987)
[Pivotal task 2](https://www.pivotaltracker.com/story/show/152429883)