### PR TITLE
Fix for subscribable attribute

### DIFF
--- a/components/app/pulse/LayerCard.js
+++ b/components/app/pulse/LayerCard.js
@@ -113,10 +113,11 @@ class LayerCard extends React.Component {
   }
 
   render() {
-    const { pulse, user } = this.props;
+    const { pulse } = this.props;
     const { layerActive, layerPoints, similarWidgets } = pulse;
     const { dataset } = this.state;
-    const subscribable = dataset && dataset.attributes && dataset.attributes.subscribable;
+    const subscribable = dataset && dataset.attributes && dataset.attributes.subscribable &&
+      Object.keys(dataset.attributes.subscribable).length > 0;
 
     const className = classNames({
       'c-layer-card': true,
@@ -131,7 +132,8 @@ class LayerCard extends React.Component {
         {layerActive && layerActive.attributes.description &&
           <div
             className="description"
-            dangerouslySetInnerHTML={{ __html: layerActive.attributes.description }} // eslint-disble-line react/no-danger
+            dangerouslySetInnerHTML={{ __html:
+              layerActive.attributes.description }} // eslint-disble-line react/no-danger
           />
         }
         {layerPoints && layerPoints.length > 0 &&

--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -420,6 +420,9 @@ class ExploreDetail extends Page {
       '-empty': !favourite
     });
 
+    const isSubscribable = dataset && dataset.attributes && dataset.attributes.subscribable &&
+      Object.keys(dataset.attributes.subscribable).length > 0;
+
     if (exploreDataset && exploreDataset.error === 'Not Found') return <Error status={404} />;
     if (dataset && !dataset.attributes.published) return <Error status={404} />;
 
@@ -543,7 +546,7 @@ class ExploreDetail extends Page {
                         Learn more
                       </a>
                     }
-                    {dataset && dataset.attributes && dataset.attributes.subscribable &&
+                    {isSubscribable &&
                       <button
                         className="c-button -secondary -fullwidth"
                         onClick={this.handleSubscribe}


### PR DESCRIPTION
## Overview
This PR includes a couple of updates related to the `subscribable` attribute. 
Explore detail and Planet Pulse pages have been modified so that they no longer show as subscribable datasets that had an empty object stored for that attribute.

## Testing instructions
Have a look at this dataset for instance: localhost:3000/data/explore/a7067e9f-fe40-4338-85da-13a6071c76fe

## [Pivotal task](https://www.pivotaltracker.com/story/show/154207449)