### PR TITLE
Fix for Explore Detail page

### DIFF
--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 // Redux
 import withRedux from 'next-redux-wrapper';
 import { initStore } from 'store';
-import { setTopicsTree, toggleLayerGroup } from 'redactions/explore';
+import { toggleLayerGroup } from 'redactions/explore';
 import { resetDataset } from 'redactions/exploreDetail';
 import { getDataset } from 'redactions/exploreDataset';
 import { toggleModal, setModalOptions } from 'redactions/modal';
@@ -116,7 +116,6 @@ class ExploreDetail extends Page {
   componentDidMount() {
     this.getDataset();
     this.getSimilarDatasets();
-    this.loadTopicsTree();
     this.countView(this.props.url.query.id);
   }
 
@@ -149,21 +148,8 @@ class ExploreDetail extends Page {
    * HELPERS
    * - getDataset
    * - getSimilarDatasets
-   * - loadTopicsTree
    * - loadInferredTags
   */
-  loadTopicsTree() {
-    const { topicsTree } = this.props;
-
-    if (!topicsTree) {
-      fetch(new Request('/static/data/TopicsTreeLite.json', { credentials: 'same-origin' }))
-        .then(response => response.json())
-        .then((data) => {
-          // Save the topics tree as variable for later use
-          this.props.setTopicsTree(data);
-        });
-    }
-  }
 
   getDataset() {
     this.setState({
@@ -335,14 +321,14 @@ class ExploreDetail extends Page {
   }
 
   handleTagSelected(tag, labels = ['TOPIC']) { // eslint-disable-line class-methods-use-this
-    const tagSt = `["${tag}"]`;
+    const tagSt = `["${tag.id}"]`;
     let treeSt = 'topics';
     if (labels.includes('TOPIC')) {
       treeSt = 'topics';
     } else if (labels.includes('GEOGRAPHY')) {
       treeSt = 'geographies';
     } else if (labels.includes('DATA_TYPE')) {
-      treeSt = 'dataType';
+      treeSt = 'dataTypes';
     }
 
     Router.pushRoute('explore', { [treeSt]: tagSt });
@@ -828,14 +814,12 @@ ExploreDetail.propTypes = {
   setBand: PropTypes.func.isRequired,
   setLayer: PropTypes.func.isRequired,
   setTitle: PropTypes.func.isRequired,
-  setTopicsTree: PropTypes.func.isRequired,
   toggleLayerGroup: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({
   // Store
   user: state.user,
-  topicsTree: state.explore.topicsTree,
   exploreDetail: state.exploreDetail,
   exploreDataset: state.exploreDataset,
   layersShown: updateLayersShown(state),
@@ -869,7 +853,6 @@ const mapDispatchToProps = dispatch => ({
       });
   },
   setTitle: title => dispatch(setTitle(title)),
-  setTopicsTree: tree => dispatch(setTopicsTree(tree)),
   toggleLayerGroup: (datasetID, addLayer) => dispatch(toggleLayerGroup(datasetID, addLayer)),
   toggleFavourite: options => dispatch(toggleFavourite(options))
 });


### PR DESCRIPTION
## Overview
Fix for similar datasets tags tooltip _(some obsolete code has also been removed)_

## Testing instructions
Check the Explore detail page of any dataset, for instance: `http://localhost:3000/data/explore/63f34231-7369-4622-81f1-28a144d17835`. Go to the similar datasets section, click on the tags icon and click in any of the tag pills shown.

@davidsingal  There's a problem with the load of the Explore page though... it loads with a huge scroll when, in theory the page should not have any scroll at all 🤔 
It looks like it somehow _inherits_ the page size of the Explore Detail page. 

## Pivotal task
None, bug found by @pablopareja