### PR TITLE
Fix an access issue to the embedded map widgets as an anonymous user

### DIFF
--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -44,7 +44,9 @@ class EmbedMap extends Page {
 
   componentDidMount() {
     this.props.getWidget(this.props.url.query.id);
-    if (this.props.user.id) this.props.checkIfFavorited(this.props.url.query.id);
+    if (this.props.user && this.props.user.id) {
+      this.props.checkIfFavorited(this.props.url.query.id);
+    }
   }
 
   getModal() {
@@ -127,7 +129,7 @@ class EmbedMap extends Page {
             </a>
             <div className="buttons">
               {
-                user.id && (
+                user && user.id && (
                   <button
                     onClick={() => this.props.setIfFavorited(widget.id, !this.props.favorited)}
                   >


### PR DESCRIPTION
## Overview
Non-logged user wouldn't be able to see embedded map widgets due to errors in the code: we would assume the users are always logged in, which is not true. This bug probably is the one that prevents a user from downloading a PDF of a map widget.

## Testing instructions
1. Open a private browsing window
2. Open this page: `/embed/map/4bed6e21-8ae2-437c-aa01-9ccd861ab4c0`
3. You should be able to see the widget

## Pivotal task
Probably fix [this task](https://www.pivotaltracker.com/story/show/153281863) but I need to test it once deployed to staging.
