### PR TITLE
Remove widget obsolete fields

### DIFF
--- a/components/app/myrw/widgets/pages/edit.js
+++ b/components/app/myrw/widgets/pages/edit.js
@@ -107,10 +107,7 @@ class WidgetsEdit extends React.Component {
         id: widget.id,
         application: widgetAtts.application,
         name: widgetAtts.name,
-        description: widgetAtts.description,
-        authors: widgetAtts.authors,
-        source: widgetAtts.source,
-        sourceUrl: widgetAtts.sourceUrl
+        description: widgetAtts.description
       },
       { widgetConfig }
     );
@@ -221,47 +218,6 @@ class WidgetsEdit extends React.Component {
                 >
                   {Input}
                 </Field>
-                <Field
-                  ref={(c) => { if (c) FORM_ELEMENTS.elements.authors = c; }}
-                  onChange={value => this.handleChange({ authors: value })}
-                  properties={{
-                    title: 'authors',
-                    label: 'Authors',
-                    type: 'text',
-                    default: widgetAtts.authors,
-                    placeholder: 'Author name'
-                  }}
-                >
-                  {Input}
-                </Field>
-                <div className="source-container">
-                  <Field
-                    ref={(c) => { if (c) FORM_ELEMENTS.elements.source = c; }}
-                    onChange={value => this.handleChange({ source: value })}
-                    properties={{
-                      title: 'source',
-                      label: 'Source name',
-                      type: 'text',
-                      default: widgetAtts.source,
-                      placeholder: 'Source name'
-                    }}
-                  >
-                    {Input}
-                  </Field>
-                  <Field
-                    ref={(c) => { if (c) FORM_ELEMENTS.elements.sourceUrl = c; }}
-                    onChange={value => this.handleChange({ sourceUrl: value })}
-                    properties={{
-                      title: 'sourceUrl',
-                      label: 'Source URL',
-                      type: 'text',
-                      default: widgetAtts.sourceUrl,
-                      placeholder: 'Paste a URL here'
-                    }}
-                  >
-                    {Input}
-                  </Field>
-                </div>
               </fieldset>
               <div className="buttons-container">
                 <Button

--- a/components/app/myrw/widgets/pages/new.js
+++ b/components/app/myrw/widgets/pages/new.js
@@ -247,44 +247,6 @@ class WidgetsNew extends React.Component {
                 >
                   {Input}
                 </Field>
-                <Field
-                  ref={(c) => { if (c) FORM_ELEMENTS.elements.authors = c; }}
-                  onChange={value => this.handleChange({ authors: value })}
-                  properties={{
-                    title: 'authors',
-                    label: 'Authors',
-                    type: 'text',
-                    placeholder: 'Author name'
-                  }}
-                >
-                  {Input}
-                </Field>
-                <div className="source-container">
-                  <Field
-                    ref={(c) => { if (c) FORM_ELEMENTS.elements.source = c; }}
-                    onChange={value => this.handleChange({ source: value })}
-                    properties={{
-                      title: 'source',
-                      label: 'Source name',
-                      type: 'text',
-                      placeholder: 'Source name'
-                    }}
-                  >
-                    {Input}
-                  </Field>
-                  <Field
-                    ref={(c) => { if (c) FORM_ELEMENTS.elements.sourceUrl = c; }}
-                    onChange={value => this.handleChange({ sourceUrl: value })}
-                    properties={{
-                      title: 'sourceUrl',
-                      label: 'Source URL',
-                      type: 'text',
-                      placeholder: 'Paste a URL here'
-                    }}
-                  >
-                    {Input}
-                  </Field>
-                </div>
               </fieldset>
               <div className="buttons-container">
                 <Button

--- a/css/components/app/pages/myrw/myrw_widgets_edit.scss
+++ b/css/components/app/pages/myrw/myrw_widgets_edit.scss
@@ -6,6 +6,7 @@
     .buttons-container {
       display: flex;
       justify-content: flex-end;
+      margin-top: 20px;
     }
   }
 }

--- a/css/components/app/pages/myrw/myrw_widgets_new.scss
+++ b/css/components/app/pages/myrw/myrw_widgets_new.scss
@@ -10,6 +10,7 @@
     .buttons-container {
       display: flex;
       justify-content: flex-end;
+      margin-top: 20px;
     }
   }
 }


### PR DESCRIPTION
## Overview
This PR removes the fields: authors, source name, source url that are no longer used.

## Testing instructions
New or Edit widget in the profile section

## [Pivotal task](https://www.pivotaltracker.com/story/show/154620673)