### PR TITLE
Splash coral --> a few tweaks

### DIFF
--- a/components/areas/AreaCard.js
+++ b/components/areas/AreaCard.js
@@ -308,7 +308,7 @@ class AreaCard extends React.Component {
                   <div className="status-label">
                     {!subscriptionConfirmed &&
                     <div className="pending-label">
-                      Pending
+                      Pending email confirmation
                     </div>
                     }
                   </div>

--- a/components/modal/AreaSubscriptionModal.js
+++ b/components/modal/AreaSubscriptionModal.js
@@ -155,7 +155,7 @@ class AreaSubscriptionModal extends React.Component {
     this.datasetService.getSubscribableDatasets('metadata').then((response) => {
       this.setState({
         loadingDatasets: false,
-        datasets: response.filter(val => val.attributes.subscribable)
+        datasets: response.filter(val => Object.keys(val.attributes.subscribable).length > 0)
       });
     }).catch(err => toastr.error('Error', err)); // TODO: update the UI
   }

--- a/components/modal/SubscribeToDatasetModal.js
+++ b/components/modal/SubscribeToDatasetModal.js
@@ -311,8 +311,9 @@ class SubscribeToDatasetModal extends React.Component {
       headerText = `Subscribe to ${dataset.attributes.name}`;
     }
     const paragraphText = saved ?
-      'Your subscription was successfully created. Please check your email address to confirm it.' :
-      'Please select an area and a subscription type.';
+      (<p>Your subscription was successfully created. <strong>Please check your
+         email address to confirm it.</strong></p>) :
+      <p>Please select an area and a subscription type</p>;
     const subscriptionTypes = Object.keys(dataset.attributes.subscribable)
       .map(val => ({ value: val, label: val }));
 
@@ -320,7 +321,7 @@ class SubscribeToDatasetModal extends React.Component {
       <div className="c-subscribe-to-dataset-modal" ref={(node) => { this.el = node; }}>
         <div className="header-div">
           <h2>{headerText}</h2>
-          <p>{paragraphText}</p>
+          {paragraphText}
         </div>
         {!saved &&
           <div>

--- a/components/subscriptions/SubscriptionSelector.js
+++ b/components/subscriptions/SubscriptionSelector.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Autobind } from 'es-decorators';
 
 // Components
 import Select from 'components/form/SelectInput';
@@ -18,6 +17,12 @@ class SubscriptionSelector extends React.Component {
       index: props.index,
       typeOptions: []
     };
+
+    // ----------------- BINDINGS -----------------------
+    this.handleDatasetSelected = this.handleDatasetSelected.bind(this);
+    this.handleTypeSelected = this.handleTypeSelected.bind(this);
+    this.handleThresholdChange = this.handleThresholdChange.bind(this);
+    this.handleRemove = this.handleRemove.bind(this);
   }
 
   componentWillReceiveProps(newProps) {
@@ -38,7 +43,6 @@ class SubscriptionSelector extends React.Component {
     }
   }
 
-  @Autobind
   handleDatasetSelected(value) {
     const { datasets } = this.props;
 
@@ -64,13 +68,11 @@ class SubscriptionSelector extends React.Component {
     }
   }
 
-  @Autobind
   handleTypeSelected(type) {
     this.setState({ selectedType: type },
       () => this.props.onUpdate(this.state));
   }
 
-  @Autobind
   handleThresholdChange(threshold) {
     let newThreshold = threshold;
     if (threshold <= 0) {
@@ -80,7 +82,6 @@ class SubscriptionSelector extends React.Component {
       () => this.props.onUpdate(this.state));
   }
 
-  @Autobind
   handleRemove() {
     this.props.onRemove(this.props.index);
   }

--- a/components/subscriptions/SubscriptionSelector.js
+++ b/components/subscriptions/SubscriptionSelector.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import sortBy from 'lodash/sortBy';
 
 // Components
 import Select from 'components/form/SelectInput';
@@ -91,8 +92,14 @@ class SubscriptionSelector extends React.Component {
     const { selectedDataset, selectedType, selectedThreshold, typeOptions } = this.state;
 
     const datasetOptions = (datasets.length > 0) ?
-      datasets.map(val => ({ label: val.attributes.metadata[0] && val.attributes.metadata[0].attributes.info ? val.attributes.metadata[0].attributes.info.name : val.attributes.name, value: val.id, id: val.id }))
+      datasets.map(val => ({
+        label: val.attributes.metadata[0] && val.attributes.metadata[0].attributes.info ?
+          val.attributes.metadata[0].attributes.info.name : val.attributes.name,
+        value: val.id,
+        id: val.id
+      }))
       : [];
+    const sortedDatasetOptions = sortBy(datasetOptions, d => d.label);
 
     return (
       <div className="c-subscription-selector" ref={(node) => { this.el = node; }}>
@@ -104,7 +111,7 @@ class SubscriptionSelector extends React.Component {
             default: selectedDataset,
             placeholder: 'Select a dataset'
           }}
-          options={datasetOptions}
+          options={sortedDatasetOptions}
           onChange={this.handleDatasetSelected}
         />
         <Select

--- a/css/components/app/pages/splash_detail.scss
+++ b/css/components/app/pages/splash_detail.scss
@@ -10,7 +10,7 @@
     max-width: 300px;
     max-height: 300px;
     background-color: $white;
-    z-index: 9999999;
+    z-index: 999;
 
     &.-closed {
       left: 0px;

--- a/css/components/app/pages/splash_detail.scss
+++ b/css/components/app/pages/splash_detail.scss
@@ -143,9 +143,12 @@
     width: 100%;
 
     .menu-container {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
       position: absolute;
       bottom: 50px;
-      left: 50px;
+      right: 50px;
       z-index: 9999;
 
       .scenario-box {

--- a/css/components/app/pages/splash_detail.scss
+++ b/css/components/app/pages/splash_detail.scss
@@ -81,8 +81,8 @@
     }
 
     .detail-container {
-      min-width: 500px;
-      max-width: 500px;
+      min-width: 600px;
+      max-width: 600px;
       height: 100%;
       padding-top: 10%;
       overflow: auto;

--- a/pages/app/SplashDetail.js
+++ b/pages/app/SplashDetail.js
@@ -16,6 +16,7 @@ import Header from 'components/splash/layout/Header';
 import Spinner from 'components/ui/Spinner';
 import Modal from 'components/ui/Modal';
 import Icon from 'components/ui/Icon';
+import Icons from 'components/app/layout/icons';
 
 // Utils
 import { PANORAMAS } from 'utils/splash/Panoramas';
@@ -153,6 +154,7 @@ class SplashDetail extends Page {
           title="SplashDetail page"
           description="SplashDetail page description"
         />
+        <Icons />
         <Header
           showEarthViewLink
         />
@@ -166,7 +168,10 @@ class SplashDetail extends Page {
               className={classnames('l-sidebar-toggle', 'btn-toggle', `-${introOpened ? 'opened' : ''}`)}
               onClick={this.handleToggleIntro}
             >
-              <Icon className={classnames('-little', `-${introOpened ? 'left' : 'right'}`)} name="icon-arrow-down" />
+              <Icon
+                className={classnames('-little', `-${introOpened ? 'left' : 'right'}`)}
+                name={`icon-arrow-${introOpened ? 'left' : 'right'}`}
+              />
             </button>
           </div>
         }

--- a/pages/app/SplashDetail.js
+++ b/pages/app/SplashDetail.js
@@ -231,6 +231,7 @@ class SplashDetail extends Page {
           <a-scene
             cursor="rayOrigin: mouse"
             embedded
+            vr-mode-ui="enabled: false"
           >
             {options &&
               <a-assets>

--- a/utils/splash/Panoramas.js
+++ b/utils/splash/Panoramas.js
@@ -92,7 +92,7 @@ export const PANORAMAS = [
       {
         name: 'dead',
         label: 'Dead',
-        image: 'https://s3.amazonaws.com/wri-api-backups/resourcewatch/staging/images/dead-optimized.jpg',
+        image: 'https://s3.amazonaws.com/wri-api-backups/resourcewatch/staging/images/360_AMsam-unhealthy_low.jpg',
         markup: ''
       }
     ]


### PR DESCRIPTION
## Overview
This PR a few updates for the Splash Coral page:
- Update version of the dead scenario background
- Set a bigger width for the text section in the hotspot detail menu
- Hide googles VR mode button
- Move the scenario selector to the right hand side of the screen
- Fix the z-index of the intro container

## Testing instructions
Go to the following address: http://localhost:3000/splash/coral

![screen shot 2018-01-18 at 9 48 00 am](https://user-images.githubusercontent.com/545342/35088654-b71afc30-fc34-11e7-8a99-91cb20e43fef.png)
