### PR TITLE
Remove layer selector from Explore embed pages

### DIFF
--- a/components/ui/Legend.js
+++ b/components/ui/Legend.js
@@ -294,8 +294,7 @@ class Legend extends React.PureComponent {
   getItemsActions(layerGroup) {
     return (
       <div className="item-actions">
-        { layerGroup.dataset !== 'c0c71e67-0088-4d69-b375-85297f79ee75'
-          && layerGroup.layers.length > 1 && (
+        { layerGroup.layers.length > 1 && (
             <button
               type="button"
               className="layers"

--- a/components/ui/Legend.js
+++ b/components/ui/Legend.js
@@ -292,20 +292,25 @@ class Legend extends React.PureComponent {
    * @returns {HTMLElement}
    */
   getItemsActions(layerGroup) {
+    const {
+      showLayersButton,
+      interactionDisabled,
+      readonly
+    } = this.props;
     return (
       <div className="item-actions">
-        { layerGroup.layers.length > 1 && (
-            <button
-              type="button"
-              className="layers"
-              onClick={e => this.onClickLayers(e, layerGroup)}
-              aria-label="Select other layer"
-              ref={(node) => { if (node) this.layersButtons.push(node); }}
-            >
-              <Icon name="icon-layers" />
-            </button>
-          ) }
-        { !this.props.interactionDisabled
+        { layerGroup.layers.length > 1 && showLayersButton && (
+          <button
+            type="button"
+            className="layers"
+            onClick={e => this.onClickLayers(e, layerGroup)}
+            aria-label="Select other layer"
+            ref={(node) => { if (node) this.layersButtons.push(node); }}
+          >
+            <Icon name="icon-layers" />
+          </button>
+        ) }
+        { !interactionDisabled
           &&
           <button
             type="button"
@@ -317,7 +322,7 @@ class Legend extends React.PureComponent {
             <Icon name="icon-opacity" />
           </button>
         }
-        { !this.props.interactionDisabled
+        { !interactionDisabled
           && <button
             type="button"
             className="toggle"
@@ -327,13 +332,13 @@ class Legend extends React.PureComponent {
             <Icon name={layerGroup.visible ? 'icon-hide' : 'icon-show'} />
           </button>
         }
-        { !this.props.interactionDisabled
+        { !interactionDisabled
           && <button type="button" className="info" onClick={() => this.onLayerInfoModal(layerGroup)} aria-label="More information">
             <Icon name="icon-info" />
           </button>
         }
-        { !this.props.readonly
-          && !this.props.interactionDisabled
+        { !readonly
+          && !interactionDisabled
           && <button type="button" className="close" onClick={() => this.onRemoveLayerGroup(layerGroup)} aria-label="Remove">
             <Icon name="icon-cross" />
           </button>
@@ -559,6 +564,8 @@ Legend.propTypes = {
   expanded: PropTypes.bool,
   // Tooltip open state
   tooltipOpened: PropTypes.bool,
+  // Show layers button or not
+  showLayersButton: PropTypes.bool,
 
   // Functions
 
@@ -586,7 +593,8 @@ Legend.propTypes = {
 Legend.defaultProps = {
   readonly: false,
   interactionDisabled: false,
-  expanded: true
+  expanded: true,
+  showLayersButton: true
 };
 
 const mapStateToProps = state => ({

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -14,6 +14,7 @@ import { logEvent } from 'utils/analytics';
 import withRedux from 'next-redux-wrapper';
 import { initStore } from 'store';
 import {
+  toggleLayerGroup,
   toggleLayerGroupVisibility,
   setLayerGroupsOrder,
   setLayerGroupActiveLayer,
@@ -508,6 +509,7 @@ const mapDispatchToProps = {
   toggleModal,
   setModalOptions,
   setDatasetsPage,
+  toggleLayerGroup,
   toggleLayerGroupVisibility,
   setLayerGroupsOrder,
   setLayerGroupActiveLayer,

--- a/pages/app/embed/EmbedLayer.js
+++ b/pages/app/embed/EmbedLayer.js
@@ -178,6 +178,7 @@ class EmbedLayer extends Page {
                 }
                 expanded={false}
                 readonly
+                showLayersButton={false}
               />
             </div>
             {/* <div className="info">


### PR DESCRIPTION
## Overview
This PR removes the layer selector in Explore layer embed pages.

## Testing instructions
Check [this link](http://localhost:3000/embed/layers/?layers=%5B%7B%22dataset%22%3A%22ad7a5641-57bc-417d-8acf-8dc9df398779%22%2C%22visible%22%3Atrue%2C%22layers%22%3A%5B%7B%22id%22%3A%22d8f78b42-cc9f-4f8c-939c-1afa57f6c7d6%22%2C%22active%22%3Atrue%7D%2C%7B%22id%22%3A%227f37560a-f4c4-4edc-a253-92226cada782%22%2C%22active%22%3Afalse%7D%2C%7B%22id%22%3A%22cf23dbd1-5944-4971-9701-3199673a8eb6%22%2C%22active%22%3Afalse%7D%2C%7B%22id%22%3A%2214087086-49d0-4260-b40c-797ebaef662e%22%2C%22active%22%3Afalse%7D%5D%7D%5D)

## [Pivotal task](https://www.pivotaltracker.com/story/show/154620263)

![image](https://user-images.githubusercontent.com/545342/35395076-a066ce78-01e9-11e8-8704-6ddd25c8d5cb.png)
