### PR TITLE
Bug: some basemaps of the explore cards wouldn't be displayed

### DIFF
--- a/components/app/explore/DatasetWidget.js
+++ b/components/app/explore/DatasetWidget.js
@@ -224,7 +224,9 @@ class DatasetWidget extends React.Component {
     const element = this.getWidgetOrLayer();
     const isWidgetMap = widget && widget.attributes.widgetConfig.type === 'map';
 
-    if (widget && mode === 'grid' && !isWidgetMap) {
+    if (mode !== 'grid') return null;
+
+    if (widget && !isWidgetMap) {
       return (
         <Link route={'explore_detail'} params={{ id: this.props.dataset.id }}>
           <a>
@@ -232,9 +234,7 @@ class DatasetWidget extends React.Component {
           </a>
         </Link>
       );
-    }
-
-    if (!widget && layer && mode === 'grid') {
+    } else if (layer || isWidgetMap) {
       return (
         <Link route={'explore_detail'} params={{ id: this.props.dataset.id }}>
           <a>
@@ -244,17 +244,13 @@ class DatasetWidget extends React.Component {
       );
     }
 
-    if (mode === 'grid') {
-      return (
-        <Link route={'explore_detail'} params={{ id: this.props.dataset.id }}>
-          <a>
-            <DatasetPlaceholderChart />
-          </a>
-        </Link>
-      );
-    }
-
-    return null;
+    return (
+      <Link route={'explore_detail'} params={{ id: this.props.dataset.id }}>
+        <a>
+          <DatasetPlaceholderChart />
+        </a>
+      </Link>
+    );
   }
 
 

--- a/components/widgets/charts/LayerChart.js
+++ b/components/widgets/charts/LayerChart.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
-import { toastr } from 'react-redux-toastr';
 
 class LayerChart extends React.Component {
   constructor(props) {
@@ -90,7 +89,7 @@ class LayerChart extends React.Component {
   getImagePreview() {
     const { data } = this.props;
 
-    if (!data.account) return;
+    if (!data || !data.account) return;
 
     if (this.mounted) this.props.toggleLoading(true);
 


### PR DESCRIPTION
## Overview
For some cards of geographical datasets, the basemaps wouldn't be displayed in Explore.

## Testing instructions
Go to `/data/explore?page=3`. All the cards should show a basemap.

## Pivotal task
None. Bug reported by Alicia.