### PR TITLE
Editor: only show the relevant columns, if defined

### DIFF
--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -365,10 +365,15 @@ class WidgetEditor extends React.Component {
           );
 
           // We add the aliases and descriptions to the fields
-          const fields = this.props.widgetEditor.fields.map(field => Object.assign({}, field, {
+          let fields = this.props.widgetEditor.fields.map(field => Object.assign({}, field, {
             alias: getMetadata(field.columnName, 'alias'),
             description: getMetadata(field.columnName, 'description')
           }));
+
+          // We filter the fields according to the relevant columns
+          const relevantColumns = attributes.widgetRelevantProps || [];
+          fields = fields.filter(field => !relevantColumns.length
+            || attributes.widgetRelevantProps.indexOf(field.columnName) !== -1);
 
           // If the widget is a raster one, we save the information
           // related to its bands (alias, description, etc.)


### PR DESCRIPTION
This PR filters out the columns of the editor that are not "relevant" when the relevant columns are defined. If no one is defined, then the whole list is displayed (as before).

You can test with this dataset `0b9f0100-ce5b-430f-ad8f-3363efa05481` and compare the list of columns with `develop`.

[Pivotal task](https://www.pivotaltracker.com/story/show/152804387)