### PR TITLE
Foundation settings working

### DIFF
--- a/components/app/explore/DatasetList.js
+++ b/components/app/explore/DatasetList.js
@@ -26,7 +26,7 @@ class DatasetList extends PureComponent {
       [`-${mode}`]: true,
       'small-12': true,
       'medium-6': mode === 'grid',
-      'large-4': mode === 'grid'
+      'xxlarge-4': mode === 'grid'
     });
 
     return (

--- a/components/app/explore/DatasetList.js
+++ b/components/app/explore/DatasetList.js
@@ -11,6 +11,7 @@ class DatasetList extends PureComponent {
   static propTypes = {
     list: PropTypes.array,
     user: PropTypes.object,
+    routes: PropTypes.object,
     mode: PropTypes.string,
     showActions: PropTypes.bool.isRequired,
     showFavorite: PropTypes.bool.isRequired,
@@ -18,7 +19,7 @@ class DatasetList extends PureComponent {
   };
 
   render() {
-    const { list, mode, showActions, showFavorite, user, onTagSelected } = this.props;
+    const { list, mode, showActions, showFavorite, user, routes, onTagSelected } = this.props;
 
     const newClassName = classNames({
       column: true,
@@ -26,7 +27,7 @@ class DatasetList extends PureComponent {
       [`-${mode}`]: true,
       'small-12': true,
       'medium-6': mode === 'grid',
-      'xxlarge-4': mode === 'grid'
+      [routes.pathname === '/app/Explore' ? 'xxlarge-4' : 'large-4']: mode === 'grid'
     });
 
     return (
@@ -54,6 +55,7 @@ class DatasetList extends PureComponent {
 
 export default connect(
   state => ({
-    user: state.user
+    user: state.user,
+    routes: state.routes
   })
 )(DatasetList);

--- a/css/_base.scss
+++ b/css/_base.scss
@@ -89,7 +89,7 @@ h1 {
   font-size: $font-size-h1 / 2;
   font-weight: 300;
   line-height: 1;
-  color: $base-font-color;
+  color: $body-font-color;
 }
 
 h2 {
@@ -101,7 +101,7 @@ h2 {
 }
 
 h3 {
-  font-size: $base-font-size;
+  font-size: $body-font-size;
   font-weight: bold;
   line-height: 1.35;
   margin-bottom: $font-size-h3 * 0.5;
@@ -110,12 +110,12 @@ h3 {
 h4 {
   font-size: $font-size-h4;
   font-weight: bold;
-  color: $base-font-color;
+  color: $body-font-color;
   margin-bottom: 1rem;
   line-height: 1.3;
 
   & > a {
-    color: $base-font-color;
+    color: $body-font-color;
   }
 }
 

--- a/css/_foundation_settings.scss
+++ b/css/_foundation_settings.scss
@@ -11,10 +11,10 @@ $breakpoints: (
   medium: 720px,
   large: 960px,
   xlarge: 1260px,
-  xxlarge: 1440px,
+  xxlarge: 1560px,
 );
 $print-breakpoint: large;
-$breakpoint-classes: (small medium large);
+$breakpoint-classes: (small medium large xlarge xxlarge);
 
 // 3. The Grid
 // -----------

--- a/css/_settings.scss
+++ b/css/_settings.scss
@@ -29,14 +29,14 @@ $sea-blue: #2C75B0;
 $blue-grey: #9AA2A9;
 
 // Theme
-$base-font-color: $charcoal-grey;
+$body-font-color: $charcoal-grey;
 $header-font-color: $color-primary;
 $link-font-color: $sea-blue;
 $active-font-color: $yellow;
 $ui-font-color: $dove-grey;
 $alt-font-color: $white;
 $ui-bg-color: $porcelain;
-$base-bg-color: $white;
+$body-bg-color: $white;
 
 $border-color-1: rgba(26, 28, 34, 0.1);
 $border-color-2: rgba(202, 204,208, 0.85);; // For inputs
@@ -53,13 +53,17 @@ $font-size-small: 13px;
 $font-size-normal: 14px;
 $font-size-medium: 16px;
 $font-size-big: 21px;
+$body-font-size: 14px;
+
 
 $font-size-h1: 64px;
 $font-size-h2: 42px;
 $font-size-h3: 26px;
 $font-size-h4: 16px;
 
-$body-font-color: $base-font-color;
+$body-background: $body-bg-color;
+$body-font-size: $body-font-color;
+$body-font-color: $body-font-color;
 $body-font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans;
 $global-weight-normal: normal;
 $global-lineheight: 1.625;

--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -131,7 +131,7 @@
       }
 
       h4 {
-        color: $base-font-color;
+        color: $body-font-color;
       }
 
       .widget-links-container {

--- a/css/components/dashboards/dashboard-card.scss
+++ b/css/components/dashboards/dashboard-card.scss
@@ -87,7 +87,7 @@
       }
 
       h4 {
-        color: $base-font-color;
+        color: $body-font-color;
       }
 
       .widget-links-container {

--- a/css/components/form/field.scss
+++ b/css/components/form/field.scss
@@ -8,7 +8,7 @@
     margin-bottom: 5px;
 
     font-size: $font-size-small;
-    color: $base-font-color;
+    color: $body-font-color;
     font-weight: 700;
     line-height: 1.8; // Prevent style issues with inline loaders
 
@@ -52,7 +52,7 @@
 
     font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans;
     font-size: $font-size-normal;
-    color: $base-font-color;
+    color: $body-font-color;
 
     border-radius: 4px;
     border: 1px solid $border-color-2;
@@ -71,7 +71,7 @@
   > textarea::placeholder,
   > select::placeholder,
   .input::placeholder {
-    color: rgba($base-font-color, .3);
+    color: rgba($body-font-color, .3);
   }
 
 

--- a/css/components/form/toggle-search.scss
+++ b/css/components/form/toggle-search.scss
@@ -15,7 +15,7 @@
 
     font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans;
     font-size: $font-size-normal;
-    color: $base-font-color;
+    color: $body-font-color;
 
     background: none;
 
@@ -35,6 +35,6 @@
     top: 50%;
     right: 5px;
     transform: translateY(-50%);
-    fill: $base-font-color;
+    fill: $body-font-color;
   }
 }

--- a/css/components/ui/button.scss
+++ b/css/components/ui/button.scss
@@ -53,7 +53,7 @@ $btn-hover-shadow: 0 20px 30px 0 rgba(0, 0, 0, 0.2);
     }
 
     &.-alt {
-      background-color: $base-bg-color;
+      background-color: $body-bg-color;
       color: $color-primary;
 
       &:hover{
@@ -64,7 +64,7 @@ $btn-hover-shadow: 0 20px 30px 0 rgba(0, 0, 0, 0.2);
 
   &.-b, &.-secondary {
     color: $color-primary;
-    background-color: $base-bg-color;
+    background-color: $body-bg-color;
     border-color: $btn-border-color;
     &:hover {
       background-color: $btn-bg-hover-color;
@@ -97,7 +97,7 @@ $btn-hover-shadow: 0 20px 30px 0 rgba(0, 0, 0, 0.2);
       color: $alt-font-color;
 
       &:hover{
-        background-color: rgba($base-bg-color, 0.1);
+        background-color: rgba($body-bg-color, 0.1);
       }
     }
   }

--- a/css/components/ui/custom_select.scss
+++ b/css/components/ui/custom_select.scss
@@ -197,7 +197,7 @@
 
   .custom-select-search {
     background-color: transparent;
-    color: $base-font-color;
+    color: $body-font-color;
     outline: none;
     border: none;
     position: absolute;
@@ -206,7 +206,7 @@
     width: 100%;
     height: 100%;
     padding: 10px $margin-size-extra-small;
-    font-family: $base-font-family;
+    font-family: $body-font-family;
     // Make sure that if you have a z-index here, you don't
     // cause issues with dropdowns being the one below another
     // (unable to select an option of the first dropdown because

--- a/css/components/ui/tree_selector.scss
+++ b/css/components/ui/tree_selector.scss
@@ -234,7 +234,7 @@
       > input[type="text"] {
         font-family: $body-font-family;
         font-size: $font-size-medium;
-        color: $base-font-color;
+        color: $body-font-color;
         cursor: pointer;
       }
 

--- a/css/components/widgets/filter_tooltip.scss
+++ b/css/components/widgets/filter_tooltip.scss
@@ -39,10 +39,10 @@
 
       // These are the values of the current range
       .input-range__label {
-        font-family: $base-font-family;
+        font-family: $body-font-family;
         font-size: $font-size-small;
         font-weight: $font-weight-bold;
-        color: $base-font-color;
+        color: $body-font-color;
       }
 
       .input-range__track,

--- a/css/components/widgets/widget_editor.scss
+++ b/css/components/widgets/widget_editor.scss
@@ -16,7 +16,7 @@
     padding: $margin-size-small;
     border: 1px solid $border-color-1;
     box-shadow: 0 1px 2px 0 rgba($color-black, .09);
-    background-color: $base-bg-color;
+    background-color: $body-bg-color;
 
     > .title {
       color: $color-dark-pink;

--- a/css/index.scss
+++ b/css/index.scss
@@ -1,16 +1,9 @@
 // Reset
 // Project settings (it doesn't include Grid system)
 @import "settings";
+@import 'foundation_settings';
 
 @import "../node_modules/normalize.css/normalize";
-
-// Foundation:
-// We are using this library only for grid system
-@import '../node_modules/foundation-sites/scss/foundation';
-@import 'foundation_settings';
-@include foundation-flex-classes;
-@include foundation-flex-grid;
-@include foundation-responsive-embed;
 
 // Libraries
 @import '../node_modules/leaflet/dist/leaflet';
@@ -277,3 +270,10 @@
 // RC-TOOLTIP
 @import '../node_modules/rc-tooltip/assets/bootstrap_white.css';
 @import "./components/ui/rc-tooltip";
+
+// Foundation:
+// We are using this library only for grid system
+@import '../node_modules/foundation-sites/scss/foundation';
+@include foundation-flex-classes;
+@include foundation-flex-grid;
+@include foundation-responsive-embed;

--- a/css/layouts/_footer.scss
+++ b/css/layouts/_footer.scss
@@ -25,7 +25,7 @@
       text-transform: uppercase;
 
       transform: translate(-50%, -10px);
-      background-color: $base-bg-color;
+      background-color: $body-bg-color;
 
       a {
         position: relative;

--- a/css/layouts/_page.scss
+++ b/css/layouts/_page.scss
@@ -10,7 +10,7 @@
  */
 
 .l-page {
-  background-color: $base-bg-color;
+  background-color: $body-bg-color;
 
   .c-page-header,
   .l-page-header {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12248,9 +12248,9 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
-widget-editor@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-0.1.0.tgz#19ae56137fb05e07bc13010f11a6daa6d4afb09e"
+widget-editor@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-0.1.1.tgz#c6f3c2ec8450b2536a33f71bf0eaa6128fd82f0b"
   dependencies:
     autobind-decorator "^2.1.0"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
## Overview
It seems that we are using other libraries that, at the same time, they are using foundation grid (wysiwyg for sure).

What I did is to put the foundation grid at the bottom of the index page to be sure that we are going to override other styles related. The best solution should be to:
1. Namespace for grid used in wysiwyg
2. Avoid using foundation in wysiwyg

## Testing instructions
Go to /data/explore page to see that the grid is working now
Go to /data/explore/:id page to see the grid working as before

## Pivotal task
https://www.pivotaltracker.com/story/show/154762200