### PR TITLE
Fix for Explore bug: Layer selector can extend beyond the top of the screen on smaller displays

### DIFF
--- a/css/components/app/explore/explore_layers_tooltip.scss
+++ b/css/components/app/explore/explore_layers_tooltip.scss
@@ -2,6 +2,6 @@
   // Prevent the tooltip from being cut on
   // the right of the screen
   max-width: 210px;
-  max-height: 300px;
+  max-height: 260px;
   overflow: auto;
 }

--- a/css/components/app/explore/explore_layers_tooltip.scss
+++ b/css/components/app/explore/explore_layers_tooltip.scss
@@ -1,5 +1,7 @@
 .c-explore-layers-tooltip {
   // Prevent the tooltip from being cut on
   // the right of the screen
-  max-width: 210px; 
+  max-width: 210px;
+  max-height: 300px;
+  overflow: auto;
 }


### PR DESCRIPTION
### Testing instructions

Check [this url](http://localhost:3000/data/explore?page=1&layers=%255B%257B%2522dataset%2522%253A%2522223b936e-06b8-4970-abd9-4f123904d95d%2522%252C%2522visible%2522%253Atrue%252C%2522layers%2522%253A%255B%257B%2522id%2522%253A%25220ac7bf69-388a-48b0-a869-c3240031c4bf%2522%252C%2522active%2522%253Afalse%252C%2522opacity%2522%253A1%257D%252C%257B%2522id%2522%253A%25224727b1ce-217a-4ebd-9018-596b17752226%2522%252C%2522active%2522%253Atrue%252C%2522opacity%2522%253A1%257D%252C%257B%2522id%2522%253A%2522b898f1f0-fb8e-40b6-ba39-9cdce7c32c34%2522%252C%2522active%2522%253Afalse%252C%2522opacity%2522%253A1%257D%252C%257B%2522id%2522%253A%2522699062bd-9d77-45f1-a380-b16f8bf8c9d6%2522%252C%2522active%2522%253Afalse%252C%2522opacity%2522%253A1%257D%252C%257B%2522id%2522%253A%2522e25191e9-8150-4371-84c3-996e45863911%2522%252C%2522active%2522%253Afalse%252C%2522opacity%2522%253A1%257D%252C%257B%2522id%2522%253A%252297cec588-0e75-4273-8475-2ac30258a3c2%2522%252C%2522active%2522%253Afalse%252C%2522opacity%2522%253A1%257D%252C%257B%2522id%2522%253A%2522792ea3f1-4af1-4927-8da4-128a970b1316%2522%252C%2522active%2522%253Afalse%252C%2522opacity%2522%253A1%257D%252C%257B%2522id%2522%253A%2522a2d56570-b9f9-41b7-adeb-2ebc516033f6%2522%252C%2522active%2522%253Afalse%252C%2522opacity%2522%253A1%257D%255D%257D%255D&geographies=%5B%22north_america%22%5D&zoom=4&latLng=%7B%22lat%22%3A-2.7235830833483856%2C%22lng%22%3A18.588867187500004%7D&sort=modified)


[Pivotal task](https://www.pivotaltracker.com/story/show/151846842)
