### PR TITLE
Bug: raster widgets couldn't be created properly

### DIFF
--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -207,10 +207,6 @@ class Step1 extends React.Component {
                 mode="dataset"
                 showSaveButton={false}
                 onChange={(value) => { this.props.onChange({ widgetConfig: value }); }}
-                onError={() => {
-                  toastr.info('Info', 'This dataset doesn\'t allow editor mode');
-                  this.props.onModeChange('advanced');
-                }}
               />
             }
 

--- a/components/app/myrw/widgets/pages/new.js
+++ b/components/app/myrw/widgets/pages/new.js
@@ -260,11 +260,6 @@ class WidgetsNew extends React.Component {
     });
   }
 
-  @Autobind
-  handleWidgetEditorError() { // eslint-disable-line class-methods-use-this
-    toastr.error('Error', 'An error occured with the widget editor');
-  }
-
   render() {
     const {
       loading,
@@ -310,7 +305,6 @@ class WidgetsNew extends React.Component {
             mode="widget"
             onUpdateWidget={this.onSubmit}
             showSaveButton
-            onError={this.handleWidgetEditorError}
           />
           <div className="form-container">
             <form className="form-container" onSubmit={this.onSubmit}>

--- a/components/widgets/editor/WidgetEditor.js
+++ b/components/widgets/editor/WidgetEditor.js
@@ -769,7 +769,6 @@ class WidgetEditor extends React.Component {
           // If either of the promises reject, it's not a real issue
           // because the state will be updated consequently and we
           // can take further actions in the UI
-          if (this.props.onError) this.props.onError();
         })
         // Whether or not the dataset has fields, we fetch the dataset info
         // to get for example the type of dataset
@@ -1166,7 +1165,6 @@ WidgetEditor.propTypes = {
   // Callbacks
   onUpdateWidget: PropTypes.func,
   onChange: PropTypes.func,
-  onError: PropTypes.func,
   // Store
   band: PropTypes.object,
   user: PropTypes.object.isRequired,


### PR DESCRIPTION
## Overview
The `WidgetEditor` contained a prop called `onError` whose purpose is wrong. Instead of notifying of an error, it just notified that either the fields didn't load or the layers. *In any case that means that the editor can't work properly.* Raster datasets don't have fields for example.

This prop would be used in the admin preventing the creation of widgets with raster datasets and would throw an error in My RW for the same datasets. To fix the issue, the prop has been deleted. 

Note that the new version of the editor is not affected by this.

## Testing instructions
### Admin
1. Go to `/admin/data/widgets/new?dataset=ff1425a9-4793-4ac2-99e5-7bdf87114cc7`
2. You should see the widget editor

### My RW
1. Go to `/myrw-detail/widgets/new`
2. Select the dataset "Average Annual Precipitation (1971-2000)"
3. You shouldn't see any toastr error

## Pivotal task
None. Bug reported by Alicia.
