### PR TITLE
Editor: "cartodb_id" not hidden and broken UI for the raster datasets

### DIFF
--- a/components/widgets/editor/services/DatasetService.js
+++ b/components/widgets/editor/services/DatasetService.js
@@ -143,7 +143,7 @@ export default class DatasetService {
             };
           })
           // We filter out the fields whose type is not supported
-          .filter(f => !!f);
+          .filter(field => !!field && field.columnName !== 'cartodb_id');
       });
   }
 


### PR DESCRIPTION
## Overview
This bug is a regression from e0433d8 (PR #428). The `cartodb_id` field wouldn't be discarded when retrieving the list of fields which caused two issues:
1. The field would appear in the UI (in the editors `ChartEditor` and `NEXGDDPEditor`)
2. The editor would let the user create a standard chart (with `ChartEditor `) for raster datasets

## Testing instructions
Open the Explore Details page of this dataset: `16df8ada-87cc-4907-adce-a98bc4e91856 `. You shouldn't see two "Chart" visualisation types.

## Pivotal task
None, bug found while isolating the editor.