### PR TITLE
Freeze widget feature

### DIFF
--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -252,9 +252,11 @@ class WidgetsForm extends React.Component {
                 formObj.queryUrl = url;
                 formObj.widgetConfig.data = { url };
                 obj.body = formObj;
+                console.log('hey!');
               });
             });
           }
+          console.log('ho!');
           console.log('obj', obj);
           this.saveWidget(obj);
         } else {

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -231,7 +231,6 @@ class WidgetsForm extends React.Component {
           // The widget has to be "frozen" first
           if (formObj.freeze) {
             const datasetObj = this.state.datasets.find(d => d.value === form.dataset);
-            console.log('datasetObj', datasetObj);
             getDataURL(
               datasetObj.value,
               datasetObj.type,
@@ -252,10 +251,11 @@ class WidgetsForm extends React.Component {
                 const url = resp.url;
                 formObj.queryUrl = url;
                 formObj.widgetConfig.data = { url };
+                obj.body = formObj;
               });
             });
-            obj.body = formObj;
           }
+          console.log('obj', obj);
           this.saveWidget(obj);
         } else {
           this.setState({

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -40,6 +40,9 @@ import Navigation from 'components/form/Navigation';
 import Step1 from 'components/admin/widgets/form/steps/Step1';
 import Spinner from 'components/ui/Spinner';
 
+// Utils
+import { getDataURL, getChartInfo } from 'utils/widgets/WidgetHelper';
+
 class WidgetsForm extends React.Component {
   constructor(props) {
     super(props);
@@ -102,14 +105,20 @@ class WidgetsForm extends React.Component {
           current &&
           (!current.widgetConfig.paramsConfig || isEmpty(current.widgetConfig.paramsConfig))
         ) ? 'advanced' : 'editor';
-
+        console.log('datasets', datasets);
         this.setState({
           // CURRENT DASHBOARD
           form: (id) ? this.setFormFromParams(current) : this.state.form,
           loading: false,
           mode,
+          dataset: current,
           // OPTIONS
-          datasets: datasets.map(p => ({ label: p.name, value: p.id }))
+          datasets: datasets.map(p => ({
+            label: p.name,
+            value: p.id,
+            type: p.type,
+            tableName: p.tableName
+          }))
         }, () => this.loadWidgetIntoRedux());
       })
       .catch((err) => {
@@ -221,7 +230,22 @@ class WidgetsForm extends React.Component {
 
           // The widget has to be "frozen" first
           if (formObj.freeze) {
-            //console.log('formObj', formObj);
+            const datasetObj = this.state.datasets.find(d => d.value === form.dataset);
+            console.log('formObj', formObj, 'dataset', datasetObj);
+            const dataURL = getDataURL(
+              datasetObj.value,
+              datasetObj.type,
+              datasetObj.tableName,
+              formObj.widgetConfig.paramsConfig.band,
+              datasetObj.provider,
+              getChartInfo(
+                datasetObj.value,
+                datasetObj.type,
+                datasetObj.provider,
+                formObj.widgetConfig.paramsConfig
+              )
+            );
+            console.log('dataURL', dataURL);
           } else  {
             this.saveWidget(obj);
           }

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -219,24 +219,12 @@ class WidgetsForm extends React.Component {
             delete obj.body.sourceUrl;
           }
 
-          // Save data
-          this.service.saveData(obj)
-            .then((data) => {
-              toastr.success('Success', `The widget "${data.id}" - "${data.name}" has been uploaded correctly`);
-
-              if (this.props.onSubmit) this.props.onSubmit();
-            })
-            .catch((errors) => {
-              this.setState({ submitting: false });
-
-              try {
-                errors.forEach(er =>
-                  toastr.error('Error', er.detail)
-                );
-              } catch (e) {
-                toastr.error('Error', 'Oops! There was an error, try again.');
-              }
-            });
+          // The widget has to be "frozen" first
+          if (formObj.freeze) {
+            //console.log('formObj', formObj);
+          } else  {
+            this.saveWidget(obj);
+          }
         } else {
           this.setState({
             step: this.state.step + 1
@@ -251,6 +239,8 @@ class WidgetsForm extends React.Component {
       }
     }, 0);
   }
+
+
 
   onChange(obj) {
     const form = Object.assign({}, this.state.form, obj);
@@ -277,6 +267,27 @@ class WidgetsForm extends React.Component {
     });
 
     return newForm;
+  }
+
+  saveWidget(obj) {
+    // Save data
+    this.service.saveData(obj)
+      .then((data) => {
+        toastr.success('Success', `The widget "${data.id}" - "${data.name}" has been uploaded correctly`);
+
+        if (this.props.onSubmit) this.props.onSubmit();
+      })
+      .catch((errors) => {
+        this.setState({ submitting: false });
+
+        try {
+          errors.forEach(er =>
+            toastr.error('Error', er.detail)
+          );
+        } catch (e) {
+          toastr.error('Error', 'Oops! There was an error, try again.');
+        }
+      });
   }
 
   validateWidgetConfig() {

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -116,7 +116,8 @@ class WidgetsForm extends React.Component {
             label: p.name,
             value: p.id,
             type: p.type,
-            tableName: p.tableName
+            tableName: p.tableName,
+            slug: p.slug
           }))
         }, () => this.loadWidgetIntoRedux());
       })
