### PR TITLE
Dataset Tags form fixes

### DIFF
--- a/components/admin/tags/TagsForm.js
+++ b/components/admin/tags/TagsForm.js
@@ -109,9 +109,11 @@ class TagsForm extends React.Component {
    * - handleSubmit
    * - handleTagsChange
   */
-  handleSubmit() {
+  handleSubmit(event) {
     const { dataset, user } = this.props;
     const { selectedTags } = this.state;
+
+    event.preventDefault();
 
     this.setState({ loading: true });
     this.graphService.updateDatasetTags(dataset, selectedTags, user.token)
@@ -180,7 +182,7 @@ class TagsForm extends React.Component {
     const { tags, selectedTags, inferredTags, graph, loadingDatasetTags,
       loadingAllTags, loadingInferredTags } = this.state;
     return (
-      <div className="c-tags-form">
+      <form className="c-tags-form" onSubmit={this.handleSubmit}>
         <Spinner
           className="-light"
           isLoading={loadingAllTags || loadingDatasetTags}
@@ -230,7 +232,7 @@ class TagsForm extends React.Component {
             onStepChange={this.handleSubmit}
           />
         }
-      </div>
+      </form>
     );
   }
 }

--- a/services/GraphService.js
+++ b/services/GraphService.js
@@ -42,8 +42,9 @@ export default class GraphService {
         tags
       }
     };
+    const method = tags.length > 0 ? 'PUT' : 'DELETE';
     return fetch(`${this.opts.apiURL}/dataset/${datasetId}/vocabulary`, {
-      method: 'PUT',
+      method,
       body: JSON.stringify(bodyObj),
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
This PR fixes the Dataset tags form _(prior to this clicking in the button "Save" had no effect whatsoever)_
The request used to update the tags of a dataset has also been updated so that it uses *DELETE* when it's sending an empty array of tags.
