### PR TITLE
Surface widget links

### DIFF
--- a/components/app/myrw/widgets/MyRWWidgetsMy.js
+++ b/components/app/myrw/widgets/MyRWWidgetsMy.js
@@ -65,8 +65,9 @@ class MyRWWidgetsMy extends React.Component {
     this.setState({
       myWidgetsLoaded: false
     });
-    this.widgetService.getUserWidgets(this.props.user.id, true, orderDirection, 'vocabulary')
+    this.widgetService.getUserWidgets(this.props.user.id, true, orderDirection, 'vocabulary,metadata')
       .then((response) => {
+        console.log('response', response);
         this.setState({
           myWidgetsLoaded: true,
           myWidgets: response

--- a/components/app/myrw/widgets/MyRWWidgetsMy.js
+++ b/components/app/myrw/widgets/MyRWWidgetsMy.js
@@ -67,7 +67,6 @@ class MyRWWidgetsMy extends React.Component {
     });
     this.widgetService.getUserWidgets(this.props.user.id, true, orderDirection, 'vocabulary,metadata')
       .then((response) => {
-        console.log('response', response);
         this.setState({
           myWidgetsLoaded: true,
           myWidgets: response

--- a/components/widgets/list/WidgetActionsTooltip.js
+++ b/components/widgets/list/WidgetActionsTooltip.js
@@ -48,6 +48,8 @@ class WidgetActionsTooltip extends React.Component {
   }
 
   render() {
+    const { widgetLinks } = this.props;
+    console.log('widgetLinks', widgetLinks);
     return (
       <div className="c-widget-actions-tooltip">
         <ul>
@@ -66,11 +68,18 @@ class WidgetActionsTooltip extends React.Component {
               Add to dashboard
             </button>
           </li>
-          <li>
-            <button onClick={() => this.handleClick('go_to_dataset')}>
-              Go to dataset
-            </button>
-          </li>
+          {!widgetLinks.length === 0 &&
+            <li>
+              <button onClick={() => this.handleClick('go_to_dataset')}>
+                Go to dataset
+              </button>
+            </li>
+          }
+          {widgetLinks.map(link =>
+            (<li>
+              {link.name}
+            </li>)
+          )}
           <li>
             <button onClick={() => this.handleClick('download_pdf')}>
               Download as PDF
@@ -83,6 +92,7 @@ class WidgetActionsTooltip extends React.Component {
 }
 
 WidgetActionsTooltip.propTypes = {
+  widgetLinks: PropTypes.array,
   toggleTooltip: PropTypes.func.isRequired,
   // Callbacks
   onGoToDataset: PropTypes.func.isRequired,

--- a/components/widgets/list/WidgetActionsTooltip.js
+++ b/components/widgets/list/WidgetActionsTooltip.js
@@ -68,7 +68,7 @@ class WidgetActionsTooltip extends React.Component {
               Add to dashboard
             </button>
           </li>
-          {!widgetLinks.length === 0 &&
+          {widgetLinks.length === 0 &&
             <li>
               <button onClick={() => this.handleClick('go_to_dataset')}>
                 Go to dataset
@@ -77,7 +77,7 @@ class WidgetActionsTooltip extends React.Component {
           }
           {widgetLinks.map(link =>
             (<li>
-              {link.name}
+              <a href={link.link} target="_blank">Go to {link.name}</a>
             </li>)
           )}
           <li>

--- a/components/widgets/list/WidgetActionsTooltip.js
+++ b/components/widgets/list/WidgetActionsTooltip.js
@@ -49,7 +49,6 @@ class WidgetActionsTooltip extends React.Component {
 
   render() {
     const { widgetLinks } = this.props;
-    console.log('widgetLinks', widgetLinks);
     return (
       <div className="c-widget-actions-tooltip">
         <ul>

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -374,6 +374,11 @@ class WidgetCard extends React.Component {
   }
 
   handleWidgetActionsClick(event) {
+    const { widget } = this.props;
+    const widgetAtts = widget.attributes;
+    const widgetLinks = (widgetAtts.metadata && widgetAtts.metadata.length > 0 &&
+      widgetAtts.metadata[0].attributes.info &&
+      widgetAtts.metadata[0].attributes.info.widgetLinks) || [];
     const position = WidgetCard.getClickPosition(event);
     this.props.toggleTooltip(true, {
       follow: false,
@@ -385,7 +390,8 @@ class WidgetCard extends React.Component {
         onAddToDashboard: this.handleAddToDashboard,
         onGoToDataset: this.handleGoToDataset,
         onEditWidget: this.handleEditWidget,
-        onDownloadPDF: this.handleDownloadPDF
+        onDownloadPDF: this.handleDownloadPDF,
+        widgetLinks
       }
     });
   }
@@ -453,6 +459,7 @@ class WidgetCard extends React.Component {
 
         {/* Actual widget */}
         <div
+          tabIndex={-1}
           role="button"
           onClick={() => this.props.onWidgetClick && this.props.onWidgetClick(widget)}
         >
@@ -462,6 +469,7 @@ class WidgetCard extends React.Component {
         <div className="info">
           <div
             className="detail"
+            tabIndex={-1}
             role="button"
             onClick={() => this.props.onWidgetClick && this.props.onWidgetClick(widget)}
           >

--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -133,6 +133,17 @@
       h4 {
         color: $base-font-color;
       }
+
+      .widget-links-container {
+        
+        ul {
+          list-style-type: circle;
+
+          li {
+            margin-left: 35px;
+          }
+        }
+      }
     }
   }
 

--- a/css/components/widgets/widget_actions_tooltip.scss
+++ b/css/components/widgets/widget_actions_tooltip.scss
@@ -13,5 +13,11 @@
       cursor: pointer;
       font-size: $font-size-medium;
     }
+
+    a {
+      padding-left: 6px;
+      font-size: $font-size-medium;
+      text-decoration: none;
+    }
   }
 }

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -127,6 +127,11 @@ class EmbedWidget extends Page {
 
     const favouriteIcon = favourited ? 'star-full' : 'star-empty';
 
+    const widgetAtts = widget && widget.attributes;
+    const widgetLinks = (widgetAtts && widgetAtts.metadata && widgetAtts.metadata.length > 0 &&
+      widgetAtts.metadata[0].attributes.info &&
+      widgetAtts.metadata[0].attributes.info.widgetLinks) || [];
+
     if (loading) {
       return (
         <EmbedLayout
@@ -179,9 +184,14 @@ class EmbedWidget extends Page {
         <div className="c-embed-widget">
           <Spinner isLoading={isLoading} className="-light" />
           <div className="widget-title">
-            <a href={`/data/explore/${widget.attributes.dataset}`} target="_blank" rel="noopener noreferrer">
+            {widgetLinks.length === 0 &&
+              <a href={`/data/explore/${widget.attributes.dataset}`} target="_blank" rel="noopener noreferrer">
+                <h4>{widget.attributes.name}</h4>
+              </a>
+            }
+            {widgetLinks.length > 0 &&
               <h4>{widget.attributes.name}</h4>
-            </a>
+            }
             <div className="buttons">
               {
                 user.id && (

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -43,16 +43,40 @@ class EmbedWidget extends Page {
 
   componentDidMount() {
     const { url } = this.props;
-    this.props.getWidget(url.query.id);
+    this.props.getWidget(url.query.id, 'metadata');
     if (this.props.user.id) this.props.checkIfFavorited(url.query.id);
   }
 
   getModal() {
     const { widget, bandDescription, bandStats } = this.props;
+    const widgetAtts = widget.attributes;
+    const widgetLinks = (widgetAtts.metadata && widgetAtts.metadata.length > 0 &&
+      widgetAtts.metadata[0].attributes.info &&
+      widgetAtts.metadata[0].attributes.info.widgetLinks) || [];
+    const noAdditionalInfo = !widget.attributes.description && !bandDescription &&
+      isEmpty(bandStats) && widgetLinks.length === 0;
     return (
       <div className="widget-modal">
-        { !widget.attributes.description && !bandDescription && isEmpty(bandStats) &&
+        { noAdditionalInfo &&
           <p>No additional information is available</p>
+        }
+
+        { widgetLinks.length > 0 &&
+          <div className="widget-links-container">
+            <h4>Links</h4>
+            <ul>
+              { widgetLinks.map(link => (
+                <li>
+                  <a
+                    href={link.link}
+                    target="_blank"
+                  >
+                    {link.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
         }
 
         { widget.attributes.description && (

--- a/redactions/widget.js
+++ b/redactions/widget.js
@@ -223,11 +223,11 @@ export function setLatLng(latLng) {
  * Retrieve the list of widgets
  * @param {string} widgetId
  */
-export function getWidget(widgetId) {
+export function getWidget(widgetId, includes = '') {
   return (dispatch) => {
     dispatch({ type: GET_WIDGET_LOADING });
     const service = new WidgetService(widgetId, { apiURL: process.env.WRI_API_URL });
-    return service.fetchData()
+    return service.fetchData(includes)
       .then((data) => {
         dispatch({ type: SET_WIDGET_DATA, payload: data });
         return data;


### PR DESCRIPTION
## Overview
This PR surfaces to app site the widget links that can be created from the metadata section in the back office. 
They are visible now in the following two pages:

1. `Profile --> My Widgets` section as part of the Widget Actions tooltip:

![image](https://user-images.githubusercontent.com/545342/34869413-1b3389b0-f787-11e7-9c0e-d25537f5942b.png)

2. Embed Widget page in the flipcard

![image](https://user-images.githubusercontent.com/545342/34869543-8e2a7cee-f787-11e7-800b-78d1dc6214fb.png)

> NOTE: The title hyperlink of the widget embed page is deactivated when there exist `widgetLinks` defined.

## Testing instructions

Check the two pages mentioned above using a widget for which you've defined a set of widget links.

## [Pivotal task](https://www.pivotaltracker.com/story/show/154212404)
