### PR TITLE
Use Transifex' locale in the some endpoints

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
   },
   "globals": {
     "L": true,
-    "config": true
+    "config": true,
+    "Transifex": true
   },
   "extends": "vizzuality",
   "rules": {

--- a/components/admin/layers/form/LayersForm.js
+++ b/components/admin/layers/form/LayersForm.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+// Redux
+import { connect } from 'react-redux';
+
 // Services
 import DatasetsService from 'services/DatasetsService';
 import LayersService from 'services/LayersService';
@@ -35,7 +38,8 @@ class LayersForm extends React.Component {
 
     // Service
     this.datasetsService = new DatasetsService({
-      authorization: props.authorization
+      authorization: props.authorization,
+      language: props.locale
     });
 
     this.service = new LayersService({
@@ -204,7 +208,12 @@ LayersForm.propTypes = {
   dataset: PropTypes.string,
   authorization: PropTypes.string,
   application: PropTypes.array,
-  onSubmit: PropTypes.func
+  onSubmit: PropTypes.func,
+  locale: PropTypes.string.isRequired
 };
 
-export default LayersForm;
+const mapStateToProps = state => ({
+  locale: state.common.locale
+});
+
+export default connect(mapStateToProps, null)(LayersForm);

--- a/components/admin/metadata/form/MetadataForm.js
+++ b/components/admin/metadata/form/MetadataForm.js
@@ -38,7 +38,8 @@ class MetadataForm extends React.Component {
     });
 
     this.service = new DatasetsService({
-      authorization: props.authorization
+      authorization: props.authorization,
+      language: props.locale
     });
 
     this.state = newState;
@@ -212,10 +213,13 @@ MetadataForm.propTypes = {
   authorization: PropTypes.string.isRequired,
   onSubmit: PropTypes.func,
   setSources: PropTypes.func,
-  resetSources: PropTypes.func
+  resetSources: PropTypes.func,
+  locale: PropTypes.string.isRequired
 };
 
-const mapStateToProps = () => ({});
+const mapStateToProps = state => ({
+  locale: state.common.locale
+});
 
 const mapDispatchToProps = dispatch => ({
   setSources: sources => dispatch(setSources(sources)),

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -66,7 +66,8 @@ class WidgetsForm extends React.Component {
     });
 
     this.datasetsService = new DatasetsService({
-      authorization: props.authorization
+      authorization: props.authorization,
+      language: props.locale
     });
   }
 
@@ -405,6 +406,7 @@ WidgetsForm.propTypes = {
   dataset: PropTypes.string, // ID of the dataset that should be pre-selected
   // Store
   widgetEditor: PropTypes.object,
+  locale: PropTypes.string.isRequired,
   // ACTIONS
   setFilters: PropTypes.func.isRequired,
   setSize: PropTypes.func.isRequired,
@@ -452,7 +454,8 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => ({
-  widgetEditor: state.widgetEditor
+  widgetEditor: state.widgetEditor,
+  locale: state.common.locale
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(WidgetsForm);

--- a/components/app/layout/Layout.js
+++ b/components/app/layout/Layout.js
@@ -8,6 +8,7 @@ import { bindActionCreators } from 'redux';
 import { toggleModal, setModalOptions } from 'redactions/modal';
 import { toggleTooltip } from 'redactions/tooltip';
 import { updateIsLoading } from 'redactions/page';
+import { setLocale } from 'redactions/common';
 
 // Components
 import { Router } from 'routes';
@@ -57,6 +58,10 @@ class Layout extends React.Component {
       this.props.updateIsLoading(false);
       if (Progress && Progress.Component.instance) Progress.hideAll();
     };
+
+    Transifex.live.onReady(() => {
+      Transifex.live.onTranslatePage(locale => this.props.setLocale(locale));
+    });
   }
 
   componentWillReceiveProps(newProps) {
@@ -128,7 +133,8 @@ Layout.propTypes = {
   toggleModal: PropTypes.func,
   toggleTooltip: PropTypes.func,
   setModalOptions: PropTypes.func,
-  updateIsLoading: PropTypes.func
+  updateIsLoading: PropTypes.func,
+  setLocale: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
@@ -140,7 +146,8 @@ const mapDispatchToProps = dispatch => ({
   toggleTooltip: () => dispatch(toggleTooltip()),
   toggleModal: open => dispatch(toggleModal(open, {}, true)),
   setModalOptions: options => dispatch(setModalOptions(options)),
-  updateIsLoading: bindActionCreators(isLoading => updateIsLoading(isLoading), dispatch)
+  updateIsLoading: bindActionCreators(isLoading => updateIsLoading(isLoading), dispatch),
+  setLocale: locale => dispatch(setLocale(locale))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Layout);

--- a/components/app/layout/Layout.js
+++ b/components/app/layout/Layout.js
@@ -61,7 +61,10 @@ class Layout extends React.Component {
 
     if (Transifex) {
       Transifex.live.onReady(() => {
-        Transifex.live.onTranslatePage(locale => this.props.setLocale(locale));
+        Transifex.live.onTranslatePage((locale) => {
+          this.props.setLocale(locale);
+          location.reload();
+        });
       });
     }
   }

--- a/components/app/layout/Layout.js
+++ b/components/app/layout/Layout.js
@@ -59,9 +59,11 @@ class Layout extends React.Component {
       if (Progress && Progress.Component.instance) Progress.hideAll();
     };
 
-    Transifex.live.onReady(() => {
-      Transifex.live.onTranslatePage(locale => this.props.setLocale(locale));
-    });
+    if (Transifex) {
+      Transifex.live.onReady(() => {
+        Transifex.live.onTranslatePage(locale => this.props.setLocale(locale));
+      });
+    }
   }
 
   componentWillReceiveProps(newProps) {

--- a/components/app/layout/head.js
+++ b/components/app/layout/head.js
@@ -30,27 +30,26 @@ class Head extends React.PureComponent {
     /* eslint-enable */
   }
 
-  getGA() {
-    return <script async src="https://www.googletagmanager.com/gtag/js?id=UA-67196006-1"></script>;
+  static getGA() {
+    return <script async src="https://www.googletagmanager.com/gtag/js?id=UA-67196006-1" />;
   }
 
-  getGASettings() {
+  static getGASettings() {
     return (
       <script
         type="text/javascript"
-        /* eslint-disable */
+        // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: `
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
           gtag('config', 'UA-67196006-1');
         ` }}
-        /* eslint-enable */
       />);
   }
 
-  getCrazyEgg() {
-    return <script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0069/4623.js" async="async"></script>;
+  static getCrazyEgg() {
+    return <script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0069/4623.js" async="async" />;
   }
 
 
@@ -62,9 +61,9 @@ class Head extends React.PureComponent {
     }
 
     return (
-      /* eslint-disable */
       <script
         type="text/javascript"
+        // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: `
           window._urq = window._urq || [];
           _urq.push(['setGACode', 'UA-67196006-1']);
@@ -76,7 +75,6 @@ class Head extends React.PureComponent {
           })();
         ` }}
       />
-      /* eslint-enable */
     );
   }
 
@@ -91,11 +89,10 @@ class Head extends React.PureComponent {
     return (
       <script
         type="text/javascript"
-        /* eslint-disable */
+        // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: `
           window.liveSettings = { api_key: '${TRANSIFEX_LIVE_API}' }
         ` }}
-        /* eslint-enable */
       />
     );
   }
@@ -159,9 +156,9 @@ class Head extends React.PureComponent {
         <link rel="stylesheet" media="screen" href="https://fonts.googleapis.com/css?family=Lato:400,300,700" />
         {Head.getStyles()}
         {this.getCesiumStyles()}
-        {this.getGA()}
-        {this.getGASettings()}
-        {this.getCrazyEgg()}
+        {Head.getGA()}
+        {Head.getGASettings()}
+        {Head.getCrazyEgg()}
         {this.getUserReport()}
         {this.getTransifexSettings()}
         {this.getTransifex()}
@@ -178,7 +175,8 @@ Head.propTypes = {
   title: PropTypes.string, // Some pages don't have any title (think embed)
   description: PropTypes.string.isRequired,
   routes: PropTypes.object.isRequired,
-  category: PropTypes.string
+  category: PropTypes.string,
+  dataset: PropTypes.object
 };
 
 export default connect(

--- a/components/app/myrw/datasets/MyRWDatasetsStarred.js
+++ b/components/app/myrw/datasets/MyRWDatasetsStarred.js
@@ -41,7 +41,7 @@ class MyRWDatasetsStarred extends React.Component {
       .then((response) => {
         const favorites = response;
         const datasetIds = favorites.map(elem => elem.attributes.resourceId);
-        DatasetService.getDatasets(datasetIds, 'widget,layer,vocabulary,metadata')
+        DatasetService.getDatasets(datasetIds, this.props.locale, 'widget,layer,vocabulary,metadata')
           .then((resp) => {
             this.setState({
               favorites,
@@ -100,11 +100,13 @@ class MyRWDatasetsStarred extends React.Component {
 
 MyRWDatasetsStarred.propTypes = {
   // Store
-  user: PropTypes.object.isRequired
+  user: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
 const mapStateToProps = state => ({
-  user: state.user
+  user: state.user,
+  locale: state.common.locale
 });
 
 export default connect(mapStateToProps, null)(MyRWDatasetsStarred);

--- a/components/app/myrw/datasets/pages/show.js
+++ b/components/app/myrw/datasets/pages/show.js
@@ -45,7 +45,9 @@ class DatasetsShow extends React.Component {
       data: {}
     };
 
-    this.service = new DatasetsService();
+    this.service = new DatasetsService({
+      language: props.locale
+    });
   }
 
   componentDidMount() {
@@ -135,11 +137,13 @@ DatasetsShow.propTypes = {
   subtab: PropTypes.string,
 
   // Store
-  user: PropTypes.object.isRequired
+  user: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
 const mapStateToProps = state => ({
-  user: state.user
+  user: state.user,
+  locale: state.common.locale
 });
 
 export default connect(mapStateToProps, null)(DatasetsShow);

--- a/components/app/myrw/widgets/pages/edit.js
+++ b/components/app/myrw/widgets/pages/edit.js
@@ -86,7 +86,11 @@ class WidgetsEdit extends React.Component {
         return data.attributes.dataset;
       })
       .then((datasetId) => {
-        const datasetService = new DatasetService(datasetId, { apiURL: process.env.WRI_API_URL });
+        const datasetService = new DatasetService(datasetId, {
+          apiURL: process.env.WRI_API_URL,
+          language: this.props.locale
+        });
+
         return datasetService.fetchData('metadata')
           .then((dataset) => {
             this.setState({ dataset });
@@ -103,7 +107,7 @@ class WidgetsEdit extends React.Component {
   }
 
   componentWillUnmount() {
-    this.props.setDataset(null)
+    this.props.setDataset(null);
   }
 
   @Autobind
@@ -411,6 +415,7 @@ WidgetsEdit.propTypes = {
   id: PropTypes.string.isRequired,
   // Store
   user: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired,
   // ACTIONS
   setFilters: PropTypes.func.isRequired,
   setSize: PropTypes.func.isRequired,
@@ -434,7 +439,8 @@ WidgetsEdit.propTypes = {
 
 const mapStateToProps = state => ({
   user: state.user,
-  widgetEditor: state.widgetEditor
+  widgetEditor: state.widgetEditor,
+  locale: state.common.locale
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/components/app/myrw/widgets/pages/new.js
+++ b/components/app/myrw/widgets/pages/new.js
@@ -59,7 +59,9 @@ class WidgetsNew extends React.Component {
 
     // Services
     this.widgetService = new WidgetService(null, { apiURL: process.env.CONTROL_TOWER_URL });
-    this.datasetsService = new DatasetsService();
+    this.datasetsService = new DatasetsService({
+      language: props.locale
+    });
   }
 
   componentDidMount() {
@@ -402,12 +404,14 @@ WidgetsNew.propTypes = {
   // Store
   user: PropTypes.object.isRequired,
   widgetEditor: PropTypes.object.isRequired,
-  setTitle: PropTypes.func.isRequired
+  setTitle: PropTypes.func.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
 const mapStateToProps = state => ({
   user: state.user,
-  widgetEditor: state.widgetEditor
+  widgetEditor: state.widgetEditor,
+  locale: state.common.locale
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/components/app/pulse/LayerCard.js
+++ b/components/app/pulse/LayerCard.js
@@ -43,8 +43,11 @@ class LayerCard extends React.Component {
     const layerActiveLoaded = pulse.layerActive && pulse.layerActive.id;
 
     if (layerActiveLoaded) {
-      this.datasetService = new DatasetService(pulse.layerActive.attributes.dataset,
-        { apiURL: process.env.WRI_API_URL });
+      this.datasetService = new DatasetService(pulse.layerActive.attributes.dataset, {
+        apiURL: process.env.WRI_API_URL,
+        language: nextProps.locale
+      });
+
       this.datasetService.fetchData().then((data) => {
         this.setState({
           dataset: data
@@ -181,6 +184,7 @@ LayerCard.propTypes = {
   // PROPS
   pulse: PropTypes.object.isRequired,
   user: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired,
 
   // Actions
   setSimilarWidgets: PropTypes.func.isRequired,
@@ -190,7 +194,8 @@ LayerCard.propTypes = {
 
 const mapStateToProps = state => ({
   pulse: state.pulse,
-  user: state.user
+  user: state.user,
+  locale: state.common.locale
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/components/areas/AreaCard.js
+++ b/components/areas/AreaCard.js
@@ -59,8 +59,11 @@ class AreaCard extends React.Component {
     };
 
     // Services
-    this.datasetService = new DatasetService(null,
-      { apiURL: process.env.WRI_API_URL });
+    this.datasetService = new DatasetService(null, {
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
+    });
+
     this.areasService = new AreasService({ apiURL: process.env.WRI_API_URL });
     this.userService = new UserService({ apiURL: process.env.WRI_API_URL });
   }
@@ -320,6 +323,7 @@ class AreaCard extends React.Component {
 AreaCard.propTypes = {
   token: PropTypes.string.isRequired,
   area: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired,
   // Callbacks
   onAreaRemoved: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
@@ -329,6 +333,10 @@ AreaCard.propTypes = {
   toggleTooltip: PropTypes.func.isRequired
 };
 
+const mapStateToProps = state => ({
+  locale: state.common.locale
+});
+
 const mapDispatchToProps = dispatch => ({
   toggleModal: (open, opts) => { dispatch(toggleModal(open, opts)); },
   setModalOptions: (options) => { dispatch(setModalOptions(options)); },
@@ -337,4 +345,4 @@ const mapDispatchToProps = dispatch => ({
   }
 });
 
-export default connect(null, mapDispatchToProps)(AreaCard);
+export default connect(mapStateToProps, mapDispatchToProps)(AreaCard);

--- a/components/areas/AreasList.js
+++ b/components/areas/AreasList.js
@@ -60,7 +60,8 @@ class AreasList extends React.Component {
         }
       })
       .catch((err) => {
-        toastr.error('Error loading subscriptions', err);
+        toastr.error('Error loading subscriptions');
+        console.error(err);
         this.setState({ loading: false });
       });
   }
@@ -96,7 +97,7 @@ class AreasList extends React.Component {
       subscription.attributes.datasets.forEach(dataset => datasetsSet.add(dataset)));
     // Fetch data for the datasets needed
 
-    DatasetService.getDatasets([...datasetsSet], 'metadata')
+    DatasetService.getDatasets([...datasetsSet], this.props.locale, 'metadata')
       .then((data) => {
         const datasetsWithLabels = data.map(elem => ({
           id: elem.id,
@@ -173,11 +174,13 @@ class AreasList extends React.Component {
 }
 
 AreasList.propTypes = {
-  user: PropTypes.object.isRequired
+  user: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
 const mapStateToProps = state => ({
-  user: state.user
+  user: state.user,
+  locale: state.common.locale
 });
 
 export default connect(mapStateToProps, null)(AreasList);

--- a/components/datasets/form/DatasetsForm.js
+++ b/components/datasets/form/DatasetsForm.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import { toastr } from 'react-redux-toastr';
 
+// Redux
+import { connect } from 'react-redux';
+
 // Service
 import DatasetsService from 'services/DatasetsService';
 
@@ -27,7 +30,8 @@ class DatasetsForm extends React.Component {
     });
 
     this.service = new DatasetsService({
-      authorization: props.authorization
+      authorization: props.authorization,
+      language: props.locale
     });
 
     // BINDINGS
@@ -202,7 +206,12 @@ DatasetsForm.propTypes = {
   authorization: PropTypes.string,
   dataset: PropTypes.string,
   basic: PropTypes.bool,
-  onSubmit: PropTypes.func
+  onSubmit: PropTypes.func,
+  locale: PropTypes.string.isRequired
 };
 
-export default DatasetsForm;
+const mapStateToProps = state => ({
+  locale: state.common.locale
+});
+
+export default connect(mapStateToProps, null)(DatasetsForm);

--- a/components/datasets/list/DatasetsListCard.js
+++ b/components/datasets/list/DatasetsListCard.js
@@ -8,6 +8,9 @@ import { Link } from 'routes';
 import Title from 'components/ui/Title';
 import DatasetsRelatedContent from 'components/datasets/common/DatasetsRelatedContent';
 
+// Redux
+import { connect } from 'react-redux';
+
 // Services
 import DatasetsService from 'services/DatasetsService';
 
@@ -16,7 +19,10 @@ class DatasetsListCard extends React.Component {
     super(props);
 
     // SERVICES
-    this.service = new DatasetsService({ authorization: props.token });
+    this.service = new DatasetsService({
+      authorization: props.token,
+      language: props.locale
+    });
   }
 
   @Autobind
@@ -96,8 +102,13 @@ DatasetsListCard.propTypes = {
   dataset: PropTypes.object,
   routes: PropTypes.object,
   token: PropTypes.string.isRequired,
+  locale: PropTypes.string.isRequired,
   // Callbacks
   onDatasetRemoved: PropTypes.func.isRequired
 };
 
-export default DatasetsListCard;
+const mapStateToProps = state => ({
+  locale: state.common.locale
+});
+
+export default connect(mapStateToProps, null)(DatasetsListCard);

--- a/components/datasets/table/actions/DeleteAction.js
+++ b/components/datasets/table/actions/DeleteAction.js
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import DatasetsService from 'services/DatasetsService';
 import { toastr } from 'react-redux-toastr';
 
+// Redux
+import { connect } from 'react-redux';
 
 class DeleteAction extends React.Component {
   constructor(props) {
@@ -15,7 +17,8 @@ class DeleteAction extends React.Component {
 
     // SERVICES
     this.service = new DatasetsService({
-      authorization: props.authorization
+      authorization: props.authorization,
+      language: props.locale
     });
   }
 
@@ -52,9 +55,13 @@ class DeleteAction extends React.Component {
 
 DeleteAction.propTypes = {
   data: PropTypes.object,
-
+  locale: PropTypes.string.isRequired,
   authorization: PropTypes.string,
   onRowDelete: PropTypes.func
 };
 
-export default DeleteAction;
+const mapStateToProps = state => ({
+  locale: state.common.locale
+});
+
+export default connect(mapStateToProps, null)(DeleteAction);

--- a/components/modal/AreaSubscriptionModal.js
+++ b/components/modal/AreaSubscriptionModal.js
@@ -80,26 +80,34 @@ class AreaSubscriptionModal extends React.Component {
 
       if (mode === 'new') {
         if (datasets.length >= 1) {
-          this.userService.createSubscriptionToArea(area.id, datasets, datasetsQuery, user)
-            .then(() => {
-              toastr.success('Success!', 'Subscription created successfully');
-              this.props.toggleModal(false);
-              this.props.onSubscriptionCreated();
-            })
+          this.userService.createSubscriptionToArea(
+            area.id,
+            datasets,
+            datasetsQuery,
+            user,
+            this.props.locale
+          ).then(() => {
+            toastr.success('Success!', 'Subscription created successfully');
+            this.props.toggleModal(false);
+            this.props.onSubscriptionCreated();
+          })
             .catch(err => toastr.error('Error creating the subscription', err));
         } else {
           toastr.error('Error', 'Please select at least one dataset');
         }
       } else if (mode === 'edit') {
         if (datasets.length >= 1) {
-          this.userService.updateSubscriptionToArea(area.subscription.id, datasets,
-            datasetsQuery, user)
-            .then(() => {
-              toastr.success('Success!', 'Subscription updated successfully');
-              this.props.toggleModal(false);
-              this.props.onSubscriptionUpdated();
-            })
-            .catch(err => toastr.error('Error updating the subscription', err));
+          this.userService.updateSubscriptionToArea(
+            area.subscription.id,
+            datasets,
+            datasetsQuery,
+            user,
+            this.props.locale
+          ).then(() => {
+            toastr.success('Success!', 'Subscription updated successfully');
+            this.props.toggleModal(false);
+            this.props.onSubscriptionUpdated();
+          }).catch(err => toastr.error('Error updating the subscription', err));
         } else {
           this.userService.deleteSubscription(area.subscription.id, user.token)
             .then(() => {

--- a/components/modal/AreaSubscriptionModal.js
+++ b/components/modal/AreaSubscriptionModal.js
@@ -35,7 +35,10 @@ class AreaSubscriptionModal extends React.Component {
     };
 
     // Services
-    this.datasetService = new DatasetService(null, { apiURL: process.env.WRI_API_URL });
+    this.datasetService = new DatasetService(null, {
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
+    });
     this.areasService = new AreasService({ apiURL: process.env.WRI_API_URL });
     this.userService = new UserService({ apiURL: process.env.WRI_API_URL });
   }
@@ -195,6 +198,7 @@ AreaSubscriptionModal.propTypes = {
   area: PropTypes.object.isRequired,
   toggleModal: PropTypes.func.isRequired,
   mode: PropTypes.string.isRequired, // edit | new
+  locale: PropTypes.string.isRequired,
   // Store
   user: PropTypes.object.isRequired,
   // Callbacks
@@ -203,7 +207,8 @@ AreaSubscriptionModal.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  user: state.user
+  user: state.user,
+  locale: state.common.locale
 });
 
 export default connect(mapStateToProps, null)(AreaSubscriptionModal);

--- a/components/modal/SubscribeToDatasetModal.js
+++ b/components/modal/SubscribeToDatasetModal.js
@@ -137,18 +137,21 @@ class SubscribeToDatasetModal extends React.Component {
                 type: selectedType.value,
                 threshold: selectedThreshold
               };
-              this.userService.createSubscriptionToArea(selectedArea.areaID,
-                datasets, datasetsQuery, user)
-                .then(() => {
-                  this.setState({
-                    loading: false,
-                    saved: true
-                  });
-                })
-                .catch((err) => {
-                  toastr.error('Error', err);
-                  this.setState({ error: err, loading: false });
+              this.userService.createSubscriptionToArea(
+                selectedArea.areaID,
+                datasets,
+                datasetsQuery,
+                user,
+                this.props.locale
+              ).then(() => {
+                this.setState({
+                  loading: false,
+                  saved: true
                 });
+              }).catch((err) => {
+                toastr.error('Error', err);
+                this.setState({ error: err, loading: false });
+              });
             }
           })
           .catch((err) => {
@@ -169,33 +172,39 @@ class SubscribeToDatasetModal extends React.Component {
         if (userAreas.map(val => val.value).includes(selectedArea.value)) {
           areaID = userAreas.find(val => val.value === selectedArea.value).areaID;
           // Create the subscription
-          this.userService.createSubscriptionToArea(areaID, datasets, datasetsQuery, user)
-            .then(() => {
-              this.setState({
-                loading: false,
-                saved: true
-              });
-            })
-            .catch((err) => {
-              toastr.error('Error', err);
-              this.setState({ error: err, loading: false });
+          this.userService.createSubscriptionToArea(
+            areaID,
+            datasets,
+            datasetsQuery,
+            user
+          ).then(() => {
+            this.setState({
+              loading: false,
+              saved: true
             });
+          }).catch((err) => {
+            toastr.error('Error', err);
+            this.setState({ error: err, loading: false });
+          });
         } else {
           // In the case there's no user area for the selected country we create one on the fly
           this.userService.createNewArea(selectedArea.label, selectedArea.isGeostore, user.token)
             .then((response) => {
               areaID = response.data.id;
-              this.userService.createSubscriptionToArea(areaID, datasets, datasetsQuery, user)
-                .then(() => {
-                  this.setState({
-                    loading: false,
-                    saved: true
-                  });
-                })
-                .catch((err) => {
-                  toastr.error('Error', err);
-                  this.setState({ error: err, loading: false });
+              this.userService.createSubscriptionToArea(
+                areaID,
+                datasets,
+                datasetsQuery,
+                user
+              ).then(() => {
+                this.setState({
+                  loading: false,
+                  saved: true
                 });
+              }).catch((err) => {
+                toastr.error('Error', err);
+                this.setState({ error: err, loading: false });
+              });
             })
             .catch(err => toastr.error('Error creating area', err));
         }
@@ -382,11 +391,13 @@ SubscribeToDatasetModal.propTypes = {
   dataset: PropTypes.object.isRequired,
   toggleModal: PropTypes.func.isRequired,
   // Store
-  user: PropTypes.object.isRequired
+  user: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
 const mapStateToProps = state => ({
-  user: state.user
+  user: state.user,
+  locale: state.common.locale
 });
 
 export default connect(mapStateToProps, null)(SubscribeToDatasetModal);

--- a/components/subscriptions/SubscriptionCard.js
+++ b/components/subscriptions/SubscriptionCard.js
@@ -4,6 +4,9 @@ import { Autobind } from 'es-decorators';
 import { Router } from 'routes';
 import { toastr } from 'react-redux-toastr';
 
+// Redux
+import { connect } from 'react-redux';
+
 // Components
 import Spinner from 'components/ui/Spinner';
 import Map from 'components/widgets/map/Map';
@@ -38,8 +41,10 @@ class SubscriptionCard extends React.Component {
     };
 
     // Services
-    this.datasetService = new DatasetService(props.subscription.attributes.datasetsQuery[0].id,
-      { apiURL: process.env.WRI_API_URL });
+    this.datasetService = new DatasetService(props.subscription.attributes.datasetsQuery[0].id, {
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
+    });
     this.areasService = new AreasService({ apiURL: process.env.WRI_API_URL });
     this.userService = new UserService({ apiURL: process.env.WRI_API_URL });
   }
@@ -208,8 +213,13 @@ class SubscriptionCard extends React.Component {
 SubscriptionCard.propTypes = {
   token: PropTypes.string.isRequired,
   subscription: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired,
   // Callbacks
   onSubscriptionRemoved: PropTypes.func.isRequired
 };
 
-export default SubscriptionCard;
+const mapStateToProps = state => ({
+  locale: state.common.locale
+});
+
+export default connect(mapStateToProps, null)(SubscriptionCard);

--- a/components/subscriptions/SubscriptionsForm.js
+++ b/components/subscriptions/SubscriptionsForm.js
@@ -74,7 +74,10 @@ class SubscriptionsForm extends React.Component {
     // Services
     this.areasService = new AreasService({ apiURL: process.env.WRI_API_URL });
     this.userService = new UserService({ apiURL: process.env.WRI_API_URL });
-    this.datasetService = new DatasetService(null, { apiURL: process.env.WRI_API_URL });
+    this.datasetService = new DatasetService(null, {
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
+    });
   }
 
   componentDidMount() {
@@ -256,11 +259,13 @@ class SubscriptionsForm extends React.Component {
 SubscriptionsForm.propTypes = {
   // Store
   user: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired,
   toggleModal: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
-  user: state.user
+  user: state.user,
+  locale: state.common.locale
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -698,7 +698,8 @@ class WidgetEditor extends React.Component {
   initComponent(props) {
     // First, we init the services
     this.datasetService = new DatasetService(props.dataset, {
-      apiURL: process.env.WRI_API_URL
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
     });
 
     this.widgetService = new WidgetService(props.dataset, {
@@ -1076,11 +1077,12 @@ class WidgetEditor extends React.Component {
   }
 }
 
-const mapStateToProps = ({ widgetEditor, user }) => ({
+const mapStateToProps = ({ widgetEditor, user, common }) => ({
   widgetEditor,
   user,
   selectedVisualizationType: widgetEditor.visualizationType,
-  band: widgetEditor.band
+  band: widgetEditor.band,
+  locale: common.locale
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -1125,7 +1127,8 @@ WidgetEditor.propTypes = {
   toggleModal: PropTypes.func,
   setBandsInfo: PropTypes.func,
   setTitle: PropTypes.func,
-  setMapParams: PropTypes.func
+  setMapParams: PropTypes.func,
+  locale: PropTypes.string.isRequired // eslint-disable-line react/no-unused-prop-types
 };
 
 WidgetEditor.defaultProps = {

--- a/components/widgets/editor/services/DatasetService.js
+++ b/components/widgets/editor/services/DatasetService.js
@@ -20,9 +20,15 @@ export default class DatasetService {
     if (!options) {
       throw new Error('options params is required.');
     }
+
     if (!options.apiURL || options.apiURL === '') {
       throw new Error('options.apiURL param is required.');
     }
+
+    if (!options.language) {
+      throw new Error('options.language param is required.');
+    }
+
     this.datasetId = datasetId;
     this.opts = options;
   }
@@ -31,7 +37,7 @@ export default class DatasetService {
    * Get subscribable datasets
    */
   getSubscribableDatasets(includes = '') {
-    return fetch(`${this.opts.apiURL}/dataset?application=${[process.env.APPLICATIONS]}&includes=${includes}&subscribable=true&page[size]=999`)
+    return fetch(`${this.opts.apiURL}/dataset?application=${[process.env.APPLICATIONS]}&language=${this.opts.language}&includes=${includes}&subscribable=true&page[size]=999`)
       .then((response) => {
         if (response.status >= 400) throw new Error(response.statusText);
         return response.json();
@@ -44,7 +50,7 @@ export default class DatasetService {
    * @returns {Promise}
    */
   fetchData(includes = '', applications = [process.env.APPLICATIONS]) {
-    return fetch(`${this.opts.apiURL}/dataset/${this.datasetId}?application=${applications.join(',')}&includes=${includes}&page[size]=999`)
+    return fetch(`${this.opts.apiURL}/dataset/${this.datasetId}?application=${applications.join(',')}&language=${this.opts.language}&includes=${includes}&page[size]=999`)
       .then((response) => {
         if (response.status >= 400) throw new Error(response.statusText);
         return response.json();
@@ -114,7 +120,7 @@ export default class DatasetService {
     return new Promise((resolve) => {
       this.getFields().then((fieldsData) => {
         const filteredFields = fieldsData.fields.filter(field => field.columnType === 'number' || field.columnType === 'date' || field.columnType === 'string');
-        const promises = (filteredFields || []).map(field => {
+        const promises = (filteredFields || []).map((field) => {
           if (field.columnType === 'number' || field.columnType === 'date') {
             return this.getMinAndMax(field.columnName, fieldsData.tableName);
           }
@@ -239,13 +245,14 @@ export default class DatasetService {
    * Fetch several datasets at once
    * @static
    * @param {string[]} datasetIDs - List of dataset IDs
+   * @param {string} language - Two-letter locale
    * @param {string} [includes=''] - List of entities to fetch
    * (string of values separated with commas)
    * @param {string[]} [applications=[process.env.APPLICATIONS]] List of applications
    * @returns {object[]}
    */
-  static getDatasets(datasetIDs, includes = '', applications = [process.env.APPLICATIONS]) {
-    return fetch(`${process.env.WRI_API_URL}/dataset/?ids=${datasetIDs}&includes=${includes}&application=${applications.join(',')}&page[size]=999`)
+  static getDatasets(datasetIDs, language, includes = '', applications = [process.env.APPLICATIONS]) {
+    return fetch(`${process.env.WRI_API_URL}/dataset/?ids=${datasetIDs}&language=${language}&includes=${includes}&application=${applications.join(',')}&page[size]=999`)
       .then((response) => {
         if (!response.ok) throw new Error(response.statusText);
         return response.json();

--- a/components/widgets/editor/services/UserService.js
+++ b/components/widgets/editor/services/UserService.js
@@ -110,13 +110,14 @@ export default class UserService {
    * Creates a subscription for a pair of dataset and country
    * @param {datasetID} ID of the dataset
    * @param {object} Either { type; 'iso', id:'ESP' } or { type: 'geostore', id: 'sakldfa7ads0ka'}
+   * @param {string} language Two-letter locale
    * @returns {Promise}
    */
-  createSubscriptionToArea(areaId, datasets, datasetsQuery, user, name = '') {
+  createSubscriptionToArea(areaId, datasets, datasetsQuery, user, language, name = '') {
     const bodyObj = {
       name,
       application: process.env.APPLICATIONS,
-      language: 'en',
+      language,
       datasets,
       datasetsQuery,
       resource: {
@@ -141,10 +142,10 @@ export default class UserService {
   /**
    *  Update Subscription
    */
-  updateSubscriptionToArea(subscriptionId, datasets, datasetsQuery, user) {
+  updateSubscriptionToArea(subscriptionId, datasets, datasetsQuery, user, language) {
     const bodyObj = {
       application: process.env.APPLICATIONS,
-      language: 'en',
+      language,
       datasets,
       datasetsQuery
     };

--- a/components/widgets/editor/table/TableView.js
+++ b/components/widgets/editor/table/TableView.js
@@ -25,7 +25,8 @@ class TableView extends React.Component {
 
     // DatasetService
     this.datasetService = new DatasetService(props.dataset, {
-      apiURL: process.env.WRI_API_URL
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
     });
   }
 
@@ -144,9 +145,13 @@ TableView.propTypes = {
   dataset: PropTypes.string.isRequired,
   tableName: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
   // Store
-  widgetEditor: PropTypes.object.isRequired // eslint-disable-line react/no-unused-prop-types
+  widgetEditor: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
-const mapStateToProps = ({ widgetEditor }) => ({ widgetEditor });
+const mapStateToProps = state => ({
+  widgetEditor: state.widgetEditor,
+  locale: state.common.locale
+});
 
 export default connect(mapStateToProps, null)(TableView);

--- a/components/widgets/editor/tooltip/FilterDateTooltip.js
+++ b/components/widgets/editor/tooltip/FilterDateTooltip.js
@@ -27,7 +27,8 @@ class FilterDateTooltip extends React.Component {
 
     // DatasetService
     this.datasetService = new DatasetService(props.datasetID, {
-      apiURL: process.env.WRI_API_URL
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
     });
   }
 
@@ -174,7 +175,8 @@ FilterDateTooltip.propTypes = {
   onToggleLoading: PropTypes.func,
   onApply: PropTypes.func,
   // store
-  widgetEditor: PropTypes.object.isRequired
+  widgetEditor: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
 FilterDateTooltip.defaultProps = {
@@ -188,7 +190,8 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => ({
-  widgetEditor: state.widgetEditor
+  widgetEditor: state.widgetEditor,
+  locale: state.common.locale
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(FilterDateTooltip);

--- a/components/widgets/editor/tooltip/FilterNumberTooltip.js
+++ b/components/widgets/editor/tooltip/FilterNumberTooltip.js
@@ -26,7 +26,8 @@ class FilterNumberTooltip extends React.Component {
 
     // DatasetService
     this.datasetService = new DatasetService(props.datasetID, {
-      apiURL: process.env.WRI_API_URL
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
     });
   }
 
@@ -165,7 +166,8 @@ FilterNumberTooltip.propTypes = {
   onToggleLoading: PropTypes.func,
   onApply: PropTypes.func,
   // store
-  widgetEditor: PropTypes.object.isRequired
+  widgetEditor: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
 FilterNumberTooltip.defaultProps = {
@@ -179,7 +181,8 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => ({
-  widgetEditor: state.widgetEditor
+  widgetEditor: state.widgetEditor,
+  locale: state.common.locale
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(FilterNumberTooltip);

--- a/components/widgets/editor/tooltip/FilterStringTooltip.js
+++ b/components/widgets/editor/tooltip/FilterStringTooltip.js
@@ -25,7 +25,8 @@ class FilterStringTooltip extends React.Component {
 
     // DatasetService
     this.datasetService = new DatasetService(props.datasetID, {
-      apiURL: process.env.WRI_API_URL
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
     });
   }
 
@@ -151,7 +152,8 @@ FilterStringTooltip.propTypes = {
   onToggleLoading: PropTypes.func,
   onApply: PropTypes.func,
   // store
-  widgetEditor: PropTypes.object.isRequired
+  widgetEditor: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
 const mapDispatchToProps = dispatch => ({
@@ -161,7 +163,8 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => ({
-  widgetEditor: state.widgetEditor
+  widgetEditor: state.widgetEditor,
+  locale: state.common.locale
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(FilterStringTooltip);

--- a/components/widgets/editor/tooltip/FilterTooltip.js
+++ b/components/widgets/editor/tooltip/FilterTooltip.js
@@ -31,7 +31,8 @@ class FilterTooltip extends React.Component {
 
     // DatasetService
     this.datasetService = new DatasetService(props.datasetID, {
-      apiURL: process.env.WRI_API_URL
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
     });
   }
 
@@ -147,7 +148,8 @@ FilterTooltip.propTypes = {
   onApply: PropTypes.func.isRequired,
   // store
   toggleTooltip: PropTypes.func.isRequired,
-  widgetEditor: PropTypes.object.isRequired
+  widgetEditor: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
 const mapDispatchToProps = dispatch => ({
@@ -157,7 +159,8 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => ({
-  widgetEditor: state.widgetEditor
+  widgetEditor: state.widgetEditor,
+  locale: state.common.locale
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(FilterTooltip);

--- a/pages/admin/DataDetail.js
+++ b/pages/admin/DataDetail.js
@@ -81,7 +81,9 @@ class DataDetail extends Page {
     switch (tab) {
       case 'datasets':
         if (id !== 'new') {
-          this.service = new DatasetsService();
+          this.service = new DatasetsService({
+            language: this.props.locale
+          });
         }
         break;
 
@@ -173,8 +175,13 @@ class DataDetail extends Page {
 
 DataDetail.propTypes = {
   user: PropTypes.object,
-  url: PropTypes.object
+  url: PropTypes.object,
+  locale: PropTypes.string.isRequired
 };
 
+const mapStateToProps = state => ({
+  locale: state.common.locale
+});
 
-export default withRedux(initStore, null, null)(DataDetail);
+
+export default withRedux(initStore, mapStateToProps, null)(DataDetail);

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -105,7 +105,10 @@ class Explore extends Page {
     };
 
     // Services
-    this.datasetService = new DatasetService(null, { apiURL: process.env.WRI_API_URL });
+    this.datasetService = new DatasetService(null, {
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
+    });
 
     // BINDINGS
     this.handleFilterDatasetsSearch = debounce(this.handleFilterDatasetsSearch.bind(this), 500);
@@ -693,6 +696,7 @@ Explore.propTypes = {
   totalDatasets: PropTypes.array,
   layerGroups: PropTypes.array,
   toggledDataset: PropTypes.string,
+  locale: PropTypes.string.isRequired,
 
 
   // ACTIONS
@@ -730,7 +734,8 @@ const mapStateToProps = (state) => {
     filteredDatasets,
     totalDatasets: totalFilteredDatasets,
     layerGroups: getLayerGroups(state),
-    rawLayerGroups: state.explore.layers
+    rawLayerGroups: state.explore.layers,
+    locale: state.common.locale
   };
 };
 

--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -83,7 +83,8 @@ class ExploreDetail extends Page {
 
     // DatasetService
     this.datasetService = new DatasetService(props.url.query.id, {
-      apiURL: process.env.WRI_API_URL
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
     });
     // GraphService
     this.graphService = new GraphService({ apiURL: process.env.WRI_API_URL });
@@ -113,7 +114,8 @@ class ExploreDetail extends Page {
         datasetLoaded: false
       }, () => {
         this.datasetService = new DatasetService(nextProps.url.query.id, {
-          apiURL: process.env.WRI_API_URL
+          apiURL: process.env.WRI_API_URL,
+          language: nextProps.locale
         });
         // Scroll to the top of the page
         window.scrollTo(0, 0);
@@ -211,7 +213,7 @@ class ExploreDetail extends Page {
       .then(res => res.map(val => val.dataset).slice(0, 7))
       .then((ids) => {
         if (ids.length === 0) return [];
-        return DatasetService.getDatasets(ids, 'widget,metadata,layer,vocabulary');
+        return DatasetService.getDatasets(ids, this.props.locale, 'widget,metadata,layer,vocabulary');
       })
       .then(similarDatasets => this.setState({ similarDatasets }))
       .catch((err) => {
@@ -766,20 +768,12 @@ ExploreDetail.propTypes = {
   url: PropTypes.object.isRequired,
   // Store
   user: PropTypes.object,
+  widgetEditor: PropTypes.object,
+  locale: PropTypes.string.isRequired,
   // ACTIONS
   resetDataset: PropTypes.func.isRequired,
   toggleModal: PropTypes.func.isRequired,
-  setModalOptions: PropTypes.func.isRequired
-};
-
-const mapStateToProps = state => ({
-  // Store
-  user: state.user,
-  topicsTree: state.explore.topicsTree,
-  exploreDetail: state.exploreDetail,
-  layersShown: updateLayersShown(state),
-  widgetEditor: PropTypes.object,
-  // ACTIONS
+  setModalOptions: PropTypes.func.isRequired,
   setFilters: PropTypes.func.isRequired,
   setSize: PropTypes.func.isRequired,
   setColor: PropTypes.func.isRequired,
@@ -794,6 +788,15 @@ const mapStateToProps = state => ({
   setLayer: PropTypes.func.isRequired,
   setTitle: PropTypes.func.isRequired,
   setTopicsTree: PropTypes.func.isRequired
+};
+
+const mapStateToProps = state => ({
+  // Store
+  user: state.user,
+  topicsTree: state.explore.topicsTree,
+  exploreDetail: state.exploreDetail,
+  layersShown: updateLayersShown(state),
+  locale: state.common.locale
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/pages/app/MyRWDetail.js
+++ b/pages/app/MyRWDetail.js
@@ -52,7 +52,9 @@ class MyRWDetail extends Page {
     switch (tab) {
       case 'datasets':
         if (id !== 'new') {
-          this.service = new DatasetsService();
+          this.service = new DatasetsService({
+            language: props.locale
+          });
         }
         break;
 
@@ -197,12 +199,14 @@ class MyRWDetail extends Page {
 
 MyRWDetail.propTypes = {
   user: PropTypes.object,
-  url: PropTypes.object
+  url: PropTypes.object,
+  locale: PropTypes.string.isRequired
 };
 
 const mapStateToProps = state => ({
   // Store
-  myrwdetail: state.myrwdetail
+  myrwdetail: state.myrwdetail,
+  locale: state.common.locale
 });
 
 export default withRedux(initStore, mapStateToProps, null)(MyRWDetail);

--- a/pages/app/embed/EmbedDataset.js
+++ b/pages/app/embed/EmbedDataset.js
@@ -30,7 +30,8 @@ class EmbedDataset extends React.Component {
 
     // DatasetService
     this.datasetService = new DatasetService(this.props.url.query.id, {
-      apiURL: process.env.WRI_API_URL
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
     });
   }
 
@@ -98,7 +99,12 @@ class EmbedDataset extends React.Component {
 }
 
 EmbedDataset.propTypes = {
-  url: PropTypes.object.isRequired
+  url: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
 };
 
-export default withRedux(initStore, null, null)(EmbedDataset);
+const mapStateToProps = state => ({
+  locale: state.common.locale
+});
+
+export default withRedux(initStore, mapStateToProps, null)(EmbedDataset);

--- a/pages/app/embed/EmbedLayer.js
+++ b/pages/app/embed/EmbedLayer.js
@@ -122,7 +122,7 @@ class EmbedLayer extends Page {
     try {
       const layerGroups = JSON.parse(decodeURIComponent(this.props.url.query.layers));
       // We actually fetch the datasets so we can reuse the explore selector
-      DatasetService.getDatasets(layerGroups.map(l => l.dataset), 'layer')
+      DatasetService.getDatasets(layerGroups.map(l => l.dataset), this.props.locale, 'layer')
         .then(layers => this.setState({
           apiLayers: layers,
           layerGroups: getLayerGroups(layers, layerGroups)
@@ -226,13 +226,15 @@ EmbedLayer.propTypes = {
 
   // Store
   modal: PropTypes.object,
+  locale: PropTypes.string.isRequired,
   toggleModal: PropTypes.func,
   toggleTooltip: PropTypes.func,
   setModalOptions: PropTypes.func
 };
 
 const mapStateToProps = state => ({
-  modal: state.modal
+  modal: state.modal,
+  locale: state.common.locale
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/redactions/admin/datasets.js
+++ b/redactions/admin/datasets.js
@@ -23,8 +23,6 @@ const initialState = {
   }
 };
 
-const service = new DatasetsService();
-
 /**
  * REDUCER
  * @export
@@ -78,8 +76,14 @@ export default function (state = initialState, action) {
  * @param {string[]} applications Name of the applications to load the datasets from
  */
 export function getDatasets(options) {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     dispatch({ type: GET_DATASETS_LOADING });
+
+    const state = getState();
+
+    const service = new DatasetsService({
+      language: state.common.locale
+    });
 
     service.fetchAdminData(options)
       .then((data) => {

--- a/redactions/common.js
+++ b/redactions/common.js
@@ -1,9 +1,16 @@
 import { Router } from 'routes';
 
-const initialState = {};
+const SET_LOCALE = 'common/GET_LOCALE';
+
+const initialState = {
+  locale: 'en'
+};
 
 export default function (state = initialState, action) {
   switch (action.type) {
+    case SET_LOCALE:
+      return Object.assign({}, state, { locale: action.payload });
+
     default:
       return state;
   }
@@ -16,5 +23,18 @@ export default function (state = initialState, action) {
 export function redirectTo(url) {
   return (dispatch) => {
     dispatch(Router.pushRoute(url));
+  };
+}
+
+/**
+ * Set the locale of the app (used by the API)
+ * NOTE: doesn't not change the language of the app, only
+ * Transifex can do so
+ * @param {string} locale Two-letter locale
+ */
+export function setLocale(locale) {
+  return {
+    type: SET_LOCALE,
+    payload: locale
   };
 }

--- a/redactions/exploreDataset.js
+++ b/redactions/exploreDataset.js
@@ -66,12 +66,15 @@ export default function (state = initialState, action) {
  * @param {string[]} applications Name of the applications to load the datasets from
  */
 export function getDataset(datasetId) {
-  const service = new DatasetService(datasetId, {
-    apiURL: process.env.WRI_API_URL
-  });
-
-  return (dispatch) => {
+  return (dispatch, getState) => {
     dispatch({ type: GET_EXPLORE_DATASET_LOADING });
+
+    const state = getState();
+
+    const service = new DatasetService(datasetId, {
+      apiURL: process.env.WRI_API_URL,
+      language: state.common.locale
+    });
 
     return service.fetchDataset('metadata,widget')
       .then((data) => {

--- a/redactions/widget.js
+++ b/redactions/widget.js
@@ -137,8 +137,13 @@ export default function (state = initialState, action) {
  * @returns {Promise<void>}
  */
 function fetchDataset(datasetId) {
-  return (dispatch) => {
-    const datasetService = new DatasetService(datasetId, { apiURL: process.env.WRI_API_URL });
+  return (dispatch, getState) => {
+    const state = getState();
+    const datasetService = new DatasetService(datasetId, {
+      apiURL: process.env.WRI_API_URL,
+      language: state.common.locale
+    });
+
     return datasetService.fetchData('metadata')
       .then(dataset => dispatch({ type: SET_WIDGET_DATASET, payload: dataset }));
   };

--- a/services/DatasetService.js
+++ b/services/DatasetService.js
@@ -34,9 +34,15 @@ export default class DatasetService {
     if (!options) {
       throw new Error('options params is required.');
     }
+
     if (!options.apiURL || options.apiURL === '') {
       throw new Error('options.apiURL param is required.');
     }
+
+    if (!options.language) {
+      throw new Error('options.language param is required.');
+    }
+
     this.datasetId = datasetId;
     this.opts = options;
   }
@@ -45,7 +51,7 @@ export default class DatasetService {
    * Get subscribable datasets
    */
   getSubscribableDatasets(includes = '') {
-    return fetch(`${this.opts.apiURL}/dataset?application=${[process.env.APPLICATIONS]}&includes=${includes}&subscribable=true&page[size]=999`)
+    return fetch(`${this.opts.apiURL}/dataset?application=${[process.env.APPLICATIONS]}&language=${this.opts.language}&includes=${includes}&subscribable=true&page[size]=999`)
       .then(response => response.json())
       .then(jsonData => jsonData.data);
   }
@@ -55,7 +61,7 @@ export default class DatasetService {
    * @returns {Promise}
    */
   fetchData(includes = '', applications = [process.env.APPLICATIONS]) {
-    const url = `${this.opts.apiURL}/dataset/${this.datasetId}?application=${applications.join(',')}&includes=${includes}&page[size]=999`;
+    const url = `${this.opts.apiURL}/dataset/${this.datasetId}?application=${applications.join(',')}&language=${this.opts.language}&includes=${includes}&page[size]=999`;
     return fetch(url)
       .then((response) => {
         if (response.status >= 400) throw Error(response.statusText);
@@ -69,7 +75,7 @@ export default class DatasetService {
    * @returns {Promise}
    */
   fetchDataset(includes = '', applications = [process.env.APPLICATIONS]) {
-    const url = `${this.opts.apiURL}/dataset/${this.datasetId}?application=${applications.join(',')}&includes=${includes}&page[size]=999`;
+    const url = `${this.opts.apiURL}/dataset/${this.datasetId}?application=${applications.join(',')}&language=${this.opts.language}&includes=${includes}&page[size]=999`;
     return fetch(url)
       .then((response) => {
         if (response.status >= 400) throw Error(response.statusText);
@@ -260,13 +266,14 @@ export default class DatasetService {
    * Fetch several datasets at once
    * @static
    * @param {string[]} datasetIDs - List of dataset IDs
+   * @param {string} language - Two-letter locale
    * @param {string} [includes=''] - List of entities to fetch
    * (string of values separated with commas)
    * @param {string[]} [applications=[process.env.APPLICATIONS]] List of applications
    * @returns {object[]}
    */
-  static getDatasets(datasetIDs, includes = '', applications = [process.env.APPLICATIONS]) {
-    return fetch(`${process.env.WRI_API_URL}/dataset/?ids=${datasetIDs}&includes=${includes}&application=${applications.join(',')}&page[size]=999`)
+  static getDatasets(datasetIDs, language, includes = '', applications = [process.env.APPLICATIONS]) {
+    return fetch(`${process.env.WRI_API_URL}/dataset/?ids=${datasetIDs}&language=${language}&includes=${includes}&application=${applications.join(',')}&page[size]=999`)
       .then((response) => {
         if (!response.ok) throw new Error(response.statusText);
         return response.json();

--- a/services/DatasetsService.js
+++ b/services/DatasetsService.js
@@ -6,6 +6,10 @@ import { getFieldUrl, getFields } from 'utils/datasets/fields';
 
 export default class DatasetsService {
   constructor(options = {}) {
+    if (!options.language) {
+      throw new Error('options.language param is required.');
+    }
+
     this.opts = options;
   }
 
@@ -13,6 +17,7 @@ export default class DatasetsService {
   fetchAdminData({ applications = [process.env.APPLICATIONS], includes, filters } = {}) {
     const qParams = {
       application: applications.join(','),
+      language: this.opts.language,
       ...!!includes && { includes },
       'page[size]': 9999999,
       env: process.env.API_ENV,
@@ -43,6 +48,7 @@ export default class DatasetsService {
   fetchAllData({ applications = [process.env.APPLICATIONS], includes, filters, env = process.env.API_ENV } = {}) {
     const qParams = {
       application: applications.join(','),
+      language: this.opts.language,
       ...!!includes && { includes },
       'page[size]': 9999999,
       ...filters,
@@ -73,6 +79,7 @@ export default class DatasetsService {
   fetchData({ id, applications = [process.env.APPLICATIONS], includes, filters }) {
     const qParams = {
       application: applications.join(','),
+      language: this.opts.language,
       includes,
       ...filters
     };

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -144,13 +144,14 @@ export default class UserService {
    * Creates a subscription for a pair of dataset and country
    * @param {datasetID} ID of the dataset
    * @param {object} Either { type; 'iso', id:'ESP' } or { type: 'geostore', id: 'sakldfa7ads0ka'}
+   * @param {string} language Two-letter locale
    * @returns {Promise}
    */
-  createSubscriptionToArea(areaId, datasets, datasetsQuery, user, name = '') {
+  createSubscriptionToArea(areaId, datasets, datasetsQuery, user, language, name = '') {
     const bodyObj = {
       name,
       application: process.env.APPLICATIONS,
-      language: 'en',
+      language,
       datasets,
       datasetsQuery,
       resource: {
@@ -175,10 +176,10 @@ export default class UserService {
   /**
    *  Update Subscription
    */
-  updateSubscriptionToArea(subscriptionId, datasets, datasetsQuery, user) {
+  updateSubscriptionToArea(subscriptionId, datasets, datasetsQuery, user, language) {
     const bodyObj = {
       application: process.env.APPLICATIONS,
-      language: 'en',
+      language,
       datasets,
       datasetsQuery
     };


### PR DESCRIPTION
This PR saves Transifex' locale in the store (under `store.common.locale`) and use it in several API calls: the ones related to the datasets and the creation/update of subscriptions.

The metadata edition don't use the locale because it has a separate selector in the form. Generally speaking, the admin section doesn't use Transifex so the locale is always `en`.

Two comments:
1. I could not test Transifex properly because 1) it doesn't launch on localhost and 2) the only locale we have set in Transifex is `en`. We need to test in staging and add another locale to see if it's correctly passed to the API.
2. When the user changes the locale, the store is updated but the page's queries that were made  with the previous locale are not re-executed. Should we reload the page whenever the locale is changed? That would be the easiest solution.

[Pivotal task](https://www.pivotaltracker.com/story/show/152069427)