### PR TITLE
Add missing "application" and "env" params to some queries

### DIFF
--- a/components/widgets/editor/services/DatasetService.js
+++ b/components/widgets/editor/services/DatasetService.js
@@ -50,7 +50,7 @@ export default class DatasetService {
    * @returns {Promise}
    */
   fetchData(includes = '', applications = [process.env.APPLICATIONS]) {
-    return fetch(`${this.opts.apiURL}/dataset/${this.datasetId}?application=${applications.join(',')}&language=${this.opts.language}&includes=${includes}&page[size]=999`)
+    return fetch(`${this.opts.apiURL}/dataset/${this.datasetId}?application=${applications.join(',')}&env=${process.env.API_ENV}&language=${this.opts.language}&includes=${includes}&page[size]=999`)
       .then((response) => {
         if (response.status >= 400) throw new Error(response.statusText);
         return response.json();

--- a/components/widgets/editor/services/WidgetService.js
+++ b/components/widgets/editor/services/WidgetService.js
@@ -10,7 +10,7 @@ export default class WidgetService {
   }
 
   fetchData(includes = '') {
-    return fetch(`${this.opts.apiURL}/widget/${this.widgetId}?includes=${includes}&page[size]=999&application=${[process.env.APPLICATIONS]}`)
+    return fetch(`${this.opts.apiURL}/widget/${this.widgetId}?includes=${includes}&page[size]=999&application=${[process.env.APPLICATIONS]}&env=${process.env.API_ENV}`)
       .then((response) => {
         if (response.status >= 400) throw new Error(response.statusText);
         return response.json();
@@ -26,7 +26,7 @@ export default class WidgetService {
       dataset: datasetId
     };
     const bodyObj = Object.assign({}, widget, widgetObj);
-    return fetch(`${this.opts.apiURL}/dataset/${datasetId}/widget`, {
+    return fetch(`${this.opts.apiURL}/dataset/${datasetId}/widget?application=${[process.env.APPLICATIONS]}&env=${process.env.API_ENV}`, {
       method: 'POST',
       body: JSON.stringify(bodyObj),
       headers: {


### PR DESCRIPTION
## Overview
Some services wouldn't have the `application` and/or `env` parameter defined in their queries.

## Testing instructions
None.

## Pivotal task
None. Bug found in the [widget-editor](https://github.com/resource-watch/widget-editor).