### PR TITLE
Display an empty container when a Vega chart fails to load in Explore

### DIFF
--- a/components/app/explore/DatasetWidgetChart.js
+++ b/components/app/explore/DatasetWidgetChart.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 // Components
 import VegaChart from 'components/widgets/charts/VegaChart';
 import Spinner from 'components/ui/Spinner';
+import DatasetPlaceholderChart from 'components/app/explore/DatasetPlaceholderChart';
 
 // Helpers
 import ChartTheme from 'utils/widgets/theme';
@@ -15,7 +16,8 @@ class DatasetWidgetChart extends React.Component {
 
     this.state = {
       widget: props.widget,
-      loading: false
+      loading: false,
+      error: false
     };
 
     // BINDINGS
@@ -53,6 +55,10 @@ class DatasetWidgetChart extends React.Component {
       '-thumbnail': (mode === 'thumbnail')
     });
 
+    if (this.state.error) {
+      return <DatasetPlaceholderChart />;
+    }
+
     return (
       <div className={classname}>
         <Spinner
@@ -66,6 +72,7 @@ class DatasetWidgetChart extends React.Component {
           reloadOnResize={mode !== 'thumbnail'}
           toggleLoading={this.triggerToggleLoading}
           getForceUpdate={(func) => { this.forceChartUpdate = func; }}
+          onError={() => this.setState({ error: true })}
         />
       </div>
     );

--- a/components/widgets/charts/VegaChart.js
+++ b/components/widgets/charts/VegaChart.js
@@ -353,7 +353,14 @@ class VegaChart extends React.Component {
 
       // We render the chart
       const vis = chart({ el: this.chart, renderer: 'canvas' });
-      vis.update();
+      try {
+        vis.update();
+      } catch (err) { // eslint-disable-line no-shadow
+        console.error(err);
+        this.toggleLoading(false);
+        if (this.props.onError) this.props.onError();
+        return;
+      }
 
       // We toggle off the loader once we've rendered the chart
       this.toggleLoading(false);
@@ -416,6 +423,7 @@ VegaChart.propTypes = {
   // Callbacks
   toggleLoading: PropTypes.func,
   toggleTooltip: PropTypes.func,
+  onError: PropTypes.func,
   // This callback should be passed the function
   // to force the re-render of the chart
   getForceUpdate: PropTypes.func


### PR DESCRIPTION
## Overview
If a widget is saved with a wrong Vega configuration, it would load indefinitely in Explore. Now, in that case, `VegaChart` executes a callback that lets you do the appropriate thing. In this example, we display an empty container.

## Testing instructions
Unfortunately Alicia fixed the broken widget. You can still see how the card would behave commenting the `try` part in `VegaChart`.

## Pivotal task
None.