### PR TITLE
Hide the geographies filter from the Explore page

### DIFF
--- a/components/app/explore/explore-dataset-filters/explore-dataset-filters-actions.js
+++ b/components/app/explore/explore-dataset-filters/explore-dataset-filters-actions.js
@@ -10,7 +10,8 @@ export const getFiltersData = createThunkAction('explore-dataset-filters/getFilt
   (dispatch) => {
     Promise.all([
       FiltersService.getTopics(),
-      FiltersService.getGeographies(),
+      // NOTE: We're temporarily hiding the geographies filter
+      // FiltersService.getGeographies(),
       FiltersService.getDataTypes()
     ]
     ).then((values = []) => {

--- a/components/app/explore/explore-dataset-filters/explore-dataset-filters-component.js
+++ b/components/app/explore/explore-dataset-filters/explore-dataset-filters-component.js
@@ -15,15 +15,18 @@ class ExploreDatasetFilters extends PureComponent {
   render() {
     const { exploreDatasetFilters, showFilters } = this.props;
     const { filters, data } = exploreDatasetFilters;
-    const { topics, dataTypes, geographies } = filters;
+    // NOTE: We're temporarily hiding the geographies filter
+    // const { topics, dataTypes, geographies } = filters;
+    const { topics, dataTypes } = filters;
 
     const newTopics = topics ?
       topics.map(t => findTagInSelectorTree(data.topics, t)) : [];
-    const newGeographies = geographies ?
-      geographies.map(t => findTagInSelectorTree(data.geographies, t)) : [];
+    // const newGeographies = geographies ?
+    //   geographies.map(t => findTagInSelectorTree(data.geographies, t)) : [];
     const newDataTypes = dataTypes ?
       dataTypes.map(t => findTagInSelectorTree(data.dataTypes, t)) : [];
-    const selectedTags = [...newTopics, ...newGeographies, ...newDataTypes];
+    // const selectedTags = [...newTopics, ...newGeographies, ...newDataTypes];
+    const selectedTags = [...newTopics, ...newDataTypes];
 
     return (
       <div className="c-explore-dataset-filters">

--- a/components/app/explore/explore-dataset-filters/explore-dataset-filters-constants.js
+++ b/components/app/explore/explore-dataset-filters/explore-dataset-filters-constants.js
@@ -1,6 +1,7 @@
+// NOTE: We're temporarily hiding the geographies filter
 const PLACEHOLDERS_DATASET_FILTERS = {
   topics: 'Topics',
-  geographies: 'Geographies',
+  // geographies: 'Geographies',
   dataTypes: 'Data Types'
 };
 

--- a/components/app/explore/explore-dataset-filters/explore-dataset-filters-reducer.js
+++ b/components/app/explore/explore-dataset-filters/explore-dataset-filters-reducer.js
@@ -6,6 +6,7 @@ export const initialState = {
   filters: {}
 };
 
+// NOTE: We're temporarily hiding the geographies filter
 export default {
   [actions.setDataFilters]: (state, { payload }) => ({ ...state, data: payload }),
   [actions.setFilters]: (state, { payload }) =>
@@ -20,10 +21,11 @@ export default {
       const newTopics = state.filters.topics;
       newTopics.splice(newTopics.indexOf(payload.value), 1);
       return { ...state, filters: Object.assign({}, ...state.filters, { topics: newTopics }) };
-    } else if (payload.labels.includes('GEOGRAPHY')) {
-      const newGeographies = state.filters.geographies;
-      newGeographies.splice(newGeographies.indexOf(payload.value), 1);
-      return { ...state, filters: Object.assign({}, ...state.filters, { topics: newGeographies }) };
+    // } else if (payload.labels.includes('GEOGRAPHY')) {
+    //   const newGeographies = state.filters.geographies;
+    //   newGeographies.splice(newGeographies.indexOf(payload.value), 1);
+    //   return { ...state, filters: Object.assign({}, ...state.filters,
+    // { topics: newGeographies }) };
     } else if (payload.labels.includes('DATA_TYPE')) {
       const newDataTypes = state.filters.dataTypes;
       newDataTypes.splice(newDataTypes.indexOf(payload.value), 1);


### PR DESCRIPTION
## Overview

This PR temporarily hides the Geographies filter from the Explore.

## Testing instructions
Check the [Explore page](http://localhost:3000)

[Pivotal task](https://www.pivotaltracker.com/story/show/154118304)

![image](https://user-images.githubusercontent.com/545342/34671160-bdb3a528-f479-11e7-8e17-720e165cfcf4.png)

  