### PR TITLE
Fixes for Subscription / AOI bugs from dataset detail page

### DIFF
--- a/components/app/myrw/areas/AreasTab.js
+++ b/components/app/myrw/areas/AreasTab.js
@@ -18,7 +18,7 @@ function AreasTab(props) {
       }
 
       {id && id === 'new' && user.token &&
-        <AreasNew tab={tab} subtab={subtab} id={id} />
+        <AreasNew tab={tab} subtab={subtab} id={id} query={query} />
       }
 
       {id && id !== 'new' && user.token &&

--- a/components/app/myrw/areas/AreasTab.js
+++ b/components/app/myrw/areas/AreasTab.js
@@ -10,11 +10,11 @@ import AreasNew from 'components/app/myrw/areas/pages/new';
 import AreasEdit from 'components/app/myrw/areas/pages/show';
 
 function AreasTab(props) {
-  const { tab, subtab, id, user } = props;
+  const { tab, subtab, id, user, query } = props;
   return (
     <div className="c-areas-tab">
       {!id && user.token &&
-        <AreasIndex tab={tab} subtab={subtab} id={id} />
+        <AreasIndex tab={tab} subtab={subtab} id={id} query={query} />
       }
 
       {id && id === 'new' && user.token &&
@@ -32,7 +32,8 @@ AreasTab.propTypes = {
   user: PropTypes.object,
   tab: PropTypes.string,
   id: PropTypes.string,
-  subtab: PropTypes.string
+  subtab: PropTypes.string,
+  query: PropTypes.object
 };
 
 const mapStateToProps = state => ({

--- a/components/app/myrw/areas/pages/index.js
+++ b/components/app/myrw/areas/pages/index.js
@@ -1,14 +1,19 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // Components
 import AreasList from 'components/areas/AreasList';
 
-function AreasIndex() {
+function AreasIndex(props) {
   return (
     <div className="c-areas-index">
-      <AreasList />
+      <AreasList query={props.query} />
     </div>
   );
 }
+
+AreasIndex.propTypes = {
+  query: PropTypes.object
+};
 
 export default AreasIndex;

--- a/components/app/myrw/areas/pages/new.js
+++ b/components/app/myrw/areas/pages/new.js
@@ -1,16 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // Components
 import AreasForm from 'components/areas/AreasForm';
 
-function AreasNew() {
+function AreasNew(props) {
   return (
     <div className="c-areas-new">
       <AreasForm
         mode="new"
+        query={props.query}
       />
     </div>
   );
 }
+
+AreasNew.propTypes = {
+  query: PropTypes.object
+};
 
 export default AreasNew;

--- a/components/areas/AreaCard.js
+++ b/components/areas/AreaCard.js
@@ -75,7 +75,16 @@ class AreaCard extends React.Component {
   }
 
   componentDidMount() {
+    const {
+      openSubscriptionsModal,
+      subscriptionThreshold,
+      subscriptionType,
+      subscriptionDataset
+    } = this.props;
     this.loadData();
+    if (openSubscriptionsModal) {
+      this.handleEditSubscription(subscriptionDataset, subscriptionType, subscriptionThreshold);
+    }
   }
 
   loadData() {
@@ -154,7 +163,11 @@ class AreaCard extends React.Component {
     Router.pushRoute('myrw_detail', { id: this.props.area.id, tab: 'areas' });
   }
 
-  handleEditSubscription() {
+  handleEditSubscription(
+    subscriptionDataset = null,
+    subscriptionType = null,
+    subscriptionThreshold = null
+  ) {
     const mode = this.props.area.subscription ? 'edit' : 'new';
     const options = {
       children: AreaSubscriptionModal,
@@ -163,7 +176,10 @@ class AreaCard extends React.Component {
         toggleModal: this.props.toggleModal,
         onSubscriptionUpdated: this.handleSubscriptionUpdated,
         onSubscriptionCreated: this.handleSubscriptionUpdated,
-        mode
+        mode,
+        subscriptionDataset,
+        subscriptionType,
+        subscriptionThreshold
       }
     };
     this.props.toggleModal(true);
@@ -320,10 +336,15 @@ class AreaCard extends React.Component {
   }
 }
 
+AreaCard.defaultProps = {
+  openSubscriptionsModal: false
+};
+
 AreaCard.propTypes = {
   token: PropTypes.string.isRequired,
   area: PropTypes.object.isRequired,
   locale: PropTypes.string.isRequired,
+  openSubscriptionsModal: PropTypes.bool,
   // Callbacks
   onAreaRemoved: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -59,6 +59,8 @@ class AreasForm extends React.Component {
   constructor(props) {
     super(props);
 
+    console.log('props', props);
+
     this.state = {
       areaOptions: [],
       loadingAreaOptions: false,
@@ -71,7 +73,7 @@ class AreasForm extends React.Component {
     this.areasService = new AreasService({ apiURL: process.env.WRI_API_URL });
     this.userService = new UserService({ apiURL: process.env.WRI_API_URL });
 
-    //---------------- Bindings --------------------
+    // ---------------- Bindings --------------------
     this.onSubmit = this.onSubmit.bind(this);
     this.onChangeSelectedArea = this.onChangeSelectedArea.bind(this);
     this.handleNameChange = this.handleNameChange.bind(this);

--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -97,8 +97,8 @@ class AreasForm extends React.Component {
     e.preventDefault();
 
     const { name, geostore } = this.state;
-    const { user, mode, id } = this.props;
-
+    const { user, mode, id, query } = this.props;
+    const { subscriptionDataset } = query;
     if (geostore) {
       this.setState({
         loading: true
@@ -106,8 +106,12 @@ class AreasForm extends React.Component {
 
       if (mode === 'new') {
         this.userService.createNewArea(name, geostore, user.token)
-          .then(() => {
-            Router.pushRoute('myrw', { tab: 'areas' });
+          .then((response) => {
+            Router.pushRoute('myrw', {
+              tab: 'areas',
+              openModal: response.data.id,
+              subscriptionDataset
+            });
             toastr.success('Success', 'Area successfully created!');
           })
           .catch(err => this.setState({ error: err, loading: false }));

--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -59,14 +59,15 @@ class AreasForm extends React.Component {
   constructor(props) {
     super(props);
 
-    console.log('props', props);
+    const { openUploadAreaModal } = props.query;
 
     this.state = {
       areaOptions: [],
       loadingAreaOptions: false,
       loading: false,
       name: '',
-      geostore: null
+      geostore: null,
+      openUploadAreaModal
     };
 
     // Services
@@ -81,9 +82,14 @@ class AreasForm extends React.Component {
   }
 
   componentDidMount() {
+    const { openUploadAreaModal } = this.state;
     this.loadAreas();
     if (this.props.id) {
       this.loadArea();
+    }
+
+    if (openUploadAreaModal) {
+      this.openUploadAreaModal();
     }
   }
 
@@ -147,6 +153,13 @@ class AreasForm extends React.Component {
         resolve(true);
       }
     });
+  }
+
+  openUploadAreaModal() {
+    this.setState({
+      geostore: 'custom'
+    },
+    () => this.onChangeSelectedArea({ value: 'upload' }));
   }
 
   handleNameChange(value) {
@@ -239,9 +252,14 @@ class AreasForm extends React.Component {
   }
 }
 
+AreasForm.defaultProps = {
+  openUploadAreaModal: false
+};
+
 AreasForm.propTypes = {
   mode: PropTypes.string.isRequired, // edit | new
-  id: PropTypes.string, // area id for edit mode
+  id: PropTypes.string, // area id for edit mode,
+  query: PropTypes.object,
   // Store
   user: PropTypes.object.isRequired,
   toggleModal: PropTypes.func.isRequired

--- a/components/areas/AreasList.js
+++ b/components/areas/AreasList.js
@@ -17,14 +17,18 @@ import AreaCard from 'components/areas/AreaCard';
 class AreasList extends React.Component {
   constructor(props) {
     super(props);
-
+    const { openModal, subscriptionThreshold, subscriptionDataset, subscriptionType } = props.query;
     this.state = {
       loading: false,
       areas: [],
       areasLoaded: false,
       subscriptionsLoaded: false,
       subscriptionsToAReas: null,
-      areasMerged: false
+      areasMerged: false,
+      openSubscriptionsModal: openModal,
+      subscriptionThreshold,
+      subscriptionDataset,
+      subscriptionType
     };
 
     this.userService = new UserService({ apiURL: process.env.WRI_API_URL });
@@ -132,7 +136,15 @@ class AreasList extends React.Component {
   }
 
   render() {
-    const { loading, areas, areasMerged } = this.state;
+    const {
+      loading,
+      areas,
+      areasMerged,
+      openSubscriptionsModal,
+      subscriptionDataset,
+      subscriptionType,
+      subscriptionThreshold
+    } = this.state;
     const { user } = this.props;
 
     return (
@@ -158,6 +170,14 @@ class AreasList extends React.Component {
                       area={val}
                       onAreaRemoved={this.handleAreaRemoved}
                       onChange={() => this.loadData()}
+                      openSubscriptionsModal={openSubscriptionsModal &&
+                        openSubscriptionsModal === val.id}
+                      subscriptionDataset={openSubscriptionsModal &&
+                        openSubscriptionsModal === val.id && subscriptionDataset}
+                      subscriptionThreshold={openSubscriptionsModal &&
+                        openSubscriptionsModal === val.id && subscriptionThreshold}
+                      subscriptionType={openSubscriptionsModal &&
+                        openSubscriptionsModal === val.id && subscriptionType}
                     />
                   </div>
                 </div>
@@ -177,7 +197,8 @@ class AreasList extends React.Component {
 
 AreasList.propTypes = {
   user: PropTypes.object.isRequired,
-  locale: PropTypes.string.isRequired
+  locale: PropTypes.string.isRequired,
+  query: PropTypes.object
 };
 
 const mapStateToProps = state => ({

--- a/components/modal/AreaSubscriptionModal.js
+++ b/components/modal/AreaSubscriptionModal.js
@@ -36,13 +36,17 @@ class AreaSubscriptionModal extends React.Component {
       if (selectorFound) {
         selectorFound.selectedType = subscriptionType;
         selectorFound.selectedThreshold = subscriptionThreshold;
-      } else {
+      } else if (subscription) {
         initialSubscriptionSelectors.push({
           index: initialSubscriptionSelectors.length,
           selectedDataset: subscriptionDataset,
           selectedType: subscriptionType,
           selectedThreshold: subscriptionThreshold
         });
+      } else {
+        initialSubscriptionSelectors[0].selectedType = subscriptionType;
+        initialSubscriptionSelectors[0].selectedThreshold = subscriptionThreshold || 1;
+        initialSubscriptionSelectors[0].selectedDataset = subscriptionDataset;
       }
     }
 

--- a/components/modal/AreaSubscriptionModal.js
+++ b/components/modal/AreaSubscriptionModal.js
@@ -20,6 +20,7 @@ import { logEvent } from 'utils/analytics';
 class AreaSubscriptionModal extends React.Component {
   constructor(props) {
     super(props);
+    const { subscriptionDataset, subscriptionType, subscriptionThreshold } = props;
     const subscription = props.area.subscription;
     const initialSubscriptionSelectors = subscription
       ? subscription.attributes.datasetsQuery.map((elem, index) =>
@@ -28,6 +29,27 @@ class AreaSubscriptionModal extends React.Component {
           selectedType: elem.type,
           selectedThreshold: elem.threshold }))
       : [{ index: 0, selectedDataset: null, selectedType: null, selectedThreshold: 1 }];
+
+    console.log('props', props);
+    console.log('initialSubscriptionSelectors BEFORE', initialSubscriptionSelectors);
+
+    if (subscriptionDataset) {
+      const selectorFound = initialSubscriptionSelectors
+        .find(selector => selector.selectedDataset === subscriptionDataset);
+      if (selectorFound) {
+        selectorFound.selectedType = subscriptionType;
+        selectorFound.selectedThreshold = subscriptionThreshold;
+      } else {
+        initialSubscriptionSelectors.push({
+          index: initialSubscriptionSelectors.length,
+          selectedDataset: subscriptionDataset,
+          selectedType: subscriptionType,
+          selectedThreshold: subscriptionThreshold
+        });
+      }
+    }
+
+    console.log('initialSubscriptionSelectors after', initialSubscriptionSelectors);
 
     this.state = {
       loadingDatasets: false,
@@ -213,6 +235,9 @@ AreaSubscriptionModal.propTypes = {
   toggleModal: PropTypes.func.isRequired,
   mode: PropTypes.string.isRequired, // edit | new
   locale: PropTypes.string.isRequired,
+  subscriptionDataset: PropTypes.string,
+  subscriptionType: PropTypes.string,
+  subscriptionThreshold: PropTypes.number,
   // Store
   user: PropTypes.object.isRequired,
   // Callbacks

--- a/components/modal/AreaSubscriptionModal.js
+++ b/components/modal/AreaSubscriptionModal.js
@@ -30,9 +30,6 @@ class AreaSubscriptionModal extends React.Component {
           selectedThreshold: elem.threshold }))
       : [{ index: 0, selectedDataset: null, selectedType: null, selectedThreshold: 1 }];
 
-    console.log('props', props);
-    console.log('initialSubscriptionSelectors BEFORE', initialSubscriptionSelectors);
-
     if (subscriptionDataset) {
       const selectorFound = initialSubscriptionSelectors
         .find(selector => selector.selectedDataset === subscriptionDataset);
@@ -48,8 +45,6 @@ class AreaSubscriptionModal extends React.Component {
         });
       }
     }
-
-    console.log('initialSubscriptionSelectors after', initialSubscriptionSelectors);
 
     this.state = {
       loadingDatasets: false,

--- a/components/modal/SubscribeToDatasetModal.js
+++ b/components/modal/SubscribeToDatasetModal.js
@@ -60,7 +60,11 @@ class SubscribeToDatasetModal extends React.Component {
       Router.pushRoute('myrw_detail', {
         tab: 'areas',
         id: 'new',
-        subscribeToDataset: { dataset: this.props.dataset.id, type: this.state.selectedType } });
+        subscriptionDataset: this.props.dataset.id,
+        subscriptionType: this.state.selectedType,
+        subscriptionThreshold: this.state.selectedThreshold,
+        openUploadAreaModal: true
+      });
     } else {
       this.setState({
         selectedArea: value,

--- a/components/modal/SubscribeToDatasetModal.js
+++ b/components/modal/SubscribeToDatasetModal.js
@@ -128,7 +128,8 @@ class SubscribeToDatasetModal extends React.Component {
                       tab: 'areas',
                       subscriptionType: selectedType.value,
                       subscriptionThreshold: selectedThreshold,
-                      dataset: dataset.id
+                      subscriptionDataset: dataset.id,
+                      openModal: selectedArea.areaID
                     });
                   },
                   onCancel: () => {

--- a/components/modal/SubscribeToDatasetModal.js
+++ b/components/modal/SubscribeToDatasetModal.js
@@ -124,7 +124,12 @@ class SubscribeToDatasetModal extends React.Component {
               toastr.confirm(`There already exist a subscription for the selected area.
                 Do you want to update it? `, {
                   onOk: () => {
-                    Router.pushRoute('myrw', { tab: 'areas' });
+                    Router.pushRoute('myrw', {
+                      tab: 'areas',
+                      subscriptionType: selectedType.value,
+                      subscriptionThreshold: selectedThreshold,
+                      dataset: dataset.id
+                    });
                   },
                   onCancel: () => {
                     this.setState({ loading: false });

--- a/components/subscriptions/SubscriptionSelector.js
+++ b/components/subscriptions/SubscriptionSelector.js
@@ -145,7 +145,7 @@ class SubscriptionSelector extends React.Component {
 
 SubscriptionSelector.propTypes = {
   datasets: PropTypes.array.isRequired,
-  index: PropTypes.string,
+  index: PropTypes.number,
   data: PropTypes.object,
   // CALLBACKS
   onRemove: PropTypes.func.isRequired,

--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -142,6 +142,7 @@ class ExploreDetail extends Page {
 
   componentWillUnmount() {
     this.props.resetDataset();
+    this.props.toggleModal(false);
   }
 
   /**

--- a/pages/app/MyRW.js
+++ b/pages/app/MyRW.js
@@ -73,7 +73,6 @@ class MyRW extends Page {
     const { tab, subtab } = this.state;
     const userName = user && user.name ? ` ${user.name.split(' ')[0]}` : '';
     const title = `Hi${userName}!`;
-
     return (
       <Layout
         title="My Resource Watch Edit Profile"
@@ -118,7 +117,7 @@ class MyRW extends Page {
                 }
 
                 {tab === 'areas' &&
-                  <AreasTab tag={tab} subtab={subtab} />
+                  <AreasTab tag={tab} subtab={subtab} query={url.query} />
                 }
 
                 {tab === 'widgets' &&

--- a/pages/app/MyRWDetail.js
+++ b/pages/app/MyRWDetail.js
@@ -179,7 +179,7 @@ class MyRWDetail extends Page {
                     <DatasetsTab tab={tab} subtab={subtab} id={id} />
                   }
                   {tab === 'areas' &&
-                    <AreasTab tab={tab} subtab={subtab} id={id} />
+                    <AreasTab tab={tab} subtab={subtab} id={id} query={url.query} />
                   }
                   {tab === 'widgets' &&
                     <WidgetsTab tab={tab} subtab={subtab} id={id} dataset={url.query.datasetId} />


### PR DESCRIPTION
## Overview
Fixes for the following two bugs:

### No subscription created when using AOI that is not currently in account

- From dataset detail: subscribe to alerts
- Select a country AOI that you don't currently have, or upload new custom AOI
- Subscription is a success
- Bug: no subscription was created, AOI now in personal area
- Repeating will add the subscription since it's in your areas already.

### Subscribing to AOI with existing subscriptions results in navigation loop.

- From dataset detail: subscribe to alerts
- Select an AOI for which you have existing subscriptions
- "There already exist a subscription for the selected area. Do you want to update it?"
- bug: Goes to AOI page with modal, options cleared, infinite loop.

## Testing instructions

Test any of the two scenarios aforementioned in the Explore Detail page of a subscribable dataset such as _*Earthquakes over the last 30 days*_

[Pivotal Task](https://www.pivotaltracker.com/story/show/153892133)