### PR TITLE
Editor: fix ever-loading filter tooltip with featureservice datasets

### DIFF
--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -59,7 +59,6 @@ import {
   getChartConfig,
   canRenderChart,
   getChartType,
-  isFieldAllowed,
   checkEditorRestoredState
 } from 'components/widgets/editor/helpers/WidgetHelper';
 import { logEvent } from 'utils/analytics';
@@ -270,9 +269,8 @@ class WidgetEditor extends React.Component {
     });
 
     this.datasetService.getFields()
-      .then((response) => {
-        const fields = response.fields.filter(field => !!isFieldAllowed(field));
-        const fieldsError = !response.fields || !response.fields.length || fields.length === 0;
+      .then((fields) => {
+        const fieldsError = !fields || !fields.length || fields.length === 0;
 
         this.setState({
           // We still need to fetch the aliases in getDatasetInfo

--- a/components/widgets/editor/helpers/WidgetHelper.js
+++ b/components/widgets/editor/helpers/WidgetHelper.js
@@ -25,7 +25,7 @@ const CHART_TYPES = {
   '1d_tick': OneDTickChart
 };
 
-const ALLOWED_FIELD_TYPES = [
+export const ALLOWED_FIELD_TYPES = [
   // --- NUMBER ----
   { name: 'esriFieldTypeSmallInteger', type: 'number', provider: 'esri' },
   { name: 'esriFieldTypeInteger', type: 'number', provider: 'esri' },
@@ -39,11 +39,11 @@ const ALLOWED_FIELD_TYPES = [
   { name: 'real', type: 'number', provider: 'sql' },
   { name: 'decimal', type: 'number', provider: 'sql' },
   // ----- TEXT -----
-  { name: 'string', type: 'text', provider: 'sql' },
-  { name: 'char', type: 'text', provider: 'sql' },
-  { name: 'varchar', type: 'text', provider: 'sql' },
-  { name: 'esriFieldTypeString', type: 'text', provider: 'esri' },
-  { name: 'text', type: 'text', provider: 'elastic' },
+  { name: 'string', type: 'string', provider: 'sql' },
+  { name: 'char', type: 'string', provider: 'sql' },
+  { name: 'varchar', type: 'string', provider: 'sql' },
+  { name: 'esriFieldTypeString', type: 'string', provider: 'esri' },
+  { name: 'text', type: 'string', provider: 'elastic' },
   // ----- DATE ----
   { name: 'esriFieldTypeDate', type: 'date', provider: 'esri' },
   { name: 'date', type: 'date', provider: 'sql' },
@@ -83,18 +83,18 @@ function isBidimensionalChart(chartType) {
   return !oneDimensionalChartTypes.includes(chartType);
 }
 
-export function isFieldAllowed(field) {
-  const fieldTypeAllowed = ALLOWED_FIELD_TYPES
-    .find(val => val.name.toLowerCase() === field.columnType.toLowerCase());
-  const isCartodbId = field.columnName === 'cartodb_id';
-  const result = !isCartodbId && fieldTypeAllowed;
-  return result;
-}
-
-export function isFieldNumber(field) {
-  const fieldd = isFieldAllowed(field);
-  return fieldd ? fieldd.type === 'number' : false;
-}
+/**
+ * Get the simplified field type of the field: "number",
+ * "text", "date", "boolean" or "array" from the raw type
+ * which could be anything from ALLOWED_FIELD_TYPES
+ * If the raw type is not accepted, null will be returned
+ * @param {string} type Raw type of the field
+ * @returns {string|null}
+ */
+export function getSimplifiedFieldType(type) {
+  const simplifiedType = ALLOWED_FIELD_TYPES.find(f => f.name === type);
+  return simplifiedType ? simplifiedType.type : null;
+};
 
 export function isFieldDate(field) {
   const fieldd = isFieldAllowed(field);

--- a/components/widgets/editor/services/DatasetService.js
+++ b/components/widgets/editor/services/DatasetService.js
@@ -2,7 +2,7 @@ import 'isomorphic-fetch';
 import Promise from 'bluebird';
 
 // Utils
-import { isFieldDate, isFieldNumber } from 'components/widgets/editor/helpers/WidgetHelper';
+import { getSimplifiedFieldType } from 'components/widgets/editor/helpers/WidgetHelper';
 
 /**
  * Dataset service
@@ -102,7 +102,7 @@ export default class DatasetService {
   getFilter(fieldData) {
     return new Promise((resolve) => {
       const newFieldData = fieldData;
-      if (isFieldNumber(fieldData) || isFieldDate(fieldData)) {
+      if (fieldData.type === 'number' || fieldData.type === 'date') {
         this.getMinAndMax(fieldData.columnName, fieldData.tableName, fieldData.geostore).then((data) => {
           newFieldData.properties = data;
           resolve(newFieldData);
@@ -116,53 +116,34 @@ export default class DatasetService {
     });
   }
 
-  getFilters() {
-    return new Promise((resolve) => {
-      this.getFields().then((fieldsData) => {
-        const filteredFields = fieldsData.fields.filter(field => field.columnType === 'number' || field.columnType === 'date' || field.columnType === 'string');
-        const promises = (filteredFields || []).map((field) => {
-          if (field.columnType === 'number' || field.columnType === 'date') {
-            return this.getMinAndMax(field.columnName, fieldsData.tableName);
-          }
-          return this.getValues(field.columnName, fieldsData.tableName);
-        });
-        Promise.all(promises).then((results) => {
-          const filters = (filteredFields || []).map((field, index) => {
-            const filterResult = {
-              columnName: field.columnName,
-              columnType: field.columnType
-            };
-            if (field.columnType === 'number' || field.columnType === 'date') {
-              filterResult.properties = results[index];
-            } else {
-              filterResult.properties = {
-                values: results[index]
-              };
-            }
-            return filterResult;
-          });
-          resolve(filters);
-        });
-      });
-    });
-  }
-
+  /**
+   * Returns the list of fields of the dataset
+   * @returns {{ columnName: string, columnType: string }[]}
+   */
   getFields() {
     return fetch(`${this.opts.apiURL}/fields/${this.datasetId}`)
       .then((response) => {
         if (response.status >= 400) throw new Error(response.statusText);
         return response.json();
       })
-      .then((jsonData) => {
-        const fieldsObj = jsonData.fields;
-        const parsedData = {
-          tableName: jsonData.tableName,
-          fields: (Object.keys(fieldsObj) || []).map(key => ({
-            columnName: key,
-            columnType: fieldsObj[key].type
-          }))
-        };
-        return parsedData;
+      .then((data) => {
+        /** @type {{ [field: string]: { type: string } }} */
+        const fieldToType = data.fields;
+
+        return Object.keys(fieldToType)
+          .map((field) => {
+            // We make sure the type of the field is the simplified
+            // version of it
+            const columnType = getSimplifiedFieldType(fieldToType[field].type);
+            if (!columnType) return null;
+
+            return {
+              columnName: field,
+              columnType
+            };
+          })
+          // We filter out the fields whose type is not supported
+          .filter(f => !!f);
       });
   }
 

--- a/components/widgets/editor/ui/ColumnBox.js
+++ b/components/widgets/editor/ui/ColumnBox.js
@@ -17,9 +17,6 @@ import AggregateFunctionTooltip from 'components/widgets/editor/tooltip/Aggregat
 import OrderByTooltip from 'components/widgets/editor/tooltip/OrderByTooltip';
 import ColumnDetails from 'components/widgets/editor/tooltip/ColumnDetails';
 
-// Utils
-import { isFieldAllowed } from 'components/widgets/editor/helpers/WidgetHelper';
-
 const NAME_MAX_LENGTH = 9;
 
 /**
@@ -406,11 +403,11 @@ class ColumnBox extends React.Component {
 
     const orderType = orderBy ? orderBy.orderType : null;
     let iconName;
-    switch (isFieldAllowed({ columnType: type }).type) {
+    switch (type) {
       case 'number':
         iconName = 'icon-item-number';
         break;
-      case 'text':
+      case 'string':
         iconName = 'icon-item-category';
         break;
       case 'date':

--- a/services/DatasetService.js
+++ b/services/DatasetService.js
@@ -1,8 +1,5 @@
 import 'isomorphic-fetch';
 
-// Utils
-import { isFieldDate, isFieldNumber } from 'utils/widgets/WidgetHelper';
-
 function parseDataset(dataset) {
   const d = Object.assign({}, { ...dataset.attributes, id: dataset.id });
   if (d.metadata) {
@@ -127,7 +124,7 @@ export default class DatasetService {
   getFilter(fieldData) {
     return new Promise((resolve) => {
       const newFieldData = fieldData;
-      if (isFieldNumber(fieldData) || isFieldDate(fieldData)) {
+      if (fieldData === 'number' || fieldData === 'date') {
         this.getMinAndMax(fieldData.columnName, fieldData.tableName).then((data) => {
           newFieldData.properties = data;
           resolve(newFieldData);
@@ -138,37 +135,6 @@ export default class DatasetService {
           resolve(newFieldData);
         });
       }
-    });
-  }
-
-  getFilters() {
-    return new Promise((resolve) => {
-      this.getFields().then((fieldsData) => {
-        const filteredFields = fieldsData.fields.filter(field => field.columnType === 'number' || field.columnType === 'date' || field.columnType === 'string');
-        const promises = (filteredFields || []).map((field) => {
-          if (field.columnType === 'number' || field.columnType === 'date') {
-            return this.getMinAndMax(field.columnName, fieldsData.tableName);
-          }
-          return this.getValues(field.columnName, fieldsData.tableName);
-        });
-        Promise.all(promises).then((results) => {
-          const filters = (filteredFields || []).map((field, index) => {
-            const filterResult = {
-              columnName: field.columnName,
-              columnType: field.columnType
-            };
-            if (field.columnType === 'number' || field.columnType === 'date') {
-              filterResult.properties = results[index];
-            } else {
-              filterResult.properties = {
-                values: results[index]
-              };
-            }
-            return filterResult;
-          });
-          resolve(filters);
-        });
-      });
     });
   }
 

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -82,24 +82,6 @@ function isBidimensionalChart(chartType) {
   return !oneDimensionalChartTypes.includes(chartType);
 }
 
-export function isFieldAllowed(field) {
-  const fieldTypeAllowed = ALLOWED_FIELD_TYPES
-    .find(val => val.name.toLowerCase() === field.columnType.toLowerCase());
-  const isCartodbId = field.columnName === 'cartodb_id';
-  const result = !isCartodbId && fieldTypeAllowed;
-  return result;
-}
-
-export function isFieldNumber(field) {
-  const fieldd = isFieldAllowed(field);
-  return fieldd ? fieldd.type === 'number' : false;
-}
-
-export function isFieldDate(field) {
-  const fieldd = isFieldAllowed(field);
-  return fieldd ? fieldd.type === 'date' : false;
-}
-
 export function getChartType(type) {
   return CHART_TYPES[type];
 }


### PR DESCRIPTION
## Overview
The featureservice datasets have fields whose types all start with `esriXXX`: `esriFieldTypeString`, `esriFieldTypeGeometry`, etc. When trying to drag a column with one of those types in the filter container, the tooltip would never finish to load. The issue is that we were managing two types of fields in the editor:
1. The real types of the fields, such as `esriFieldTypeString`
2. Simplified types, such as `string`

This PR makes sure that we always use the simplified types from the start (when fetching the fields), so we can remove inconsistencies (= bugs). In addition, the type `string` would be sometimes called `text`, so now it's always `string`.

As a result, the user can now use `esriXXX` columns to filter a dataset.

## Testing instructions
You can test the editor perfectly handles `esriXXX` types with this dataset: `3c542216-9840-45ec-803d-7df977302099`.

## Pivotal task
None. Bug originally detected in PReP.