### PR TITLE
Add media buttons to share widget modal

### DIFF
--- a/components/modal/EmbedMyWidgetModal.js
+++ b/components/modal/EmbedMyWidgetModal.js
@@ -51,9 +51,32 @@ class EmbedMyWidgetModal extends React.Component {
         <p>You may include this content on your webpage. To do this, copy the following html
         code and insert it into the source code of your page:</p>
         <div className="url-container">
-          <input ref={(n) => { this.input = n; }} value={iframeText} className="url" readOnly />
-          <button className="c-btn -primary" onClick={() => this.onCopyClick()}>
-            Copy
+          <div className="c-field">
+            <label htmlFor="share-url">Code to embed</label>
+            <div className="url-input-div">
+              <input
+                id="share-url"
+                ref={(n) => { this.input = n; }}
+                value={iframeText}
+                className="url"
+                readOnly
+              />
+              <div className="copy-button">
+                <a
+                  className="c-btn"
+                  tabIndex={0}
+                  role="button"
+                  onClick={() => this.onCopyClick()}
+                >
+                  Copy code
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="buttons">
+          <button className="c-button -primary" onClick={() => this.props.toggleModal()}>
+            Close
           </button>
         </div>
       </div>
@@ -63,7 +86,8 @@ class EmbedMyWidgetModal extends React.Component {
 
 EmbedMyWidgetModal.propTypes = {
   widgetId: PropTypes.string.isRequired,
-  visualizationType: PropTypes.string.isRequired
+  visualizationType: PropTypes.string.isRequired,
+  toggleModal: PropTypes.func.isRequired
 };
 
 export default EmbedMyWidgetModal;

--- a/components/modal/EmbedMyWidgetModal.js
+++ b/components/modal/EmbedMyWidgetModal.js
@@ -2,6 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { toastr } from 'react-redux-toastr';
 
+// Components
+import Icon from 'components/ui/Icon';
+
+// Utils
+import { logEvent } from 'utils/analytics';
+
 class EmbedMyWidgetModal extends React.Component {
   constructor(props) {
     super(props);
@@ -23,10 +29,10 @@ class EmbedMyWidgetModal extends React.Component {
   }
 
   render() {
-    const { widgetId, visualizationType } = this.props;
+    const { widget, visualizationType } = this.props;
     const { protocol, hostname, port } = window && window.location ? window.location : {};
     const embedHost = window && window.location ? `${protocol}//${hostname}${port !== '' ? `:${port}` : port}` : '';
-
+    console.log('widget', widget);
     let embedType;
     switch (visualizationType) {
       case 'map':
@@ -43,7 +49,7 @@ class EmbedMyWidgetModal extends React.Component {
         break;
     }
 
-    const url = `${embedHost}/embed/${embedType}/${widgetId}`;
+    const url = `${embedHost}/embed/${embedType}/${widget.id}`;
     const iframeText = `<iframe src="${url}" width="100%" height="474" frameBorder="0"></iframe>`;
     return (
       <div className="c-embed-my-widget-modal">
@@ -61,6 +67,24 @@ class EmbedMyWidgetModal extends React.Component {
                 className="url"
                 readOnly
               />
+              <div className="media">
+                <a
+                  href={`http://www.facebook.com/sharer/sharer.php?u=${url}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => logEvent('Share', `Share a specific widget: ${this.props.widget.id}`, 'Facebook')}
+                >
+                  <Icon name="icon-facebook" className="-medium" />
+                </a>
+                <a
+                  href={`https://twitter.com/share?url=${url}&text=${encodeURIComponent(widget.attributes.name)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => logEvent('Share', `Share a specific widget: ${this.props.widget.id}`, 'Twitter')}
+                >
+                  <Icon name="icon-twitter" className="-medium" />
+                </a>
+              </div>
               <div className="copy-button">
                 <a
                   className="c-btn"
@@ -85,7 +109,7 @@ class EmbedMyWidgetModal extends React.Component {
 }
 
 EmbedMyWidgetModal.propTypes = {
-  widgetId: PropTypes.string.isRequired,
+  widget: PropTypes.object.isRequired,
   visualizationType: PropTypes.string.isRequired,
   toggleModal: PropTypes.func.isRequired
 };

--- a/components/modal/EmbedMyWidgetModal.js
+++ b/components/modal/EmbedMyWidgetModal.js
@@ -32,7 +32,6 @@ class EmbedMyWidgetModal extends React.Component {
     const { widget, visualizationType } = this.props;
     const { protocol, hostname, port } = window && window.location ? window.location : {};
     const embedHost = window && window.location ? `${protocol}//${hostname}${port !== '' ? `:${port}` : port}` : '';
-    console.log('widget', widget);
     let embedType;
     switch (visualizationType) {
       case 'map':

--- a/components/ui/Modal.js
+++ b/components/ui/Modal.js
@@ -39,13 +39,16 @@ export default class Modal extends React.Component {
       >
         <div className="modal-container">
           <button className="modal-close" onClick={() => this.props.toggleModal(false)}>
-            <Icon name="icon-cross" className="-big" />
+            <Icon name="icon-cross" className="-small" />
           </button>
           <div className="modal-content">
             {this.props.loading ? <Spinner isLoading /> : this.getContent()}
           </div>
         </div>
-        <div className="modal-backdrop" onClick={() => this.props.toggleModal(false)} />
+        <div
+          className="modal-backdrop"
+          onClick={() => this.props.toggleModal(false)}
+        />
       </section>
     );
   }

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -335,7 +335,8 @@ class WidgetCard extends React.Component {
         visualizationType: (this.props.widget.attributes.widgetConfig
           && this.props.widget.attributes.widgetConfig.paramsConfig
           && this.props.widget.attributes.widgetConfig.paramsConfig.visualizationType)
-          || 'chart'
+          || 'chart',
+        toggleModal: this.props.toggleModal
       }
     };
     this.props.toggleModal(true);

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -331,7 +331,7 @@ class WidgetCard extends React.Component {
     const options = {
       children: EmbedMyWidgetModal,
       childrenProps: {
-        widgetId: this.props.widget.id,
+        widget: this.props.widget,
         visualizationType: (this.props.widget.attributes.widgetConfig
           && this.props.widget.attributes.widgetConfig.paramsConfig
           && this.props.widget.attributes.widgetConfig.paramsConfig.visualizationType)

--- a/css/components/modal/embed_my_widget_modal.scss
+++ b/css/components/modal/embed_my_widget_modal.scss
@@ -6,14 +6,56 @@
   }
 
   .url-container {
-    display: flex;
-    justify-content: space-between;
+    margin-bottom: 30px;
 
-    margin-top: 60px;
-
-    input {
-      width: 100%;
-      margin-right: 20px;
+    h5 {
+      margin-bottom: 10px;
     }
+
+    .url-input-div {
+      display: flex;
+      align-items: center;
+      border: 1px solid $border-color-1;
+      border-radius: 4px;
+
+      input {
+        border: none;
+        flex-grow: 1;
+        height: 45px;
+        padding: 0 15px;
+      }
+
+      .media {
+        a {
+          fill: $color-dark-pink;
+          margin-right: 10px;
+          cursor: pointer;
+        }
+      }
+
+      .copy-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 40px;
+        width: 100px;
+        margin: 4px;
+
+        cursor: pointer;
+        color: $color-dark-pink;
+
+        a {
+          text-align: center;
+        }
+
+        &:hover {
+          background-color: rgba(195,45,123,0.05);
+        }
+      }
+    }
+  }
+
+  .buttons-div {
+    margin-top: 60px;
   }
 }

--- a/css/components/ui/modal.scss
+++ b/css/components/ui/modal.scss
@@ -72,11 +72,6 @@
     cursor: pointer;
     z-index: 2; /* Otherwise, it won't be reachable */
 
-    svg {
-      width: 20px;
-      height: 20px;
-    }
-
     &:hover {
       svg { fill: $color-primary; }
     }


### PR DESCRIPTION
## Overview
This PR adds two social media buttons - Facebook and Twitter - to the share widget modal. It also updates the design so that it complies with the layout used in other share modals.
Finally it changes the size of the close icon in all modals _(it was too big before this change)_

## Testing instructions
Go to Profile --> Widgets --> My Widgets/Starred Widgets and click in one of the actions Share/Embed

## [Pivotal task](https://www.pivotaltracker.com/story/show/153644665)

![image](https://user-images.githubusercontent.com/545342/34940459-eae512ea-f9ef-11e7-834b-08a523c858c5.png)
