### PR TITLE
Timelines: layer order

### DIFF
--- a/components/widgets/editor/ui/Legend.js
+++ b/components/widgets/editor/ui/Legend.js
@@ -377,14 +377,14 @@ class Legend extends React.PureComponent {
     return this.props.layerGroups.map((layerGroup) => {
       const datasetSpec = Object.assign({}, layerGroup);
       const activeLayer = datasetSpec.layers.find(l => l.active);
-
-      datasetSpec.layers = sortBy(datasetSpec.layers, (l) => l.layerConfig.dateTime);
+      const timelineLayers = datasetSpec.layers.filter(l => l.layerConfig.timeline);
 
       // Legend with timeline
-      if (datasetSpec.dataset === 'c0c71e67-0088-4d69-b375-85297f79ee75' &&
-        datasetSpec.layers.length) {
-        const firstLayer = datasetSpec.layers[0];
-        const lastLayer = datasetSpec.layers[datasetSpec.layers.length - 1];
+      if (timelineLayers.length > 0) {
+        const sortedIimelineLayers = sortBy(timelineLayers, l => l.order);
+        console.log('sortedIimelineLayers', sortedIimelineLayers);
+        const firstLayer = sortedIimelineLayers[0];
+        const lastLayer = sortedIimelineLayers[sortedIimelineLayers.length - 1];
         const minYear = moment(firstLayer.layerConfig.dateTime, 'YYYY-MM-DD').year();
         const maxYear = moment(lastLayer.layerConfig.dateTime, 'YYYY-MM-DD').year();
 

--- a/components/widgets/editor/ui/Legend.js
+++ b/components/widgets/editor/ui/Legend.js
@@ -381,8 +381,7 @@ class Legend extends React.PureComponent {
 
       // Legend with timeline
       if (timelineLayers.length > 0) {
-        const sortedIimelineLayers = sortBy(timelineLayers, l => l.order);
-        console.log('sortedIimelineLayers', sortedIimelineLayers);
+        const sortedIimelineLayers = sortBy(timelineLayers, l => l.layerConfig.order);
         const firstLayer = sortedIimelineLayers[0];
         const lastLayer = sortedIimelineLayers[sortedIimelineLayers.length - 1];
         const minYear = moment(firstLayer.layerConfig.dateTime, 'YYYY-MM-DD').year();


### PR DESCRIPTION
## Overview
This PR adds the possibility to display in Explore the timeline of any given dataset having a set of layers with the following attributes inside the `layerConfig` object:

- `timeline`: should be equals to `true` for the layers that should be part of the timeline
- `order`: number that will be used to calculate the position of the layer in the timeline

## Testing instructions
Check any of these two datasets in Explore:
- c0c71e67-0088-4d69-b375-85297f79ee75
- b8307c16-fd77-4e35-9b68-8726a025f401
or experiment with other datasets adding the _*timeline*_ capability to them following the instructions mentioned above.

## [Pivotal task](https://www.pivotaltracker.com/story/show/153613743)
