### PR TITLE
Back office: Add code to datasets table

### DIFF
--- a/components/datasets/table/DatasetsTable.js
+++ b/components/datasets/table/DatasetsTable.js
@@ -24,6 +24,7 @@ import StatusTD from './td/StatusTD';
 import RelatedContentTD from './td/RelatedContentTD';
 import UpdatedAtTD from './td/UpdatedAtTD';
 import OwnerTD from './td/OwnerTD';
+import CodeTD from './td/CodeTD';
 
 class DatasetsTable extends React.Component {
   constructor(props) {
@@ -86,6 +87,7 @@ class DatasetsTable extends React.Component {
           <CustomTable
             columns={[
               { label: 'Name', value: 'name', td: NameTD, tdProps: { route: routes.detail } },
+              { label: 'Code', value: 'metadata', td: CodeTD },
               { label: 'Status', value: 'status', td: StatusTD },
               { label: 'Published', value: 'published', td: PublishedTD },
               { label: 'Provider', value: 'provider' },

--- a/components/datasets/table/td/CodeTD.js
+++ b/components/datasets/table/td/CodeTD.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function CodeTD(props) {
+  const { value, index } = props;
+  const metadata = value.length && value.length > 0 && value[0];
+  const metadataInfo = metadata && metadata.attributes && metadata.attributes.info;
+  const codeSt = metadataInfo ? metadataInfo.rwId : '';
+
+  return (
+    <td key={index} className="main">
+      {codeSt}
+    </td>
+  );
+}
+
+
+CodeTD.propTypes = {
+  value: PropTypes.string,
+  index: PropTypes.string
+};
+
+export default CodeTD;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/33883152-0313289a-df3b-11e7-9e92-dc36a690a625.png)

## Overview
A new column has been added to the back office datasets table that displays the RW ID

## Testing instructions
Go to `/admin`

[Pivotal task](https://www.pivotaltracker.com/story/show/153542856)

@mbarrenechea we need to fix the sorting for columns that are not displaying direct children of the dataset object: https://www.pivotaltracker.com/story/show/153592166