@@ -230,6 +231,7 @@ class WidgetsForm extends React.Component {
           // The widget has to be "frozen" first
           if (formObj.freeze) {
             const datasetObj = this.state.datasets.find(d => d.value === form.dataset);
+            console.log('datasetObj', datasetObj);
             getDataURL(
               datasetObj.value,
               datasetObj.type,
@@ -241,12 +243,15 @@ class WidgetsForm extends React.Component {
                 datasetObj.type,
                 datasetObj.provider,
                 widgetEditor
-              )
+              ),
+              false,
+              datasetObj.slug
             ).then((dataURL) => {
               const sqlSt = dataURL.split('sql=')[1];
-              this.service.freezeWidget(sqlSt).then((jsonObjURL) => {
-                console.log('jsonObjURL', jsonObjURL);
-              });
+              console.log('sqlSt', sqlSt);
+              // this.service.freezeWidget(sqlSt).then((jsonObjURL) => {
+              //   console.log('jsonObjURL', jsonObjURL);
+              // });
             });
           } else {
             this.saveWidget(obj);

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -250,7 +250,16 @@ class WidgetsForm extends React.Component {
               this.service.freezeWidget(sqlSt).then((resp) => {
                 const url = resp.url;
                 formObj.queryUrl = url;
-                formObj.widgetConfig.data = { url };
+                formObj.widgetConfig.data = [
+                  {
+                    format: {
+                      property: 'data',
+                      type: 'json'
+                    },
+                    name: 'table',
+                    url
+                  }
+                ];
                 obj.body = formObj;
                 this.saveWidget(obj);
               });

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -231,11 +231,13 @@ class WidgetsForm extends React.Component {
           // The widget has to be "frozen" first
           if (formObj.freeze) {
             const datasetObj = this.state.datasets.find(d => d.value === form.dataset);
+            const tempBand = formObj.widgetConfig.paramsConfig ?
+              formObj.widgetConfig.paramsConfig.band : null;
             getDataURL(
               datasetObj.value,
               datasetObj.type,
               datasetObj.tableName,
-              formObj.widgetConfig.paramsConfig.band,
+              tempBand,
               datasetObj.provider,
               getChartInfo(
                 datasetObj.value,

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -248,10 +248,9 @@ class WidgetsForm extends React.Component {
               datasetObj.slug
             ).then((dataURL) => {
               const sqlSt = dataURL.split('sql=')[1];
-              console.log('sqlSt', sqlSt);
-              // this.service.freezeWidget(sqlSt).then((jsonObjURL) => {
-              //   console.log('jsonObjURL', jsonObjURL);
-              // });
+              this.service.freezeWidget(sqlSt).then((jsonObjURL) => {
+                console.log('jsonObjURL', jsonObjURL);
+              });
             });
           } else {
             this.saveWidget(obj);

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -248,13 +248,15 @@ class WidgetsForm extends React.Component {
               datasetObj.slug
             ).then((dataURL) => {
               const sqlSt = dataURL.split('sql=')[1];
-              this.service.freezeWidget(sqlSt).then((jsonObjURL) => {
-                console.log('jsonObjURL', jsonObjURL);
+              this.service.freezeWidget(sqlSt).then((resp) => {
+                const url = resp.url;
+                formObj.queryUrl = url;
+                formObj.widgetConfig.data = { url };
               });
             });
-          } else {
-            this.saveWidget(obj);
+            obj.body = formObj;
           }
+          this.saveWidget(obj);
         } else {
           this.setState({
             step: this.state.step + 1
@@ -424,6 +426,7 @@ class WidgetsForm extends React.Component {
             mode={this.state.mode}
             onChange={value => this.onChange(value)}
             onModeChange={this.handleModeChange}
+            showEditor={this.props.showEditor}
           />
         }
 
@@ -440,11 +443,16 @@ class WidgetsForm extends React.Component {
   }
 }
 
+WidgetsForm.defaultProps = {
+  showEditor: true
+};
+
 WidgetsForm.propTypes = {
   authorization: PropTypes.string,
   id: PropTypes.string,
   onSubmit: PropTypes.func,
   dataset: PropTypes.string, // ID of the dataset that should be pre-selected
+  showEditor: PropTypes.bool,
   // Store
   widgetEditor: PropTypes.object,
   locale: PropTypes.string.isRequired,

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -105,7 +105,6 @@ class WidgetsForm extends React.Component {
           current &&
           (!current.widgetConfig.paramsConfig || isEmpty(current.widgetConfig.paramsConfig))
         ) ? 'advanced' : 'editor';
-        console.log('datasets', datasets);
         this.setState({
           // CURRENT DASHBOARD
           form: (id) ? this.setFormFromParams(current) : this.state.form,
@@ -231,8 +230,7 @@ class WidgetsForm extends React.Component {
           // The widget has to be "frozen" first
           if (formObj.freeze) {
             const datasetObj = this.state.datasets.find(d => d.value === form.dataset);
-            console.log('formObj', formObj, 'dataset', datasetObj);
-            const dataURL = getDataURL(
+            getDataURL(
               datasetObj.value,
               datasetObj.type,
               datasetObj.tableName,
@@ -242,11 +240,15 @@ class WidgetsForm extends React.Component {
                 datasetObj.value,
                 datasetObj.type,
                 datasetObj.provider,
-                formObj.widgetConfig.paramsConfig
+                widgetEditor
               )
-            );
-            console.log('dataURL', dataURL);
-          } else  {
+            ).then((dataURL) => {
+              const sqlSt = dataURL.split('sql=')[1];
+              this.service.freezeWidget(sqlSt).then((jsonObjURL) => {
+                console.log('jsonObjURL', jsonObjURL);
+              });
+            });
+          } else {
             this.saveWidget(obj);
           }
         } else {

--- a/components/admin/widgets/form/WidgetsForm.js
+++ b/components/admin/widgets/form/WidgetsForm.js
@@ -252,13 +252,12 @@ class WidgetsForm extends React.Component {
                 formObj.queryUrl = url;
                 formObj.widgetConfig.data = { url };
                 obj.body = formObj;
-                console.log('hey!');
+                this.saveWidget(obj);
               });
             });
+          } else {
+            this.saveWidget(obj);
           }
-          console.log('ho!');
-          console.log('obj', obj);
-          this.saveWidget(obj);
         } else {
           this.setState({
             step: this.state.step + 1

--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -199,12 +199,12 @@ class Step1 extends React.Component {
               onChange={value => this.props.onChange({ freeze: value.checked })}
               properties={{
                 name: 'freeze',
-                label: this.props.form.freeze ? '' : 'Do you want to freeze this widget?',
+                label: this.props.id ? '' : 'Do you want to freeze this widget?',
                 value: 'freeze',
                 title: 'Freeze',
                 defaultChecked: this.props.form.freeze,
                 checked: this.props.form.freeze,
-                disabled: this.props.form.freeze
+                disabled: this.props.id && this.props.form.freeze
               }}
             >
               {Checkbox}

--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -181,6 +181,22 @@ class Step1 extends React.Component {
             {Checkbox}
           </Field>
 
+          {/* FREEZE */}
+          <Field
+            ref={(c) => { if (c) FORM_ELEMENTS.elements.published = c; }}
+            onChange={value => this.props.onChange({ published: value.checked })}
+            properties={{
+              name: 'freeze',
+              label: 'Do you want to freeze this widget?',
+              value: 'freeze',
+              title: 'Freeze',
+              defaultChecked: this.props.form.freeze,
+              checked: this.props.form.freeze
+            }}
+          >
+            {Checkbox}
+          </Field>
+
         </fieldset>
 
         {this.state.form.dataset &&
@@ -240,6 +256,7 @@ class Step1 extends React.Component {
                 {Code}
               </Field>
             }
+
           </fieldset>
         }
       </fieldset>

--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -183,8 +183,8 @@ class Step1 extends React.Component {
 
           {/* FREEZE */}
           <Field
-            ref={(c) => { if (c) FORM_ELEMENTS.elements.published = c; }}
-            onChange={value => this.props.onChange({ published: value.checked })}
+            ref={(c) => { if (c) FORM_ELEMENTS.elements.freeze = c; }}
+            onChange={value => this.props.onChange({ freeze: value.checked })}
             properties={{
               name: 'freeze',
               label: 'Do you want to freeze this widget?',

--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -20,6 +20,11 @@ import Code from 'components/form/Code';
 import Checkbox from 'components/form/Checkbox';
 import WidgetEditor from 'components/widgets/editor/WidgetEditor';
 import SwitchOptions from 'components/ui/SwitchOptions';
+import VegaChart from 'components/widgets/charts/VegaChart';
+import Spinner from 'components/ui/Spinner';
+
+// utils
+import ChartTheme from 'utils/widgets/theme';
 
 class Step1 extends React.Component {
   constructor(props) {
@@ -27,11 +32,13 @@ class Step1 extends React.Component {
 
     this.state = {
       id: props.id,
-      form: props.form
+      form: props.form,
+      loadingVegaChart: true
     };
 
-    // BINDINGS
+    // ------------------- BINDINGS ---------------------------
     this.triggerChangeMode = this.triggerChangeMode.bind(this);
+    this.triggerToggleLoadingVegaChart = this.triggerToggleLoadingVegaChart.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -64,9 +71,13 @@ class Step1 extends React.Component {
     }
   }
 
+  triggerToggleLoadingVegaChart(loading) {
+    this.setState({ loadingVegaChart: loading });
+  }
+
   render() {
-    const { id } = this.state;
-    const { widgetEditor } = this.props;
+    const { id, loadingVegaChart } = this.state;
+    const { widgetEditor, showEditor } = this.props;
 
     // Reset FORM_ELEMENTS
     FORM_ELEMENTS.elements = {};
@@ -182,24 +193,31 @@ class Step1 extends React.Component {
           </Field>
 
           {/* FREEZE */}
-          <Field
-            ref={(c) => { if (c) FORM_ELEMENTS.elements.freeze = c; }}
-            onChange={value => this.props.onChange({ freeze: value.checked })}
-            properties={{
-              name: 'freeze',
-              label: 'Do you want to freeze this widget?',
-              value: 'freeze',
-              title: 'Freeze',
-              defaultChecked: this.props.form.freeze,
-              checked: this.props.form.freeze
-            }}
-          >
-            {Checkbox}
-          </Field>
-
+          <div className="freeze-container">
+            <Field
+              ref={(c) => { if (c) FORM_ELEMENTS.elements.freeze = c; }}
+              onChange={value => this.props.onChange({ freeze: value.checked })}
+              properties={{
+                name: 'freeze',
+                label: this.props.form.freeze ? '' : 'Do you want to freeze this widget?',
+                value: 'freeze',
+                title: 'Freeze',
+                defaultChecked: this.props.form.freeze,
+                checked: this.props.form.freeze,
+                disabled: this.props.form.freeze
+              }}
+            >
+              {Checkbox}
+            </Field>
+            {this.props.form.freeze &&
+              <div className="freeze-text">
+                This widget has been <strong>frozen</strong> and cannot be edited...
+              </div>
+            }
+          </div>
         </fieldset>
 
-        {this.state.form.dataset &&
+        {this.state.form.dataset && showEditor &&
           <fieldset className={`c-field-container ${editorFieldContainerClass}`}>
             <div className="l-row row align-right">
               <div className="column shrink">
@@ -259,10 +277,26 @@ class Step1 extends React.Component {
 
           </fieldset>
         }
+        {!showEditor && this.state.form.dataset &&
+          <div>
+            <Spinner isLoading={loadingVegaChart} className="-light -relative" />
+            <VegaChart
+              data={this.state.form.widgetConfig}
+              theme={ChartTheme()}
+              showLegend
+              reloadOnResize
+              toggleLoading={this.triggerToggleLoadingVegaChart}
+            />
+          </div>
+        }
       </fieldset>
     );
   }
 }
+
+Step1.defaultProps = {
+  showEditor: true
+};
 
 Step1.propTypes = {
   id: PropTypes.string,
@@ -271,6 +305,7 @@ Step1.propTypes = {
   datasets: PropTypes.array,
   onChange: PropTypes.func,
   onModeChange: PropTypes.func,
+  showEditor: PropTypes.bool,
   // REDUX
   widgetEditor: PropTypes.object,
   setTitle: PropTypes.func

--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -209,9 +209,9 @@ class Step1 extends React.Component {
             >
               {Checkbox}
             </Field>
-            {this.props.form.freeze &&
+            {this.props.form.freeze && this.props.mode === 'new' &&
               <div className="freeze-text">
-                This widget has been <strong>frozen</strong> and cannot be edited...
+                This widget has been <strong>frozen</strong> and cannot be modified...
               </div>
             }
           </div>

--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -214,7 +214,7 @@ class Step1 extends React.Component {
             >
               {Checkbox}
             </Field>
-            {this.props.form.freeze && this.props.mode === 'new' &&
+            {this.props.form.freeze && this.props.id &&
               <div className="freeze-text">
                 This widget has been <strong>frozen</strong> and cannot be modified...
               </div>

--- a/components/admin/widgets/pages/show.js
+++ b/components/admin/widgets/pages/show.js
@@ -71,6 +71,7 @@ class WidgetsShow extends React.Component {
                     Router.pushRoute('admin_data', { tab: 'widgets' });
                   }
                 }}
+                showEditor={false}
               />
               }
 

--- a/css/components/admin/widget/form.scss
+++ b/css/components/admin/widget/form.scss
@@ -1,3 +1,5 @@
 .c-widgets-form {
-
+  .freeze-text {
+    font-style: italic;
+  }
 }

--- a/services/WidgetsService.js
+++ b/services/WidgetsService.js
@@ -162,14 +162,35 @@ export default class WidgetsService {
           value: this.opts.authorization
         }],
         onSuccess: ({ data }) => {
-          const collections = flatten(data.map((d) => {
-            return d.attributes.resources
-              .filter(val => val.type === 'widget')
-              .map(val => ({ id: val.id, tags: val.tags }))
-              .filter(val => val.tags.find(tag => tag.includes(this.opts.user.id)));
-          }));
+          const collections = flatten(data.map(d => d.attributes.resources
+            .filter(val => val.type === 'widget')
+            .map(val => ({ id: val.id, tags: val.tags }))
+            .filter(val => val.tags.find(tag => tag.includes(this.opts.user.id)))
+          ));
 
           resolve(collections);
+        },
+        onError: (error) => {
+          reject(error);
+        }
+      });
+    });
+  }
+
+  /**
+  * This method freezes a widget and returns the URL of the corresponding JSON
+  * file that was created on the cloud
+  */
+  freezeWidget(sqlQuery) {
+    return new Promise((resolve, reject) => {
+      get({
+        url: `${process.env.WRI_API_URL}/query?sql=${sqlQuery}`,
+        headers: [{
+          key: 'Authorization',
+          value: this.opts.authorization
+        }],
+        onSuccess: () => {
+          resolve();
         },
         onError: (error) => {
           reject(error);

--- a/services/WidgetsService.js
+++ b/services/WidgetsService.js
@@ -184,7 +184,7 @@ export default class WidgetsService {
   freezeWidget(sqlQuery) {
     return new Promise((resolve, reject) => {
       get({
-        url: `${process.env.WRI_API_URL}/query?sql=${sqlQuery}`,
+        url: `${process.env.WRI_API_URL}/query?sql=${sqlQuery}&freeze=true`,
         headers: [{
           key: 'Authorization',
           value: this.opts.authorization

--- a/services/WidgetsService.js
+++ b/services/WidgetsService.js
@@ -189,8 +189,8 @@ export default class WidgetsService {
           key: 'Authorization',
           value: this.opts.authorization
         }],
-        onSuccess: () => {
-          resolve();
+        onSuccess: (response) => {
+          resolve(response);
         },
         onError: (error) => {
           reject(error);

--- a/utils/getQueryByFilters.js
+++ b/utils/getQueryByFilters.js
@@ -21,7 +21,8 @@ export default function getQueryByFilters(
   filters = [],
   arrColumns = [],
   arrOrder = [],
-  sortOrder = 'asc'
+  sortOrder = 'asc',
+  datasetSlug = null
 ) {
   // We compute the WHERE part of the query which corresponds
   // to the filters
@@ -84,5 +85,7 @@ export default function getQueryByFilters(
     groupBy = groupBy.slice(0, -1); // remove extra comma at the end
   }
 
-  return `SELECT ${columns} FROM ${tableName} ${where} ${groupBy} ${orderBy}`;
+  const sourceSt = datasetSlug || tableName;
+
+  return `SELECT ${columns} FROM ${sourceSt} ${where} ${groupBy} ${orderBy}`;
 }

--- a/utils/widgets/WidgetHelper.js
+++ b/utils/widgets/WidgetHelper.js
@@ -250,7 +250,7 @@ export async function getRasterDataURL(dataset, datasetType, tableName, band, pr
  * @return {string}
  */
 export async function getDataURL(dataset, datasetType, tableName, band, provider,
-  chartInfo, isTable = false) {
+  chartInfo, isTable = false, datasetSlug = null) {
   // If the dataset is a raster one, the behaviour is totally different
   if (datasetType === 'raster') {
     if (!band) return '';
@@ -315,7 +315,7 @@ export async function getDataURL(dataset, datasetType, tableName, band, provider
   }
 
   const sortOrder = chartInfo.order ? chartInfo.order.orderType : 'asc';
-  const query = `${getQueryByFilters(tableName, chartInfo.filters, columns, orderByColumn, sortOrder)} LIMIT ${chartInfo.limit}`;
+  const query = `${getQueryByFilters(tableName, chartInfo.filters, columns, orderByColumn, sortOrder, datasetSlug)} LIMIT ${chartInfo.limit}`;
 
   const geostore = chartInfo.areaIntersection ? `&geostore=${chartInfo.areaIntersection}` : '';
 


### PR DESCRIPTION
## Overview

This PR includes the logic needed to freeze widgets. 
> NOTE: This process cannot be undone, once a widget has been frozen the graphical part of it cannot be changed.

## Testing instructions

Create/update a new widget and select the `freeze` checkbox.

## [Pivotal task](https://www.pivotaltracker.com/story/show/154207889)