### PR TITLE
Editor: frozen while restoring some widgets

### DIFF
--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -209,7 +209,8 @@ class WidgetEditor extends React.Component {
       && this.props.widgetEditor.visualizationType !== 'table'
       && this.props.widgetEditor.visualizationType !== 'map'
       && this.props.widgetEditor.visualizationType !== 'embed'
-      && (hasChangedWidgetEditor || previousState.tableName !== this.state.tableName)
+      && (hasChangedWidgetEditor || previousState.tableName !== this.state.tableName
+        || previousState.initializing !== this.state.initializing)
       && !this.state.initializing) {
       this.fetchChartConfig();
     }


### PR DESCRIPTION
## Overview
A regression from dc184c9 (PR #445) made that the editor wouldn't be able to render the widget that it's restoring.

The error comes from the fact that before rendering, we would make sure the props of the editor have changed. Nevertheless, while restoring a widget, at some point the props never change and only the property `initializing` of the state is toggled from `true` to `false`.

## Testing instructions
Go to the Explore Details page of this dataset: `35ce2b98-adbb-4873-b334-d7b1cc542de7`. The editor is loading and then it correctly displays a graph.

## Pivotal task
[Task](https://www.pivotaltracker.com/story/show/153313401)