### PR TITLE
Rescue EmbedDataset page and fix how bar charts are displayed in it

### DIFF
--- a/components/app/layout/head.js
+++ b/components/app/layout/head.js
@@ -15,6 +15,7 @@ const TRANSIFEX_BLACKLIST = [
   '/app/embed/EmbedText',
   '/app/embed/EmbedWidget',
   '/app/embed/EmbedEmbed',
+  '/app/embed/EmbedDataset',
   '/app/embed/EmbedSimilarDatasets'
 ];
 

--- a/css/components/app/pages/embed/embed_dataset.scss
+++ b/css/components/app/pages/embed/embed_dataset.scss
@@ -7,9 +7,53 @@
   height: 100vh;
   overflow: hidden;
 
+  // We share the vertical space between
+  // the title and the widget
+  display: flex;
+  flex-direction: column;
 
-  .c-chart {
-    min-height: 250px;
-    height: 100%;
+  border: 1px solid $border-color-1;
+  border-radius: 4px;
+
+  .widget-content {
+    position: relative;
+    display: flex; // Do not change this without testing (see comment on .c-map)
+    align-items: stretch;
+    flex-grow: 1;
+    padding: $margin-size-extra-small;
+    overflow: hidden;
+
+    &.-external {
+      .c-map { // Do not change this without testing (see comment on .c-map)
+        height: calc(100% - #{$margin-size-extra-small});
+      }
+    }
+
+    iframe {
+      width: 100%;
+    }
+
+    .c-chart {
+      height: auto; // Do not change this without testing (see comment on .c-map)
+      display: flex;
+      flex-direction: column;
+      // In case of a bar chart with scrolling, we need
+      // to use an overflow
+      overflow-x: auto;
+      max-width: 100%;
+
+      .chart {
+        height: 100%;
+
+        .vega {
+          height: 100%;
+
+          canvas {
+            display: block; // Prevent a UA margin
+            margin: 0 auto;
+          }
+        }
+      }
+    }
   }
 }

--- a/css/components/app/pages/embed/embed_dataset.scss
+++ b/css/components/app/pages/embed/embed_dataset.scss
@@ -1,0 +1,15 @@
+.c-embed-dataset {
+  position: relative; // Limit the scope of the map and spinner
+
+  // We use all the space available of the
+  // iframe and prevent any scroll
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+
+
+  .c-chart {
+    min-height: 250px;
+    height: 100%;
+  }
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -267,6 +267,7 @@
 @import "./components/app/pages/embed/embed_widget";
 @import "./components/app/pages/embed/embed_layer";
 @import "./components/app/pages/embed/embed_table";
+@import "./components/app/pages/embed/embed_dataset";
 
 // Subscriptions
 @import "./components/app/subscriptions/subscription_card";

--- a/pages/app/embed/EmbedDataset.js
+++ b/pages/app/embed/EmbedDataset.js
@@ -73,11 +73,14 @@ class EmbedDataset extends React.Component {
         />
         {widget &&
           <div>
-            <VegaChart
-              data={widget.attributes.widgetConfig}
-              theme={ChartTheme()}
-              toggleLoading={this.triggerToggleLoading}
-            />
+            <div className="widget-content">
+              <VegaChart
+                data={widget.attributes.widgetConfig}
+                theme={ChartTheme()}
+                toggleLoading={this.triggerToggleLoading}
+                reloadOnResize
+              />
+            </div>
             <div className="info">
               <div className="widget-title">
                 <h2>

--- a/pages/app/embed/EmbedDataset.js
+++ b/pages/app/embed/EmbedDataset.js
@@ -8,6 +8,8 @@ import { initStore } from 'store';
 import Spinner from 'components/ui/Spinner';
 import VegaChart from 'components/widgets/charts/VegaChart';
 import EmbedLayout from 'components/app/layout/EmbedLayout';
+import Page from 'components/app/layout/Page';
+import { setEmbed } from 'redactions/common';
 
 // Services
 import DatasetService from 'services/DatasetService';
@@ -15,7 +17,23 @@ import DatasetService from 'services/DatasetService';
 // Utils
 import ChartTheme from 'utils/widgets/theme';
 
-class EmbedDataset extends React.Component {
+class EmbedDataset extends Page {
+  static async getInitialProps(context) {
+    const props = await super.getInitialProps(context);
+    const { store, isServer, req } = context;
+
+    store.dispatch(setEmbed(true));
+
+    return {
+      ...props,
+      referer: isServer ? req.headers.referer : location.href
+    };
+  }
+
+  isLoadedExternally() {
+    return !/localhost|staging.resourcewatch.org/.test(this.props.referer);
+  }
+
   constructor(props) {
     super(props);
 

--- a/pages/app/embed/EmbedDataset.js
+++ b/pages/app/embed/EmbedDataset.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'routes';
+import withRedux from 'next-redux-wrapper';
+import { initStore } from 'store';
+
+// Layout
+import Head from 'components/app/layout/head';
+
+// Components
+import Spinner from 'components/ui/Spinner';
+import VegaChart from 'components/widgets/charts/VegaChart';
+import Tooltip from 'components/ui/Tooltip';
+
+// Services
+import DatasetService from 'services/DatasetService';
+
+// Utils
+import ChartTheme from 'utils/widgets/theme';
+
+class EmbedDataset extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      dataset: null,
+      loading: true
+    };
+
+    // DatasetService
+    this.datasetService = new DatasetService(this.props.url.query.id, {
+      apiURL: process.env.WRI_API_URL,
+      language: props.locale
+    });
+
+    // ---------------------- Bindings --------------------------
+    this.triggerToggleLoading = this.triggerToggleLoading.bind(this);
+    // ----------------------------------------------------------
+  }
+
+  componentDidMount() {
+    this.datasetService.fetchData('widget, metadata').then((data) => {
+      this.setState({
+        dataset: data,
+        loading: false
+      });
+    });
+  }
+
+  triggerToggleLoading(loading) {
+    this.setState({ loading });
+  }
+
+  render() {
+    const { dataset, loading } = this.state;
+    const widgets = dataset && dataset.attributes.widget;
+    let widget = null;
+
+    if (widgets) {
+      widget = widgets.find(value => value.attributes.default === true);
+    }
+
+    return (
+      <div className="c-embed-dataset">
+        <Head
+          title={widget && dataset.attributes.name}
+          description={widget && dataset.attributes.name}
+        />
+        <Tooltip />
+        <Spinner
+          isLoading={loading}
+          className="-light"
+        />
+        {widget &&
+          <div>
+            <VegaChart
+              data={widget.attributes.widgetConfig}
+              theme={ChartTheme()}
+              toggleLoading={this.triggerToggleLoading}
+            />
+            <div className="info">
+              <div className="widget-title">
+                <h2>
+                  <Link
+                    route="explore_detail"
+                    params={{ id: dataset.id }}
+                  >
+                    <a>{dataset.attributes.name}</a>
+                  </Link>
+                </h2>
+              </div>
+              <div className="widget-description">
+                {dataset.attributes.metadata[0].attributes.description}
+              </div>
+            </div>
+          </div>
+        }
+      </div>
+    );
+  }
+}
+
+EmbedDataset.propTypes = {
+  url: PropTypes.object.isRequired,
+  locale: PropTypes.string.isRequired
+};
+
+const mapStateToProps = state => ({
+  locale: state.common.locale
+});
+
+export default withRedux(initStore, mapStateToProps, null)(EmbedDataset);

--- a/pages/app/embed/EmbedDataset.js
+++ b/pages/app/embed/EmbedDataset.js
@@ -4,13 +4,10 @@ import { Link } from 'routes';
 import withRedux from 'next-redux-wrapper';
 import { initStore } from 'store';
 
-// Layout
-import Head from 'components/app/layout/head';
-
 // Components
 import Spinner from 'components/ui/Spinner';
 import VegaChart from 'components/widgets/charts/VegaChart';
-import Tooltip from 'components/ui/Tooltip';
+import EmbedLayout from 'components/app/layout/EmbedLayout';
 
 // Services
 import DatasetService from 'services/DatasetService';
@@ -54,6 +51,10 @@ class EmbedDataset extends React.Component {
   render() {
     const { dataset, loading } = this.state;
     const widgets = dataset && dataset.attributes.widget;
+    const meatadataObj = dataset && dataset.attributes.metadata[0];
+    const datasetName = meatadataObj && meatadataObj.attributes.info ?
+      meatadataObj.attributes.info.name : dataset && dataset.attributes.name;
+    const datasetDescription = dataset && dataset.attributes.description;
     let widget = null;
 
     if (widgets) {
@@ -61,44 +62,44 @@ class EmbedDataset extends React.Component {
     }
 
     return (
-      <div className="c-embed-dataset">
-        <Head
-          title={widget && dataset.attributes.name}
-          description={widget && dataset.attributes.name}
-        />
-        <Tooltip />
-        <Spinner
-          isLoading={loading}
-          className="-light"
-        />
-        {widget &&
-          <div>
-            <div className="widget-content">
-              <VegaChart
-                data={widget.attributes.widgetConfig}
-                theme={ChartTheme()}
-                toggleLoading={this.triggerToggleLoading}
-                reloadOnResize
-              />
-            </div>
-            <div className="info">
-              <div className="widget-title">
-                <h2>
-                  <Link
-                    route="explore_detail"
-                    params={{ id: dataset.id }}
-                  >
-                    <a>{dataset.attributes.name}</a>
-                  </Link>
-                </h2>
+      <EmbedLayout
+        title={datasetName}
+        description={datasetDescription}
+      >
+        <div className="c-embed-dataset">
+          <Spinner
+            isLoading={loading}
+            className="-light"
+          />
+          {widget &&
+            <div>
+              <div className="widget-content">
+                <VegaChart
+                  data={widget.attributes.widgetConfig}
+                  theme={ChartTheme()}
+                  toggleLoading={this.triggerToggleLoading}
+                  reloadOnResize
+                />
               </div>
-              <div className="widget-description">
-                {dataset.attributes.metadata[0].attributes.description}
+              <div className="info">
+                <div className="widget-title">
+                  <h2>
+                    <Link
+                      route="explore_detail"
+                      params={{ id: dataset.id }}
+                    >
+                      <a>{dataset.attributes.name}</a>
+                    </Link>
+                  </h2>
+                </div>
+                <div className="widget-description">
+                  {dataset.attributes.metadata[0].attributes.description}
+                </div>
               </div>
             </div>
-          </div>
-        }
-      </div>
+          }
+        </div>
+      </EmbedLayout>
     );
   }
 }

--- a/pages/app/embed/EmbedDataset.js
+++ b/pages/app/embed/EmbedDataset.js
@@ -51,11 +51,11 @@ class EmbedDataset extends React.Component {
   render() {
     const { dataset, loading } = this.state;
     const widgets = dataset && dataset.attributes.widget;
-    const meatadataObj = dataset && dataset.attributes.metadata[0];
-    const datasetName = meatadataObj && meatadataObj.attributes.info ?
-      meatadataObj.attributes.info.name : dataset && dataset.attributes.name;
-    const datasetDescription = meatadataObj && meatadataObj.attributes.info ?
-      meatadataObj.attributes.info.description : dataset && dataset.attributes.description;
+    const metadataObj = dataset && dataset.attributes.metadata[0];
+    const datasetName = metadataObj && metadataObj.attributes.info ?
+      metadataObj.attributes.info.name : dataset && dataset.attributes.name;
+    const datasetDescription = metadataObj && metadataObj.attributes ?
+      metadataObj.attributes.description : dataset && dataset.attributes.description;
     let widget = null;
 
     if (widgets) {

--- a/pages/app/embed/EmbedDataset.js
+++ b/pages/app/embed/EmbedDataset.js
@@ -54,7 +54,8 @@ class EmbedDataset extends React.Component {
     const meatadataObj = dataset && dataset.attributes.metadata[0];
     const datasetName = meatadataObj && meatadataObj.attributes.info ?
       meatadataObj.attributes.info.name : dataset && dataset.attributes.name;
-    const datasetDescription = dataset && dataset.attributes.description;
+    const datasetDescription = meatadataObj && meatadataObj.attributes.info ?
+      meatadataObj.attributes.info.description : dataset && dataset.attributes.description;
     let widget = null;
 
     if (widgets) {
@@ -88,12 +89,12 @@ class EmbedDataset extends React.Component {
                       route="explore_detail"
                       params={{ id: dataset.id }}
                     >
-                      <a>{dataset.attributes.name}</a>
+                      <a>{datasetName}</a>
                     </Link>
                   </h2>
                 </div>
                 <div className="widget-description">
-                  {dataset.attributes.metadata[0].attributes.description}
+                  {datasetDescription}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Overview
This PR rescues the `EmbedDataset` page and also makes sure that the bar widgets are properly shown.

## Testing instructions
Check the following url: https://staging.resourcewatch.org/embed/dataset/5e87d53c-10d9-419e-a0e6-122e26b064ca

## [Pivotal task](https://www.pivotaltracker.com/story/show/154757382)

![image](https://user-images.githubusercontent.com/545342/35569916-e2f90e58-05cd-11e8-9a37-9b19d84f54dc.png)