### PR TITLE
Fix undefined ENV variables in browser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ ENV OPBEAT_APP_ID 7170680c2a
 ENV ADD_SEARCH_KEY cb7e797b8a3c0d09c323955f0c4f957a
 ENV TRANSIFEX_LIVE_API fca0343bce994bf8ba3dcdeaab389136
 ENV BING_MAPS_API_KEY PPB0chXATYqlJ5t8oMPp~8SV9SIe2D0Ntc5sW3HExZA~AqTJgLkvvOdot-y1QukRox537t604Je0pxhygfcraTQGVWr7Ko9LwPoS7-MHW0qY
+ENV API_ENV production,preproduction
+ENV GOOGLE_ANALYTICS UA-67196006-1
 
 RUN apt-get update && \
     apt-get install -y bash git build-essential \

--- a/Dockerfile-staging
+++ b/Dockerfile-staging
@@ -13,6 +13,8 @@ ENV OPBEAT_APP_ID 7170680c2a
 ENV ADD_SEARCH_KEY cb7e797b8a3c0d09c323955f0c4f957a
 ENV TRANSIFEX_LIVE_API fca0343bce994bf8ba3dcdeaab389136
 ENV BING_MAPS_API_KEY PPB0chXATYqlJ5t8oMPp~8SV9SIe2D0Ntc5sW3HExZA~AqTJgLkvvOdot-y1QukRox537t604Je0pxhygfcraTQGVWr7Ko9LwPoS7-MHW0qY
+ENV API_ENV production,preproduction
+ENV GOOGLE_ANALYTICS UA-67196006-1
 
 RUN apt-get update && \
     apt-get install -y bash git build-essential \

--- a/next.config.js
+++ b/next.config.js
@@ -57,7 +57,9 @@ module.exports = {
         'process.env.STATIC_SERVER_URL': JSON.stringify(process.env.STATIC_SERVER_URL),
         'process.env.ADD_SEARCH_KEY': JSON.stringify(process.env.ADD_SEARCH_KEY),
         'process.env.TRANSIFEX_LIVE_API': JSON.stringify(process.env.TRANSIFEX_LIVE_API),
-        'process.env.BING_MAPS_API_KEY': JSON.stringify(process.env.BING_MAPS_API_KEY)
+        'process.env.BING_MAPS_API_KEY': JSON.stringify(process.env.BING_MAPS_API_KEY),
+        'process.env.API_ENV': JSON.stringify(process.env.API_ENV),
+        'process.env.GOOGLE_ANALYTICS': JSON.stringify(process.env.GOOGLE_ANALYTICS)
       })
     );
 


### PR DESCRIPTION
This PR fixes a bug where the newest ENV variables `API_ENV` and `GOOGLE_ANALYTICS` would be `undefined` in the browser causing what seems to be unrelated issues.

[Pivotal task (of a bug caused by this)](https://www.pivotaltracker.com/n/projects/1374154/stories/152806171)