### PR TITLE
Editor: remove a prop validation error

### DIFF
--- a/components/widgets/editor/tooltip/FilterTooltip.js
+++ b/components/widgets/editor/tooltip/FilterTooltip.js
@@ -24,7 +24,8 @@ class FilterTooltip extends React.Component {
     const filter = filters && filters.find(f => f.name === props.name);
 
     this.state = {
-      selected: (filter) ? filter.value : [],
+      /** @type {any[]} selected */
+      selected: (filter && filter.value) || [],
       notNullSelected: filter && filter.notNull,
       loading: true
     };


### PR DESCRIPTION
## Overview
This PR fixes a prop validation error when adding a filter in the editor.

## Testing instructions
Add a column which has string values only to the filter container and check whether or not there's a prop validation error related to the `FilterStringTooltip` component.

## Pivotal task
None. Bug detected in PReP.
