### PR TITLE
Editor: a widget using outdated data could break the UI

### DIFF
--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -98,6 +98,7 @@ const DEFAULT_STATE = {
   hasGeoInfo: false, // Whether the dataset includes geographical information
   tableName: null, // Name of the table
   chartLoading: false, // Whether the chart is loading its data/rendering
+  initializing: false, // Flag to prevent rendering the vis before the end of the init
 
   // CHART CONFIG
   chartConfig: null, // Vega chart configuration
@@ -208,7 +209,8 @@ class WidgetEditor extends React.Component {
       && this.props.widgetEditor.visualizationType !== 'table'
       && this.props.widgetEditor.visualizationType !== 'map'
       && this.props.widgetEditor.visualizationType !== 'embed'
-      && (hasChangedWidgetEditor || previousState.tableName !== this.state.tableName)) {
+      && (hasChangedWidgetEditor || previousState.tableName !== this.state.tableName)
+      && !this.state.initializing) {
       this.fetchChartConfig();
     }
   }
@@ -757,7 +759,8 @@ class WidgetEditor extends React.Component {
       layersLoaded: false,
       layersError: false,
       jiminyLoaded: false,
-      jiminyError: false
+      jiminyError: false,
+      initializing: true
     }, () => {
       Promise.all([this.getFields(), this.getLayers()])
         .then(() => this.getJiminy())
@@ -792,7 +795,8 @@ class WidgetEditor extends React.Component {
             // up to date (for example, the aliases)
             this.checkEditorRestoredState();
           }
-        });
+        })
+        .then(() => this.setState({ initializing: false }));
     });
   }
 


### PR DESCRIPTION
## Overview
The editor is sometimes restored with widgets that use data that isn't available anymore. In such a case, the function `checkEditorRestoredState` makes sure to remove the bits that would cause an issue. Nevertheless, while the widget is being restored, and before its state is checked, the editor would try to render what was in the API.

To avoid this behaviour, a flag has been added in the state of `WidgetEditor`. This flag is set to `true` at the beginning of the initialisation of the editor and is not removed until the state is checked. While this flag is active, the visualisation can't be rendered.

## Testing instructions
Go to the Explore Details page of this dataset: `de452a4c-a55c-464d-9037-8c3e9fe48365 `. You shouldn't see non-existing columns in the column containers, nor an ever-loading spinner.

## Pivotal task
First point of [this task](https://www.pivotaltracker.com/story/show/153242686).