### PR TITLE
Small layout changes to the dashboards

### DIFF
--- a/pages/app/Dashboards.js
+++ b/pages/app/Dashboards.js
@@ -11,7 +11,6 @@ import { fetchDashboards, setPagination, setExpanded } from 'components/dashboar
 // Components
 import Page from 'components/app/layout/Page';
 import Layout from 'components/app/layout/Layout';
-import Breadcrumbs from 'components/ui/Breadcrumbs';
 import DashboardThumbnailList from 'components/dashboards/thumbnail-list/dashboard-thumbnail-list';
 
 class Dashboards extends Page {
@@ -47,7 +46,6 @@ class Dashboards extends Page {
             <div className="row">
               <div className="column small-12">
                 <div className="page-header-content">
-                  <Breadcrumbs items={[{ name: 'Data', href: '/data' }]} />
                   <h1>Dashboards</h1>
                 </div>
               </div>

--- a/pages/app/DashboardsDetail.js
+++ b/pages/app/DashboardsDetail.js
@@ -43,7 +43,7 @@ class DashboardsDetail extends Page {
             <div className="row">
               <div className="column small-12">
                 <div className="page-header-content">
-                  <Breadcrumbs items={[{ name: 'Data', href: '/data/dashboards' }]} />
+                  <Breadcrumbs items={[{ name: 'Dashboards', href: '/data/dashboards' }]} />
                   <h1>{dashboardDetail.dashboard.name}</h1>
                 </div>
               </div>

--- a/pages/app/DashboardsDetail.js
+++ b/pages/app/DashboardsDetail.js
@@ -11,8 +11,9 @@ import { fetchDashboard } from 'components/dashboards/detail/dashboard-detail-ac
 import Page from 'components/app/layout/Page';
 import Layout from 'components/app/layout/Layout';
 import Breadcrumbs from 'components/ui/Breadcrumbs';
-
 import DashboardDetail from 'components/dashboards/detail/dashboard-detail';
+import DashboardThumbnailList from 'components/dashboards/thumbnail-list/dashboard-thumbnail-list';
+import { fetchDashboards } from 'components/dashboards/thumbnail-list/dashboard-thumbnail-list-actions';
 
 class DashboardsDetail extends Page {
   static async getInitialProps({ asPath, pathname, query, req, store, isServer }) {
@@ -22,6 +23,16 @@ class DashboardsDetail extends Page {
     store.dispatch(setRouter(url));
 
     await store.dispatch(fetchDashboard({ id: url.query.slug }));
+
+    // We load the list of dashboards if not already done
+    // NOTE: this typically happens is the page is SSRed
+    const isDashboardPrivate = store.getState().dashboardDetail.dashboard.private;
+    const thumbnailListLoaded = !!store.getState().dashboardThumbnailList.dashboards.length;
+    if (!isDashboardPrivate && !thumbnailListLoaded) {
+      await store.dispatch(fetchDashboards({
+        filters: { 'filter[published]': 'true' }
+      }));
+    }
 
     return { isServer, user, url };
   }
@@ -52,6 +63,25 @@ class DashboardsDetail extends Page {
         </header>
 
         <div className="l-section">
+          { !dashboardDetail.dashboard.private && (
+            <div className="l-container">
+              <div className="row">
+                <div className="column small-12">
+                  <DashboardThumbnailList
+                    onSelect={({ slug }) => {
+                      // We need to make an amendment to have this working
+                      // Router.pushRoute('dashboards_detail', { slug });
+                      window.location = `/data/dashboards/${slug}`;
+                    }}
+                    onExpand={(bool) => {
+                      this.props.setExpanded(bool);
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
           <div className="l-container">
             <div className="row">
               <div className="column small-12">


### PR DESCRIPTION
## Overview
The back button ("breadcrumbs") located in the header of the dashboard pages has been updated/removed to ensure a correct user flow. In addition, the list of dashboard thumbnails is not displayed anymore in the detail page of a private dashboard.

## Testing instructions
On the dashboard index page, you shouldn't see any back button in the header, and in the detail page, the button should be called "Dashboards". In the detail page of a private dashboard such as `my-dash`, the thumbnail list shouldn't be visible.

## Pivotal task
[Task 1: back button](https://www.pivotaltracker.com/story/show/153368227)
[Task 2: thumbnail list](https://www.pivotaltracker.com/story/show/153367652)