### PR TITLE
Pulse: 3D layers loading improved

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "rc-slider": "7.0.8",
     "react": "15.6.2",
     "react-ace": "4.3.0",
-    "react-cesium": "git://github.com/Vizzuality/react-cesium.git#daf555b9e9738ceb921536547ad0b74b8dd413bf",
+    "react-cesium": "git://github.com/Vizzuality/react-cesium.git#d3c4bbb4ff2ead603511c9669a7e9aa6d97e132c",
     "react-dnd": "2.4.0",
     "react-dnd-html5-backend": "2.4.1",
     "react-dom": "15.6.2",

--- a/pages/app/Pulse.js
+++ b/pages/app/Pulse.js
@@ -137,7 +137,6 @@ class Pulse extends Page {
     if (nextProps.pulse.layerPoints !== this.props.pulse.layerPoints) {
       if (nextProps.pulse.layerPoints && nextProps.pulse.layerPoints.length > 0) {
         this.setState({
-          loading: false,
           layerPoints: nextProps.pulse.layerPoints.slice(0),
           texture: null,
           useDefaultLayer: false,
@@ -380,6 +379,12 @@ class Pulse extends Page {
     this.props.toggleTooltip(false);
   }
 
+  @Autobind
+  handleShapesCreated() {
+    console.log('handle shapes created!');
+    this.setState({ loading: false });
+  }
+
   render() {
     const { url, layersGroup, pulse } = this.props;
     const { layerActive, layerPoints } = pulse;
@@ -413,6 +418,7 @@ class Pulse extends Page {
               onClick={this.handleCesiumClick}
               onMouseDown={this.handleCesiumMouseDown}
               onMoveStart={this.handleCesiumMoveStart}
+              onShapesCreated={this.handleShapesCreated}
               shapes={shapes}
               zoom={zoom}
               homeButton={false}


### PR DESCRIPTION
The spinner is now being hidden only when a callback is fired from the Map component.

[Pivotal task](https://www.pivotaltracker.com/story/show/153169487)