### PR TITLE
Widget links appear now in the cards that are part of the dashboards

### DIFF
--- a/components/dashboards/wysiwyg/widget-block/widget-block-actions.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-actions.js
@@ -67,7 +67,7 @@ export const fetchWidget = createThunkAction('WIDGET_BLOCK_FETCH_DATA', (payload
   dispatch(setWidgetLoading({ id, value: true }));
   dispatch(setWidgetError({ id, value: null }));
 
-  fetch(`${process.env.WRI_API_URL}/widget/${payload.id}?&application=${process.env.APPLICATIONS}`)
+  fetch(`${process.env.WRI_API_URL}/widget/${payload.id}?&application=${process.env.APPLICATIONS}&includes=${payload.includes}`)
     .then(response => response.json())
     .then(({ data }) => {
       const widget = { id: data.id, ...data.attributes };

--- a/components/dashboards/wysiwyg/widget-block/widget-block-component.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block-component.js
@@ -43,6 +43,9 @@ export default function WidgetBlock({
     favouriteLoading
   } = data[id];
 
+  const widgetLinks = (widget && (widget.metadata && widget.metadata.length > 0 &&
+    widget.metadata[0].attributes.info &&
+    widget.metadata[0].attributes.info.widgetLinks)) || [];
   return (
     <div className="c-dashboard-card">
       <header>
@@ -145,6 +148,24 @@ export default function WidgetBlock({
                 <p>{widget.description}</p>
               </div>
             )}
+
+            { widgetLinks.length > 0 &&
+              <div className="widget-links-container">
+                <h4>Links</h4>
+                <ul>
+                  { widgetLinks.map(link => (
+                    <li>
+                      <a
+                        href={link.link}
+                        target="_blank"
+                      >
+                        {link.name}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            }
           </div>
         }
       </div>

--- a/components/dashboards/wysiwyg/widget-block/widget-block.js
+++ b/components/dashboards/wysiwyg/widget-block/widget-block.js
@@ -70,7 +70,8 @@ class WidgetBlock extends React.Component {
 
   triggerFetch = props => props.fetchWidget({
     id: props.item.content.widgetId,
-    itemId: props.item.id
+    itemId: props.item.id,
+    includes: 'metadata'
   })
 
   render() {

--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -135,12 +135,16 @@
       }
 
       .widget-links-container {
-        
+
         ul {
           list-style-type: circle;
 
           li {
             margin-left: 35px;
+
+            a {
+              color: $link-font-color;
+            }
           }
         }
       }

--- a/css/components/dashboards/dashboard-card.scss
+++ b/css/components/dashboards/dashboard-card.scss
@@ -89,6 +89,21 @@
       h4 {
         color: $base-font-color;
       }
+
+      .widget-links-container {
+
+        ul {
+          list-style-type: circle;
+
+          li {
+            margin-left: 35px;
+
+            a {
+              color: $link-font-color;
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview
This PR adds the widget links - when present - to the flipcard of widget blocks from dashboards.

## Testing instructions
Check the widget *_Forest Restoration Opportunity by Type_* from the forest dashboard --> http://localhost:3000/data/dashboards/forest-new

## [Pivotal task](https://www.pivotaltracker.com/story/show/154603621)
