### PR TITLE
Editor: some layers wouldn't appear and some esri ones wouldn't load

### DIFF
--- a/components/widgets/editor/services/DatasetService.js
+++ b/components/widgets/editor/services/DatasetService.js
@@ -213,7 +213,7 @@ export default class DatasetService {
   }
 
   getLayers() {
-    return fetch(`${this.opts.apiURL}/dataset/${this.datasetId}/layer?application=${[process.env.APPLICATIONS]}`)
+    return fetch(`${this.opts.apiURL}/dataset/${this.datasetId}/layer?application=${[process.env.APPLICATIONS]}&env=${process.env.API_ENV}`)
       .then((response) => {
         if (response.status >= 400) throw new Error(response.statusText);
         return response.json();

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dotenv": "4.0.0",
     "es-decorators": "1.0.0",
     "es6-promise": "4.1.1",
-    "esri-leaflet": "2.0.8",
+    "esri-leaflet": "2.1.1",
     "eventemitter3": "2.0.3",
     "express": "4.14.0",
     "express-session": "1.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3934,12 +3934,11 @@ esrecurse@^4.1.0:
     estraverse "^4.1.0"
     object-assign "^4.0.1"
 
-esri-leaflet@2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/esri-leaflet/-/esri-leaflet-2.0.8.tgz#c906b58f28bd7f88d0e9f646d61bc0d226a79517"
+esri-leaflet@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/esri-leaflet/-/esri-leaflet-2.1.1.tgz#0554b4fd2c360051b638774779561bc9dc03e8a6"
   dependencies:
     arcgis-to-geojson-utils "^1.0.1"
-    leaflet "^1.0.0"
     leaflet-virtual-grid "^1.0.3"
     tiny-binary-search "^1.0.2"
 
@@ -6220,7 +6219,7 @@ leaflet@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.0.3.tgz#1f401b98b45c8192134c6c8d69686253805007c8"
 
-leaflet@^1.0.0, leaflet@^1.0.0-rc.1:
+leaflet@^1.0.0-rc.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.2.0.tgz#fd5d93d9cb00091f5f8a69206d0d6744c1c82697"
 


### PR DESCRIPTION
## Overview
This PR fixes two independent issues affecting some layers in the widget editor:
1. The `env` parameter wouldn't be sent with the query retrieving the layers so some datasets would appear with less or no dataset.
2. A special kind of esri layer would fail to render on the map because the `esri-leaflet` dependency had a bug. It's been updated.

## Testing instructions
1. Go to the Explore Details page of any dataset.
2. Replace the ID in the URL by this one: `ffe316c8-c059-4ed6-a5c9-bc640afe4d0e ` and reload the page.
3. You should be able to display the layer on the map.

## Pivotal task
None. Bug originally found on PReP.
