### PR TITLE
Editor: some "0" could be displayed instead of aliases or field descriptions

### DIFF
--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -353,20 +353,20 @@ class WidgetEditor extends React.Component {
     return this.datasetService.fetchData('metadata')
       .then(({ attributes }) => { // eslint-disable-line arrow-body-style
         return new Promise((resolve) => {
-          const metadata = attributes.metadata.length
-            && attributes.metadata[0]
+          const metadata = !!attributes.metadata.length
+            && !!attributes.metadata[0]
             && attributes.metadata[0].attributes.columns;
 
           // Return the metadata's field for the specified column
-          const getMetadata = (column, field) => (metadata
-            && metadata[column]
+          const getMetadata = (column, field) => (!!metadata
+            && !!metadata[column]
             && metadata[column][field]
           );
 
           // We add the aliases and descriptions to the fields
           let fields = this.props.widgetEditor.fields.map(field => Object.assign({}, field, {
-            alias: getMetadata(field.columnName, 'alias'),
-            description: getMetadata(field.columnName, 'description')
+            alias: getMetadata(field.columnName, 'alias') || '',
+            description: getMetadata(field.columnName, 'description') || ''
           }));
 
           // We filter the fields according to the relevant columns


### PR DESCRIPTION
## Overview
If a dataset didn't contain any metadata, we would store the aliases and field descriptions as `0` in Redux because of the binary operators. Instead, a default empty string is now assigned.

This PR also resolves some related prop validation errors.

## Testing instructions
1. Go to the Explore Details page of this dataset: `45b6a92d-d8b1-49f1-80f6-27d962e7aae4`
2. Hover any column for a few seconds

The tooltip shouldn't contain any `0` below the column's name.

## Pivotal task
[Task](https://www.pivotaltracker.com/n/projects/1374154/stories/153056618)