### PR TITLE
Editor: prevent the filter tooltip from opening when restoring the state

### DIFF
--- a/components/widgets/editor/ui/ColumnBox.js
+++ b/components/widgets/editor/ui/ColumnBox.js
@@ -91,20 +91,30 @@ class ColumnBox extends React.Component {
     };
   }
 
+  componentDidMount() {
+    // This condition is truthy when the column is opened
+    // inside the filters container
+    if (this.props.isA === 'filter') {
+      const columnName = this.props.name;
+      const filters = this.props.widgetEditor.filters;
+      const filter = filters.find(f => f.name === columnName);
+      // We assume that a filter is considered as "just been
+      // dropped" if it still haven't been assigned a value
+      const hasBeenDropped = !filter || !filter.value
+        || (Array.isArray(filter.value) && !filter.value.length);
+
+      // We ONLY open the filter tooltip if the user has just
+      // dropped the column, not when we're restoring the state
+      // of the editor
+      if (hasBeenDropped) this.openFilterTooltip();
+    }
+  }
 
   componentWillReceiveProps(nextProps) {
-    // Open the filter tooltip the when the columnbox has been dropped
-    if (this.props.isA && this.props.isA === 'filter' && !this.state.filterTooltipAlreadyOpened) {
-      this.openFilterTooltip();
-      this.setState({
-        filterTooltipAlreadyOpened: true
-      });
-    }
-
     // We add a dragging cursor to the column box if it's being dragged
     // We have to set the CSS property to the body otherwise it won't be
     // taken into account
-    if (nextProps.isDragging !== this.props.isDragging) {
+    if (!this.props.isDragging && nextProps.isDragging) {
       document.body.classList.toggle('-dragging', nextProps.isDragging);
 
       // We prevent the details tooltip from showing...
@@ -271,6 +281,12 @@ class ColumnBox extends React.Component {
     }
   }
 
+  /**
+   * Open the filter tooltip
+   * NOTE: make sure the component is mounted before calling
+   * this method (it needs to compute bounding rects)
+   * @param {MouseEvent} [event] Click event
+   */
   openFilterTooltip(event) {
     const { name, type, datasetID, tableName } = this.props;
 

--- a/components/widgets/editor/ui/FilterContainer.js
+++ b/components/widgets/editor/ui/FilterContainer.js
@@ -38,7 +38,6 @@ class FilterContainer extends React.Component {
     this.props.setFilterValue(name, value, notNull);
   }
 
-
   render() {
     const { canDrop, connectDropTarget, widgetEditor } = this.props;
     const filters = widgetEditor.filters;


### PR DESCRIPTION
This PR fixes a bug where the tooltips of the filters would open when restoring the state of the editor.

You can test the issue with this dataset: `f8d3e79c-c3d0-4f9a-9b68-9c5ad1f025e4`.

The solution, while working, is based on the assumption that if a filter has no value, it's because it's just been dropped in the container of the filters. In such a case, the tooltip should open to let the user specify the filter.

I've spent _minutes_ finding a better approach, but it seems none of them is trivial. The problem here is that we need to know when a column has just been dropped vs. it's been added artificially to the container (case of the restoration of the editor's state). When a column is dropped, its instance is deleted and a new instance is created in the container. Linking those two instances together is not easy and would require a large amount of work. Not to mention we have a timing constraint because we need to wait for the column to be rendered in the container in order to position the tooltip.

In the future, if the logic of this solution happens to fail, we might need to rethink how this feature is implemented.

[Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/152838738)