### PR TITLE
Explore detail fix: datasets without tags

### DIFF
--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -165,6 +165,7 @@ class ExploreDetail extends Page {
       loading: true
     }, () => {
       this.datasetService.fetchData('layer,metadata,vocabulary,widget').then((response) => {
+        console.log('response', response);
         const defaultEditableWidget = response.attributes.widget.find(widget => widget.attributes.defaultEditableWidget === true);
 
         this.setState({
@@ -174,8 +175,11 @@ class ExploreDetail extends Page {
         }, () => defaultEditableWidget && this.loadDefaultWidgetIntoRedux(defaultEditableWidget));
 
         // Load inferred tags
-        const tags = response.attributes.vocabulary[0].attributes.tags;
-        this.loadInferredTags(tags);
+        const vocabulary = response.attributes.vocabulary;
+        const tags = vocabulary && vocabulary.length > 0 && vocabulary[0].attributes.tags;
+        if (tags) {
+          this.loadInferredTags(tags);
+        }
       }).catch((error) => {
         toastr.error('Error', 'Unable to load the dataset');
         console.error(error);


### PR DESCRIPTION
Prior to this fix an error was thrown when trying to load the inferred tags of the dataset when it had not tags associated to it yet.

## Testing instructions
Check the Explore detail page of any dataset that has no tags associated to it.

## Pivotal task
None, I found the bug by chance.