### PR TITLE
Widget block

### DIFF
--- a/components/app/layout/Page.js
+++ b/components/app/layout/Page.js
@@ -6,7 +6,7 @@ export default class Page extends React.PureComponent {
   static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     return { user, isServer, url };
   }

--- a/components/dashboards/detail/dashboard-detail-component.js
+++ b/components/dashboards/detail/dashboard-detail-component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 // Wysiwyg
 import Wysiwyg from 'vizz-wysiwyg';
-import DashboardWidget from 'components/dashboards/wysiwyg/DashboardWidget';
+import WidgetBlock from 'components/dashboards/wysiwyg/widget-block/widget-block';
 import WidgetBlockEdition from 'components/dashboards/wysiwyg/widget-block-edition/widget-block-edition';
 
 export default function DashboardDetail({ dashboardDetail }) {
@@ -21,7 +21,7 @@ export default function DashboardDetail({ dashboardDetail }) {
       items={items}
       blocks={{
         widget: {
-          Component: DashboardWidget,
+          Component: WidgetBlock,
           EditionComponent: WidgetBlockEdition,
           renderer: 'modal'
         }

--- a/components/dashboards/form/steps/Step1.js
+++ b/components/dashboards/form/steps/Step1.js
@@ -17,7 +17,7 @@ import Checkbox from 'components/form/Checkbox';
 
 // Wysiwyg
 import Wysiwyg from 'components/form/Wysiwyg';
-import DashboardWidget from 'components/dashboards/wysiwyg/DashboardWidget';
+import WidgetBlock from 'components/dashboards/wysiwyg/widget-block/widget-block';
 import WidgetBlockEdition from 'components/dashboards/wysiwyg/widget-block-edition/widget-block-edition';
 
 class Step1 extends React.Component {
@@ -151,7 +151,7 @@ class Step1 extends React.Component {
               default: this.state.form.content,
               blocks: {
                 widget: {
-                  Component: DashboardWidget,
+                  Component: WidgetBlock,
                   EditionComponent: WidgetBlockEdition,
                   renderer: 'modal'
                 }

--- a/components/dashboards/wysiwyg/widget-block/widget-block-actions.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-actions.js
@@ -17,6 +17,7 @@ export const setWidget = createAction('WIDGET_BLOCK_GET');
 export const setWidgetLoading = createAction('WIDGET_BLOCK_LOADING');
 export const setWidgetError = createAction('WIDGET_BLOCK_ERROR');
 export const setWidgetType = createAction('WIDGET_BLOCK_TYPE');
+export const setWidgetModal = createAction('WIDGET_BLOCK_MODAL');
 export const removeWidget = createAction('WIDGET_BLOCK_REMOVE');
 
 // Layer actions

--- a/components/dashboards/wysiwyg/widget-block/widget-block-actions.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-actions.js
@@ -1,0 +1,62 @@
+import 'isomorphic-fetch';
+import { createAction, createThunkAction } from 'redux-actions';
+
+// Actions widgets
+export const setWidget = createAction('WIDGET_BLOCK_GET');
+export const setWidgetLoading = createAction('WIDGET_BLOCK_LOADING');
+export const setWidgetError = createAction('WIDGET_BLOCK_ERROR');
+export const setWidgetType = createAction('WIDGET_BLOCK_TYPE');
+export const removeWidget = createAction('WIDGET_BLOCK_REMOVE');
+
+// Actions layers
+export const setLayers = createAction('WIDGET_BLOCK_LAYERS_GET');
+export const setLayersLoading = createAction('WIDGET_BLOCK_LAYERS_LOADING');
+export const setLayersError = createAction('WIDGET_BLOCK_LAYERS_ERROR');
+
+// Async actions
+export const fetchWidget = createThunkAction('WIDGET_BLOCK_FETCH_DATA', (payload = {}) => (dispatch) => {
+  const id = `${payload.id}/${payload.itemId}`;
+
+  dispatch(setWidgetLoading({ id, value: true }));
+  dispatch(setWidgetError({ id, value: null }));
+
+  fetch(`${process.env.WRI_API_URL}/widget/${payload.id}?&application=${[process.env.APPLICATIONS]}`)
+    .then(response => response.json())
+    .then(({ data }) => {
+      const widget = { id: data.id, ...data.attributes };
+      const { widgetConfig } = widget;
+
+      dispatch(setWidgetLoading({ id, value: false }));
+      dispatch(setWidgetError({ id, value: null }));
+      dispatch(setWidgetType({ id, value: (widgetConfig && widgetConfig.type) || 'vega' }));
+      dispatch(setWidget({ id, value: widget }));
+
+      if (widgetConfig.type && widgetConfig.type === 'map') {
+        dispatch(fetchLayers({ id, widget }));
+      }
+    })
+    .catch((err) => {
+      dispatch(setWidgetLoading(false));
+      dispatch(setWidgetError(err));
+    });
+});
+
+
+export const fetchLayers = createThunkAction('WIDGET_BLOCK_LAYERS_FETCH_DATA', (payload = {}) => (dispatch) => {
+  const id = payload.id;
+
+  dispatch(setLayersLoading({ id, value: true }));
+  dispatch(setLayersError({ id, value: null }));
+
+  fetch(`${process.env.WRI_API_URL}/layer/${payload.widget.widgetConfig.layer_id}?&application=${[process.env.APPLICATIONS]}`)
+    .then(response => response.json())
+    .then(({ data }) => {
+      dispatch(setLayersLoading({ id, value: false }));
+      dispatch(setLayersError({ id, value: null }));
+      dispatch(setLayers({ id, value: data }));
+    })
+    .catch((err) => {
+      dispatch(setLayersLoading({ id, value: false }));
+      dispatch(setLayersError({ id, value: err }));
+    });
+});

--- a/components/dashboards/wysiwyg/widget-block/widget-block-actions.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-actions.js
@@ -53,7 +53,18 @@ export const fetchLayers = createThunkAction('WIDGET_BLOCK_LAYERS_FETCH_DATA', (
     .then(({ data }) => {
       dispatch(setLayersLoading({ id, value: false }));
       dispatch(setLayersError({ id, value: null }));
-      dispatch(setLayers({ id, value: data }));
+      dispatch(setLayers({
+        id,
+        value: [{
+          dataset: data.attributes.dataset,
+          visible: true,
+          layers: [{
+            active: true,
+            id: data.id,
+            ...data.attributes
+          }]
+        }]
+      }));
     })
     .catch((err) => {
       dispatch(setLayersLoading({ id, value: false }));

--- a/components/dashboards/wysiwyg/widget-block/widget-block-component.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-component.js
@@ -1,21 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import isEmpty from 'lodash/isEmpty';
 
 // Components
-import TextChart from 'components/widgets/charts/TextChart';
 import VegaChart from 'components/widgets/charts/VegaChart';
+import TextChart from 'components/widgets/charts/TextChart';
 import Map from 'components/widgets/editor/map/Map';
 import Legend from 'components/widgets/editor/ui/Legend';
 
-import Title from 'components/widgets/editor/ui/Title';
-import Spinner from 'components/widgets/editor/ui/Spinner';
+import Icon from 'components/ui/Icon';
+import Title from 'components/ui/Title';
+import Spinner from 'components/ui/Spinner';
 
 // Utils
 import getChartTheme from 'utils/widgets/theme';
 import LayerManager from 'components/widgets/editor/helpers/LayerManager';
 
-export default function WidgetBlock({ data, item, onToggleLoading }) {
+export default function WidgetBlock({
+  data,
+  item,
+  onToggleFavourite,
+  onToggleModal,
+  onToggleLoading
+}) {
   const id = `${item.content.widgetId}/${item.id}`;
 
   if (!data[id]) {
@@ -29,7 +35,9 @@ export default function WidgetBlock({ data, item, onToggleLoading }) {
     widgetError,
     layers,
     layersLoading,
-    layersError
+    layersError,
+    favourite,
+    favouriteLoading
   } = data[id];
 
   return (
@@ -38,15 +46,28 @@ export default function WidgetBlock({ data, item, onToggleLoading }) {
         <div className="header-container">
           <Title className="-default">{widget ? widget.name : '–'}</Title>
 
-          {/* <button
-            onClick={this.handleFavouriteClick}
-          >
-            <Icon name={`icon-${iconName}`} className="c-icon -small" />
-          </button> */}
+          <div className="buttons">
+            <button
+              type="button"
+              onClick={() => onToggleFavourite(favourite, widget)}
+            >
+              {!favouriteLoading &&
+                <Icon name={`icon-${favourite.id ? 'star-full' : 'star-empty'}`} className="c-icon -small" />
+              }
+
+              {favouriteLoading &&
+                <Spinner isLoading className="-transparent -tiny -inline" />
+              }
+            </button>
+
+            <button
+              type="button"
+              onClick={() => onToggleModal(widget)}
+            >
+              <Icon name="icon-info" className="c-icon -small" />
+            </button>
+          </div>
         </div>
-        {/* <ul className="categories">
-          {this.props.categories.map(category => <li key={category}>{category}</li>)}
-        </ul> */}
       </header>
 
       <div className="widget-container">
@@ -108,11 +129,13 @@ export default function WidgetBlock({ data, item, onToggleLoading }) {
 WidgetBlock.propTypes = {
   data: PropTypes.object,
   item: PropTypes.object,
+  onToggleFavourite: PropTypes.func,
   onToggleLoading: PropTypes.func
 };
 
 WidgetBlock.defaultProps = {
   data: {},
   item: {},
+  onToggleFavourite: null,
   onToggleLoading: null
 };

--- a/components/dashboards/wysiwyg/widget-block/widget-block-component.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-component.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import isEmpty from 'lodash/isEmpty';
+
+// Components
+import TextChart from 'components/widgets/charts/TextChart';
+import VegaChart from 'components/widgets/charts/VegaChart';
+import Map from 'components/widgets/editor/map/Map';
+import Legend from 'components/widgets/editor/ui/Legend';
+
+import Title from 'components/widgets/editor/ui/Title';
+import Spinner from 'components/widgets/editor/ui/Spinner';
+
+// Utils
+import getChartTheme from 'utils/widgets/theme';
+import LayerManager from 'components/widgets/editor/helpers/LayerManager';
+
+export default function WidgetBlock({ data, item, onToggleLoading }) {
+  const id = `${item.content.widgetId}/${item.id}`;
+
+  if (!data[id]) {
+    return null;
+  }
+
+  const {
+    widget,
+    widgetType,
+    widgetLoading,
+    widgetError,
+    layers,
+    layersLoading,
+    layersError
+  } = data[id];
+
+  return (
+    <div className="c-dashboard-card">
+      <header>
+        <div className="header-container">
+          <Title className="-default">{widget ? widget.name : '–'}</Title>
+
+          {/* <button
+            onClick={this.handleFavouriteClick}
+          >
+            <Icon name={`icon-${iconName}`} className="c-icon -small" />
+          </button> */}
+        </div>
+        {/* <ul className="categories">
+          {this.props.categories.map(category => <li key={category}>{category}</li>)}
+        </ul> */}
+      </header>
+
+      <div className="widget-container">
+        <Spinner isLoading={widgetLoading || layersLoading} className="-light -small" />
+
+        {!widgetError && widgetType === 'text' && widget &&
+          <TextChart
+            widgetConfig={widget.widgetConfig}
+            toggleLoading={loading => onToggleLoading(loading)}
+          />
+        }
+
+        {!widgetError && widgetType === 'vega' && widget.widgetConfig && widget &&
+          <VegaChart
+            data={widget.widgetConfig}
+            theme={getChartTheme()}
+            toggleLoading={loading => onToggleLoading(loading)}
+            reloadOnResize
+          />
+        }
+
+        {!widgetError && !layersError && widgetType === 'map' && layers && (
+          <div>
+            <Map
+              LayerManager={LayerManager}
+              mapConfig={{}}
+              layerGroups={layers}
+            />
+            <Legend
+              layerGroups={layers}
+              className={{ color: '-dark' }}
+              toggleLayerGroupVisibility={
+                layerGroup => this.onToggleLayerGroupVisibility(layerGroup)
+              }
+              setLayerGroupsOrder={() => {}}
+              setLayerGroupActiveLayer={() => {}}
+              expanded={false}
+              readonly
+            />
+          </div>
+        )}
+
+        {!widgetError && !layersError && !item && !item.content.widgetId &&
+          <div className="message">
+            <div className="no-data">No data</div>
+          </div>
+        }
+
+        {(widgetError || layersError) &&
+          <div className="message">
+            <div className="error">Unable to load the widget <span>{widgetError || layersError}</span></div>
+          </div>
+        }
+      </div>
+    </div>
+  );
+}
+
+WidgetBlock.propTypes = {
+  data: PropTypes.object,
+  item: PropTypes.object,
+  onToggleLoading: PropTypes.func
+};
+
+WidgetBlock.defaultProps = {
+  data: {},
+  item: {},
+  onToggleLoading: null
+};

--- a/components/dashboards/wysiwyg/widget-block/widget-block-component.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-component.js
@@ -20,7 +20,8 @@ export default function WidgetBlock({
   item,
   onToggleFavourite,
   onToggleModal,
-  onToggleLoading
+  onToggleLoading,
+  onToggleLayerGroupVisibility
 }) {
   const id = `${item.content.widgetId}/${item.id}`;
 
@@ -33,6 +34,7 @@ export default function WidgetBlock({
     widgetType,
     widgetLoading,
     widgetError,
+    widgetModal,
     layers,
     layersLoading,
     layersError,
@@ -62,9 +64,15 @@ export default function WidgetBlock({
 
             <button
               type="button"
-              onClick={() => onToggleModal(widget)}
+              onClick={() => onToggleModal(!widgetModal)}
             >
-              <Icon name="icon-info" className="c-icon -small" />
+              {!widgetModal &&
+                <Icon name="icon-info" className="c-icon -small" />
+              }
+
+              {widgetModal &&
+                <Icon name="icon-cross" className="c-icon -small" />
+              }
             </button>
           </div>
         </div>
@@ -100,7 +108,7 @@ export default function WidgetBlock({
               layerGroups={layers}
               className={{ color: '-dark' }}
               toggleLayerGroupVisibility={
-                layerGroup => this.onToggleLayerGroupVisibility(layerGroup)
+                layerGroup => onToggleLayerGroupVisibility(layerGroup)
               }
               setLayerGroupsOrder={() => {}}
               setLayerGroupActiveLayer={() => {}}
@@ -121,6 +129,21 @@ export default function WidgetBlock({
             <div className="error">Unable to load the widget <span>{widgetError || layersError}</span></div>
           </div>
         }
+
+        {widgetModal &&
+          <div className="widget-modal">
+            {widget && !widget.description &&
+              <p>No additional information is available</p>
+            }
+
+            {widget && widget.description && (
+              <div>
+                <h4>Description</h4>
+                <p>{widget.description}</p>
+              </div>
+            )}
+          </div>
+        }
       </div>
     </div>
   );
@@ -129,6 +152,7 @@ export default function WidgetBlock({
 WidgetBlock.propTypes = {
   data: PropTypes.object,
   item: PropTypes.object,
+  onToggleModal: PropTypes.func,
   onToggleFavourite: PropTypes.func,
   onToggleLoading: PropTypes.func
 };
@@ -136,6 +160,7 @@ WidgetBlock.propTypes = {
 WidgetBlock.defaultProps = {
   data: {},
   item: {},
+  onToggleModal: null,
   onToggleFavourite: null,
   onToggleLoading: null
 };

--- a/components/dashboards/wysiwyg/widget-block/widget-block-default-state.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-default-state.js
@@ -1,0 +1,1 @@
+export default {};

--- a/components/dashboards/wysiwyg/widget-block/widget-block-reducers.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-reducers.js
@@ -1,0 +1,102 @@
+import * as actions from './widget-block-actions';
+
+const defaultWidget = {
+  widget: {},
+  widgetLoading: false,
+  widgetError: null,
+  widgetType: 'vega',
+
+  // Add-ons
+  layers: [],
+  layersLoading: false,
+  layersError: null,
+
+  favourites: []
+};
+
+
+export default {
+  [actions.setWidget]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      widget: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
+  },
+
+  [actions.setWidgetLoading]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      widgetLoading: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
+  },
+
+  [actions.setWidgetError]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      widgetError: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
+  },
+
+  [actions.setWidgetType]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      widgetType: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
+  },
+
+  [actions.removeWidget]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    delete state[action.payload.id];
+    return state;
+  },
+
+  [actions.setLayers]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      layers: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
+  },
+
+  [actions.setLayersLoading]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      layersLoading: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
+  },
+
+  [actions.setLayersError]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      layersError: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
+  }
+};

--- a/components/dashboards/wysiwyg/widget-block/widget-block-reducers.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-reducers.js
@@ -5,6 +5,7 @@ const defaultWidget = {
   widgetLoading: false,
   widgetError: null,
   widgetType: 'vega',
+  widgetModal: false,
 
   // Layers
   layers: [],
@@ -59,6 +60,17 @@ export default {
       ...defaultWidget,
       ...state[action.payload.id],
       widgetType: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
+  },
+
+  [actions.setWidgetModal]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      widgetModal: action.payload.value
     };
     return { ...state, [action.payload.id]: widget };
   },

--- a/components/dashboards/wysiwyg/widget-block/widget-block-reducers.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-reducers.js
@@ -6,12 +6,15 @@ const defaultWidget = {
   widgetError: null,
   widgetType: 'vega',
 
-  // Add-ons
+  // Layers
   layers: [],
   layersLoading: false,
   layersError: null,
 
-  favourites: []
+  // Favourites
+  favourite: {},
+  favouriteLoading: false,
+  favouriteError: null
 };
 
 
@@ -98,5 +101,39 @@ export default {
       layersError: action.payload.value
     };
     return { ...state, [action.payload.id]: widget };
+  },
+
+  [actions.setFavourite]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      favourite: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
+  },
+
+  [actions.setFavouriteLoading]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      favouriteLoading: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
+  },
+
+  [actions.setFavouriteError]: (state, action) => {
+    if (!action.payload.id) return state;
+
+    const widget = {
+      ...defaultWidget,
+      ...state[action.payload.id],
+      favouriteError: action.payload.value
+    };
+    return { ...state, [action.payload.id]: widget };
   }
+
 };

--- a/components/dashboards/wysiwyg/widget-block/widget-block.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block.js
@@ -1,0 +1,68 @@
+import React, { createElement } from 'react';
+import PropTypes from 'prop-types';
+
+import { connect } from 'react-redux';
+import * as actions from './widget-block-actions';
+import reducers from './widget-block-reducers';
+import defaultState from './widget-block-default-state';
+
+import WidgetBlockComponent from './widget-block-component';
+
+// Mandatory
+export {
+  actions, reducers, defaultState
+};
+
+class WidgetBlock extends React.Component {
+  static propTypes = {
+    item: PropTypes.object.isRequired,
+
+    // Redux
+    setWidgetLoading: PropTypes.func.isRequired,
+    removeWidget: PropTypes.func.isRequired
+  };
+
+  async componentWillMount() {
+    if (this.props.item.content.widgetId) {
+      await this.triggerFetch(this.props);
+    }
+  }
+
+  async componentWillReceiveProps(nextProps) {
+    if (nextProps.item.content.widgetId !== this.props.item.content.widgetId) {
+      await this.triggerFetch(nextProps);
+    }
+  }
+
+  componentWillUnmount() {
+    const { item } = this.props;
+    // Reset widget
+    this.props.removeWidget({
+      id: `${item.content.widgetId}/${item.id}`
+    });
+  }
+
+  /**
+   * HELPERS
+   * - triggerFetch
+  */
+  triggerFetch = props => props.fetchWidget({
+    id: props.item.content.widgetId,
+    itemId: props.item.id
+  })
+
+  render() {
+    return createElement(WidgetBlockComponent, {
+      onToggleLoading: (loading) => {
+        this.props.setWidgetLoading(loading);
+      },
+      ...this.props
+    });
+  }
+}
+export default connect(
+  state => ({
+    data: state.widgetBlock
+  }),
+  actions
+)(WidgetBlock);

--- a/components/dashboards/wysiwyg/widget-block/widget-block.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block.js
@@ -16,12 +16,14 @@ export {
 class WidgetBlock extends React.Component {
   static propTypes = {
     item: PropTypes.object.isRequired,
+    data: PropTypes.object.isRequired,
 
     // Redux
     setWidgetLoading: PropTypes.func.isRequired,
     setWidgetModal: PropTypes.func.isRequired,
-    toggleFavourite: PropTypes.func.isRequired,
-    removeWidget: PropTypes.func.isRequired
+    removeWidget: PropTypes.func.isRequired,
+    setLayers: PropTypes.func.isRequired,
+    toggleFavourite: PropTypes.func.isRequired
   };
 
   async componentWillMount() {
@@ -96,13 +98,18 @@ class WidgetBlock extends React.Component {
         });
       },
       onToggleLayerGroupVisibility: (layerGroup) => {
-        console.log(layerGroup);
-        // const layerGroups = this.state.layers.map((l) => {
-        //   if (l.dataset !== layerGroup.dataset) return l;
-        //   return Object.assign({}, l, { visible: !layerGroup.visible });
-        // });
-        //
-        // this.setState({ layers: [...layerGroups] });
+        const { data, item } = this.props;
+        const layers = [...data[`${item.content.widgetId}/${item.id}`].layers];
+
+        const layerGroups = layers.map((l) => {
+          if (l.dataset !== layerGroup.dataset) return l;
+          return Object.assign({}, l, { visible: !layerGroup.visible });
+        });
+
+        this.props.setLayers({
+          id: `${item.content.widgetId}/${item.id}`,
+          value: layerGroups
+        });
       },
       ...this.props
     });

--- a/components/dashboards/wysiwyg/widget-block/widget-block.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block.js
@@ -19,6 +19,7 @@ class WidgetBlock extends React.Component {
 
     // Redux
     setWidgetLoading: PropTypes.func.isRequired,
+    setWidgetModal: PropTypes.func.isRequired,
     toggleFavourite: PropTypes.func.isRequired,
     removeWidget: PropTypes.func.isRequired
   };
@@ -69,11 +70,21 @@ class WidgetBlock extends React.Component {
 
   render() {
     return createElement(WidgetBlockComponent, {
-      onToggleModal: (loading) => {
-        // this.props.setWidgetLoading(loading);
+      onToggleModal: (modal) => {
+        const { item } = this.props;
+
+        this.props.setWidgetModal({
+          id: `${item.content.widgetId}/${item.id}`,
+          value: modal
+        });
       },
       onToggleLoading: (loading) => {
-        this.props.setWidgetLoading(loading);
+        const { item } = this.props;
+
+        this.props.setWidgetLoading({
+          id: `${item.content.widgetId}/${item.id}`,
+          value: loading
+        });
       },
       onToggleFavourite: (favourite, widget) => {
         const { item } = this.props;
@@ -83,6 +94,15 @@ class WidgetBlock extends React.Component {
           favourite,
           widget
         });
+      },
+      onToggleLayerGroupVisibility: (layerGroup) => {
+        console.log(layerGroup);
+        // const layerGroups = this.state.layers.map((l) => {
+        //   if (l.dataset !== layerGroup.dataset) return l;
+        //   return Object.assign({}, l, { visible: !layerGroup.visible });
+        // });
+        //
+        // this.setState({ layers: [...layerGroups] });
       },
       ...this.props
     });

--- a/components/dashboards/wysiwyg/widget-block/widget-block.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block.js
@@ -69,6 +69,9 @@ class WidgetBlock extends React.Component {
 
   render() {
     return createElement(WidgetBlockComponent, {
+      onToggleModal: (loading) => {
+        // this.props.setWidgetLoading(loading);
+      },
       onToggleLoading: (loading) => {
         this.props.setWidgetLoading(loading);
       },

--- a/components/dashboards/wysiwyg/widget-block/widget-block.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block.js
@@ -19,18 +19,21 @@ class WidgetBlock extends React.Component {
 
     // Redux
     setWidgetLoading: PropTypes.func.isRequired,
+    toggleFavourite: PropTypes.func.isRequired,
     removeWidget: PropTypes.func.isRequired
   };
 
   async componentWillMount() {
     if (this.props.item.content.widgetId) {
       await this.triggerFetch(this.props);
+      this.setFavourite(this.props);
     }
   }
 
   async componentWillReceiveProps(nextProps) {
     if (nextProps.item.content.widgetId !== this.props.item.content.widgetId) {
       await this.triggerFetch(nextProps);
+      this.setFavourite(nextProps);
     }
   }
 
@@ -45,7 +48,20 @@ class WidgetBlock extends React.Component {
   /**
    * HELPERS
    * - triggerFetch
+   * - setFavourite
   */
+  setFavourite = (props) => {
+    const { item } = props;
+    const favourite = props.user.favourites.find(f =>
+      f.attributes.resourceId === item.content.widgetId
+    );
+
+    props.setFavourite({
+      id: `${item.content.widgetId}/${item.id}`,
+      value: favourite || {}
+    });
+  }
+
   triggerFetch = props => props.fetchWidget({
     id: props.item.content.widgetId,
     itemId: props.item.id
@@ -56,13 +72,23 @@ class WidgetBlock extends React.Component {
       onToggleLoading: (loading) => {
         this.props.setWidgetLoading(loading);
       },
+      onToggleFavourite: (favourite, widget) => {
+        const { item } = this.props;
+
+        this.props.toggleFavourite({
+          id: `${item.content.widgetId}/${item.id}`,
+          favourite,
+          widget
+        });
+      },
       ...this.props
     });
   }
 }
 export default connect(
   state => ({
-    data: state.widgetBlock
+    data: state.widgetBlock,
+    user: state.user
   }),
   actions
 )(WidgetBlock);

--- a/components/widgets/editor/services/UserService.js
+++ b/components/widgets/editor/services/UserService.js
@@ -35,7 +35,7 @@ export default class UserService {
    * @returns {Promise}
    */
   getFavouriteWidgets(token) {
-    return this.getFavourites(token, 'widget', true);
+    return this.setFavourites(token, 'widget', true);
   }
 
   /**
@@ -44,7 +44,7 @@ export default class UserService {
     * @param {token} User token
    * @returns {Promise}
    */
-  getFavourites(token, resourceType = null, include = true) {
+  setFavourites(token, resourceType = null, include = true) {
     const resourceTypeSt = (resourceType !== null) ? `&resourceType=${resourceType}` : '';
     return new Promise((resolve) => {
       fetch(`${this.opts.apiURL}/favourite?include=${include}${resourceTypeSt}&application=${[process.env.APPLICATIONS]}`, {

--- a/css/components/dashboards/dashboard-card.scss
+++ b/css/components/dashboards/dashboard-card.scss
@@ -69,5 +69,26 @@
     .c-chart {
       height: auto;
     }
+
+    .widget-modal {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      padding: $margin-size-extra-small;
+      z-index: 3;
+      background-color: $white;
+      overflow-x: hidden;
+      overflow-y: auto;
+
+      > div {
+        margin-bottom: $margin-size-extra-small;
+      }
+
+      h4 {
+        color: $base-font-color;
+      }
+    }
   }
 }

--- a/css/components/dashboards/dashboard-card.scss
+++ b/css/components/dashboards/dashboard-card.scss
@@ -1,5 +1,6 @@
 .c-dashboard-card {
   width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   background-color: $color-white;
@@ -8,36 +9,27 @@
   box-shadow: 0 1px 2px 0 rgba($color-black, .05);
 
   > header {
+    min-height: 51px;
     padding: 15px;
     border-bottom: 2px solid rgba($color-black, .05);
 
     .header-container {
+      position: relative;
       display: flex;
       align-items: baseline;
       justify-content: space-between;
+      padding-right: 80px;
 
-      .c-icon {
-        cursor: pointer;
-      }
-    }
+      .buttons {
+        position: absolute;
+        top: 2px;
+        right: 0;
+        margin: 0;
+        padding: 0;
 
-    .categories {
-      margin: 5px 0 0;
-      padding: 0;
-      list-style: none;
-
-      li {
-        display: inline-block;
-        text-transform: uppercase;
-        font-size: $font-size-small-medium;
-        font-weight: $font-weight-bold;
-        color: $color-secondary;
-
-        &:not(:last-of-type)::after {
-          display: inline-block;
-          margin: 0 .5ch;
-          color: $color-text-2;
-          content: '+';
+        button {
+          position: relative;
+          cursor: pointer;
         }
       }
     }

--- a/css/components/ui/modal.scss
+++ b/css/components/ui/modal.scss
@@ -6,7 +6,7 @@
   height: 100%;
   background: rgba($color-black, .3);
   transition: all $animation-time $ease-in-sine;
-  z-index: 1000; // Just to be sure that is over all the content
+  z-index: 100000; // Just to be sure that is over all the content
   visibility: visible;
   opacity: 1;
   display: flex;

--- a/css/components/ui/spinner.scss
+++ b/css/components/ui/spinner.scss
@@ -74,6 +74,17 @@
       }
     }
   }
+
+  // Sizes
+  &.-tiny {
+    .spinner-box {
+      .icon {
+        width: 14px;
+        height: 14px;
+      }
+    }
+  }
+
 }
 
  // ROTATE

--- a/pages/app/About.js
+++ b/pages/app/About.js
@@ -18,7 +18,7 @@ class About extends Page {
   static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     await store.dispatch(getStaticData('about'));
     return { isServer, user, url };

--- a/pages/app/Dashboards.js
+++ b/pages/app/Dashboards.js
@@ -18,7 +18,7 @@ class Dashboards extends Page {
   static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
 
     store.dispatch(setPagination(false));

--- a/pages/app/DashboardsDetail.js
+++ b/pages/app/DashboardsDetail.js
@@ -20,7 +20,7 @@ class DashboardsDetail extends Page {
   static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
 
     store.dispatch(setPagination(true));

--- a/pages/app/DashboardsDetail.js
+++ b/pages/app/DashboardsDetail.js
@@ -6,14 +6,12 @@ import { initStore } from 'store';
 import { setUser } from 'redactions/user';
 import { setRouter } from 'redactions/routes';
 import { fetchDashboard } from 'components/dashboards/detail/dashboard-detail-actions';
-import { fetchDashboards, setSelected, setExpanded, setPagination } from 'components/dashboards/thumbnail-list/dashboard-thumbnail-list-actions';
 
 // Components
 import Page from 'components/app/layout/Page';
 import Layout from 'components/app/layout/Layout';
 import Breadcrumbs from 'components/ui/Breadcrumbs';
 
-import DashboardThumbnailList from 'components/dashboards/thumbnail-list/dashboard-thumbnail-list';
 import DashboardDetail from 'components/dashboards/detail/dashboard-detail';
 
 class DashboardsDetail extends Page {
@@ -23,12 +21,7 @@ class DashboardsDetail extends Page {
     await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
 
-    store.dispatch(setPagination(true));
     await store.dispatch(fetchDashboard({ id: url.query.slug }));
-    await store.dispatch(setSelected(url.query.slug));
-    await store.dispatch(fetchDashboards({
-      filters: { 'filter[published]': 'true' }
-    }));
 
     return { isServer, user, url };
   }
@@ -62,23 +55,6 @@ class DashboardsDetail extends Page {
           <div className="l-container">
             <div className="row">
               <div className="column small-12">
-                <DashboardThumbnailList
-                  onSelect={({ slug }) => {
-                    // We need to make an amendment to have this working
-                    // Router.pushRoute('dashboards_detail', { slug });
-                    window.location = `/data/dashboards/${slug}`;
-                  }}
-                  onExpand={(bool) => {
-                    this.props.setExpanded(bool);
-                  }}
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className="l-container">
-            <div className="row">
-              <div className="column small-12">
                 <DashboardDetail />
               </div>
             </div>
@@ -94,11 +70,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = {
-  fetchDashboard,
-  fetchDashboards,
-  setSelected,
-  setExpanded,
-  setPagination
+  fetchDashboard
 };
 
 export default withRedux(initStore, mapStateToProps, mapDispatchToProps)(DashboardsDetail);

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -95,7 +95,7 @@ class Explore extends Page {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const botUserAgent = isServer && /AddSearchBot/.test(req.headers['user-agent']);
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
 
     // We set the initial state of the map

--- a/pages/app/ExploreBeta.js
+++ b/pages/app/ExploreBeta.js
@@ -22,7 +22,7 @@ class ExploreBeta extends Page {
   static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     await store.dispatch(getDatasets({
       pageNumber: query.page,

--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -64,7 +64,7 @@ class ExploreDetail extends Page {
   static async getInitialProps({ asPath, pathname, query, req, res, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     await store.dispatch(getDataset(url.query.id));
 

--- a/pages/app/ExploreDetailBeta.js
+++ b/pages/app/ExploreDetailBeta.js
@@ -31,7 +31,7 @@ class ExploreDetail extends Page {
   static async getInitialProps({ asPath, pathname, query, req, res, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     await store.dispatch(getDataset(url.query.id));
 

--- a/pages/app/ExploreDetailPrivate.js
+++ b/pages/app/ExploreDetailPrivate.js
@@ -62,7 +62,7 @@ class ExploreDetailPrivate extends Page {
   static async getInitialProps({ asPath, pathname, query, req, res, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     await store.dispatch(getDataset(url.query.id));
 

--- a/pages/app/GetInvolved.js
+++ b/pages/app/GetInvolved.js
@@ -83,7 +83,7 @@ class GetInvolved extends Page {
   static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     await store.dispatch(getStaticData('get-involved'));
     return { isServer, user, url };

--- a/pages/app/GetInvolvedDetail.js
+++ b/pages/app/GetInvolvedDetail.js
@@ -31,7 +31,7 @@ class GetInvolvedDetail extends Page {
   static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     await store.dispatch(getStaticData(query.id));
     if (query.id === 'submit-an-insight') {

--- a/pages/app/Policy.js
+++ b/pages/app/Policy.js
@@ -15,7 +15,7 @@ class Policy extends Page {
   static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     await store.dispatch(getStaticData('privacy-policy'));
     return { isServer, user, url };

--- a/pages/app/Terms.js
+++ b/pages/app/Terms.js
@@ -15,7 +15,7 @@ class Terms extends Page {
   static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     await store.dispatch(getStaticData('terms-of-service'));
     return { isServer, user, url };

--- a/pages/app/embed/EmbedEmbed.js
+++ b/pages/app/embed/EmbedEmbed.js
@@ -16,7 +16,7 @@ import Spinner from 'components/ui/Spinner';
 import Icon from 'components/widgets/editor/ui/Icon';
 
 class EmbedWidget extends Page {
-  static getInitialProps({ asPath, pathname, query, req, store, isServer }) {
+  static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const referer = isServer ? req.headers.referer : location.href;

--- a/pages/app/embed/EmbedEmbed.js
+++ b/pages/app/embed/EmbedEmbed.js
@@ -20,7 +20,7 @@ class EmbedWidget extends Page {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const referer = isServer ? req.headers.referer : location.href;
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     return { user, isServer, url, referer, isLoading: true };
   }

--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -26,7 +26,7 @@ class EmbedMap extends Page {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const referer = isServer ? req.headers.referer : location.href;
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     return { user, isServer, url, referer, isLoading: true };
   }

--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -22,7 +22,7 @@ import Icon from 'components/widgets/editor/ui/Icon';
 import LayerManager from 'components/widgets/editor/helpers/LayerManager';
 
 class EmbedMap extends Page {
-  static getInitialProps({ asPath, pathname, query, req, store, isServer }) {
+  static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const referer = isServer ? req.headers.referer : location.href;

--- a/pages/app/embed/EmbedTable.js
+++ b/pages/app/embed/EmbedTable.js
@@ -15,7 +15,7 @@ import EmbedLayout from 'components/app/layout/EmbedLayout';
 import Spinner from 'components/ui/Spinner';
 
 class EmbedTable extends Page {
-  static getInitialProps({ asPath, pathname, query, req, store, isServer }) {
+  static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const referer = isServer ? req.headers.referer : location.href;

--- a/pages/app/embed/EmbedTable.js
+++ b/pages/app/embed/EmbedTable.js
@@ -19,7 +19,7 @@ class EmbedTable extends Page {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const referer = isServer ? req.headers.referer : location.href;
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     return { user, isServer, url, referer, isLoading: true };
   }

--- a/pages/app/embed/EmbedText.js
+++ b/pages/app/embed/EmbedText.js
@@ -20,7 +20,7 @@ class EmbedText extends Page {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const referer = isServer ? req.headers.referer : location.href;
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     return { user, isServer, url, referer, isLoading: true };
   }

--- a/pages/app/embed/EmbedText.js
+++ b/pages/app/embed/EmbedText.js
@@ -16,7 +16,7 @@ import TextChart from 'components/widgets/charts/TextChart';
 import Spinner from 'components/ui/Spinner';
 
 class EmbedText extends Page {
-  static getInitialProps({ asPath, pathname, query, req, store, isServer }) {
+  static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const referer = isServer ? req.headers.referer : location.href;

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -24,7 +24,7 @@ class EmbedWidget extends Page {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const referer = isServer ? req.headers.referer : location.href;
-    store.dispatch(setUser(user));
+    await store.dispatch(setUser(user));
     store.dispatch(setRouter(url));
     return { user, isServer, url, referer, isLoading: true };
   }

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -20,7 +20,7 @@ import ChartTheme from 'utils/widgets/theme';
 import Icon from 'components/widgets/editor/ui/Icon';
 
 class EmbedWidget extends Page {
-  static getInitialProps({ asPath, pathname, query, req, store, isServer }) {
+  static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
     const { user } = isServer ? req : store.getState();
     const url = { asPath, pathname, query };
     const referer = isServer ? req.headers.referer : location.href;

--- a/redactions/user.js
+++ b/redactions/user.js
@@ -6,13 +6,14 @@ const service = new UserService({ apiURL: process.env.CONTROL_TOWER_URL });
  * CONSTANTS
 */
 const SET_USER = 'user/SET_USER';
-const GET_USER_FAVORITES = 'user/GET_USER_FAVORITES';
+const SET_USER_FAVOURITES = 'user/SET_USER_FAVOURITES';
 
 
 /**
  * REDUCER
 */
 const initialState = {
+  favourites: []
   // id: null,
   // role: null,
   // provider: null,
@@ -25,7 +26,7 @@ export default function (state = initialState, action) {
       return Object.assign({}, state, action.payload);
     }
 
-    case GET_USER_FAVORITES: {
+    case SET_USER_FAVOURITES: {
       return Object.assign({}, state, { favourites: action.payload });
     }
 
@@ -36,27 +37,35 @@ export default function (state = initialState, action) {
 
 /**
  * ACTIONS
+ * - setFavourites
  * - setUser
 */
-export function setUser(user) {
-  // If the user isn't logged in, we set the user variable as an empty object
-  if (!user) {
-    return dispatch => dispatch({ type: SET_USER, payload: {} });
-  }
-
-  const userObj = Object.assign({}, user);
-  if (userObj.token) {
-    userObj.token = userObj.token.includes('Bearer') ? userObj.token : `Bearer ${userObj.token}`;
-  }
-  return dispatch => dispatch({ type: SET_USER, payload: userObj });
-}
-
-export function getFavourites() {
+export function setFavourites() {
   return (dispatch, getState) => {
     const { user } = getState();
-    return service.getFavourites(user.token)
+
+    return service.setFavourites(user.token)
       .then((response) => {
-        dispatch({ type: GET_USER_FAVORITES, payload: response });
+        dispatch({ type: SET_USER_FAVOURITES, payload: response });
       });
+  };
+}
+
+
+export function setUser(user) {
+  return (dispatch) => {
+    if (!user) {
+      // If the user isn't logged in, we set the user variable as an empty object
+      return dispatch({ type: SET_USER, payload: {} });
+    }
+
+    const userObj = { ...user };
+    if (userObj.token) {
+      userObj.token = userObj.token.includes('Bearer') ? userObj.token : `Bearer ${userObj.token}`;
+    }
+
+    dispatch({ type: SET_USER, payload: userObj });
+
+    return dispatch(setFavourites());
   };
 }

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -49,7 +49,7 @@ export default class UserService {
    * @returns {Promise}
    */
   getFavouriteWidgets(token) {
-    return this.getFavourites(token, 'widget', true);
+    return this.setFavourites(token, 'widget', true);
   }
 
   /**
@@ -59,7 +59,7 @@ export default class UserService {
    * @returns {Promise}
    */
   getFavouriteDatasets(token) {
-    return this.getFavourites(token, 'dataset', true);
+    return this.setFavourites(token, 'dataset', true);
   }
 
   /**
@@ -68,7 +68,7 @@ export default class UserService {
     * @param {token} User token
    * @returns {Promise}
    */
-  getFavourites(token, resourceType = null, include = true) {
+  setFavourites(token, resourceType = null, include = true) {
     const resourceTypeSt = (resourceType !== null) ? `&resource-type=${resourceType}` : '';
     return new Promise((resolve) => {
       fetch(`${this.opts.apiURL}/favourite?include=${include}${resourceTypeSt}&application=${[process.env.APPLICATIONS]}`, {

--- a/store.js
+++ b/store.js
@@ -9,6 +9,7 @@ import * as reducers from 'redactions';
 import { handleModule } from 'redux-actions';
 import * as dashboardDetail from 'components/dashboards/detail/dashboard-detail';
 import * as dashboardThumbnailList from 'components/dashboards/thumbnail-list/dashboard-thumbnail-list';
+import * as widgetBlockModule from 'components/dashboards/wysiwyg/widget-block/widget-block';
 import * as widgetBlockEditionModule from 'components/dashboards/wysiwyg/widget-block-edition/widget-block-edition';
 
 if (process.env.NODE_ENV === 'production') {
@@ -24,6 +25,7 @@ const reducer = combineReducers({
   ...reducers,
   dashboardDetail: handleModule(dashboardDetail),
   dashboardThumbnailList: handleModule(dashboardThumbnailList),
+  widgetBlock: handleModule(widgetBlockModule),
   widgetBlockEdition: handleModule(widgetBlockEditionModule)
 });
 


### PR DESCRIPTION
## Overview
This PR migrate the old DashboardWidget to the new structure. All the widgets (for the dashboard) are stored in redux, widgetBlock is an object of ids.

It also gets the user with favorites, that's why I need to change the call to get the user to an await function. So if you want to access favorites you only need to have access to the user object. Is it better, isn't it?

It removes the thumbnail list from the dashboard detail (David's request).

## Pivotal task
https://www.pivotaltracker.com/story/show/153313796