### PR TITLE
Explore detail: Add partner logos

### DIFF
--- a/css/components/app/pages/explore_detail.scss
+++ b/css/components/app/pages/explore_detail.scss
@@ -139,4 +139,16 @@
     }
   }
 
+  .partner-container {
+
+    .partner-text-container {
+      margin-bottom: 15px;
+    }
+
+    .partner-logo-container {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  }
 }

--- a/css/components/app/pages/explore_detail.scss
+++ b/css/components/app/pages/explore_detail.scss
@@ -142,6 +142,7 @@
   .partner-container {
 
     .partner-text-container {
+      margin-top: 15px;
       margin-bottom: 15px;
     }
 

--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -545,7 +545,9 @@ class ExploreDetail extends Page {
                         Partner:
                       </div>
                       <div className="partner-logo-container">
-                        <img src={partnerDetail.logo && partnerDetail.logo.medium} alt={partnerDetail.name} />
+                        <a href={partnerDetail.website} target="_blank" rel="noopener noreferrer">
+                          <img src={partnerDetail.logo && partnerDetail.logo.medium} alt={partnerDetail.name} />
+                        </a>
                       </div>
                     </div>
                   }

--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -15,6 +15,7 @@ import { toggleModal, setModalOptions } from 'redactions/modal';
 import updateLayersShown from 'selectors/explore/layersShownExploreDetail';
 import { setUser, getUserFavourites, getUserCollections } from 'redactions/user';
 import { setRouter } from 'redactions/routes';
+import { getPartnerData } from 'redactions/partnerDetail';
 
 // Next
 import { Link, Router } from 'routes';
@@ -43,6 +44,7 @@ import SimilarDatasets from 'components/app/explore/similar-datasets/similar-dat
 // Utils
 import { TAGS_BLACKLIST } from 'utils/graph/TagsUtil';
 import { logEvent } from 'utils/analytics';
+import { PARTNERS_CONNECTIONS } from 'utils/partners/partnersConnections';
 
 // helpers
 import { belongsToACollection } from 'components/collections-panel/collections-panel-helpers';
@@ -165,6 +167,12 @@ class ExploreDetail extends Page {
         const tags = vocabulary && vocabulary.length > 0 && vocabulary[0].attributes.tags;
         if (tags) {
           this.loadInferredTags(tags);
+        }
+
+        // Load connected partner
+        const partnerConnection = PARTNERS_CONNECTIONS.find(pc => pc.datasetId === response.id);
+        if (partnerConnection) {
+          this.props.getPartnerData(partnerConnection.partnerId);
         }
       }).catch((error) => {
         toastr.error('Error', 'Unable to load the dataset');
@@ -349,7 +357,7 @@ class ExploreDetail extends Page {
   }
 
   render() {
-    const { url, user, exploreDataset } = this.props;
+    const { url, user, exploreDataset, partnerDetail } = this.props;
     const { dataset, loading, inferredTags } = this.state;
     const metadataObj = dataset && dataset.attributes.metadata;
     const metadata = metadataObj && metadataObj.length > 0 && metadataObj[0];
@@ -378,6 +386,8 @@ class ExploreDetail extends Page {
       '-filled': isInACollection,
       '-empty': !isInACollection
     });
+
+    //const partnerConnectionFound = dataset &&
 
     const isSubscribable = dataset && dataset.attributes && dataset.attributes.subscribable &&
       Object.keys(dataset.attributes.subscribable).length > 0;
@@ -529,6 +539,16 @@ class ExploreDetail extends Page {
                       </button>
                     }
                   </div>
+                  { partnerDetail.logo &&
+                    <div className="partner-container">
+                      <div className="partner-text-container">
+                        Partner:
+                      </div>
+                      <div className="partner-logo-container">
+                        <img src={partnerDetail.logo && partnerDetail.logo.medium} alt={partnerDetail.name} />
+                      </div>
+                    </div>
+                  }
                 </div>
               </div>
             </div>
@@ -767,6 +787,7 @@ const mapStateToProps = state => ({
   user: state.user,
   exploreDetail: state.exploreDetail,
   exploreDataset: state.exploreDataset,
+  partnerDetail: state.partnerDetail.data,
   layersShown: updateLayersShown(state),
   locale: state.common.locale
 });
@@ -775,7 +796,8 @@ const mapDispatchToProps = {
   resetDataset,
   toggleModal,
   setModalOptions,
-  toggleLayerGroup
+  toggleLayerGroup,
+  getPartnerData
 };
 
 export default withRedux(initStore, mapStateToProps, mapDispatchToProps)(ExploreDetail);

--- a/pages/app/ExploreDetail.js
+++ b/pages/app/ExploreDetail.js
@@ -387,8 +387,6 @@ class ExploreDetail extends Page {
       '-empty': !isInACollection
     });
 
-    //const partnerConnectionFound = dataset &&
-
     const isSubscribable = dataset && dataset.attributes && dataset.attributes.subscribable &&
       Object.keys(dataset.attributes.subscribable).length > 0;
 

--- a/utils/partners/partnersConnections.js
+++ b/utils/partners/partnersConnections.js
@@ -1,0 +1,194 @@
+export const PARTNERS_CONNECTIONS = [
+  {
+    datasetId: '3624554e-b240-4edb-9110-1f010642c3f3',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '894f43a8-ce8e-43a5-a4c7-fa80faa43d63',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '96ce9416-7a34-4c67-a21f-4f9b914d0d45',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '1ef55baf-bbbe-480d-85e9-7132c742f196',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '3d2ce960-abda-4c9c-bd29-1929e9ca24c9',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '3a46f6b4-0eec-49d4-bbfc-e2e8f64e6117',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '6e05a9e8-ba07-4e6f-8337-31c5362d07fe',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '83de627f-524b-4162-a10c-384dc3e8107a',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '71b81fe0-23fc-4154-8601-ba987381594c',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: 'fc8cf356-f4be-4635-a896-fb468aaaa832',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '0b9f0100-ce5b-430f-ad8f-3363efa05481',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '134caa0a-21f7-451d-a7fe-30db31a424aa',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: 'd7c3d954-ac86-4d1a-bb6a-c8c432a94e26',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '9948b8b8-2aaa-4146-be1e-91da5a1aaa88',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: 'c53a195f-d5f0-4acc-b1be-b773420a6606',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: 'e6e83d98-aa1f-495f-916c-b33d0657e0fe',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: 'ed521429-58b4-4c55-9bbe-4f4bfd2fcb1f',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '86fff033-dd27-41be-be64-2ec8983b3db1',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '7bcf2f48-8ebd-4900-a485-57a75f9f4e85',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: 'c2142922-84d9-4564-8216-a4867b9e48c5',
+    partnerId: 'wri'
+  },
+  {
+    datasetId: '0087944f-871c-44bc-b4d9-cd5acfc27023',
+    partnerId: 'google'
+  },
+  {
+    datasetId: 'e2869a81-6b83-49b2-a50d-428c54b72593',
+    partnerId: 'google'
+  },
+  {
+    datasetId: '0448c79d-0ee0-42ff-9331-aeee70cef301',
+    partnerId: 'google'
+  },
+  {
+    datasetId: '60be01b0-99fb-459c-8a08-b934270f8c4b',
+    partnerId: 'google'
+  },
+  {
+    datasetId: 'b8307c16-fd77-4e35-9b68-8726a025f401',
+    partnerId: 'google'
+  },
+  {
+    datasetId: '0087944f-871c-44bc-b4d9-cd5acfc27023',
+    partnerId: 'umd'
+  },
+  {
+    datasetId: 'e663eb09-04de-4f39-b871-35c6c2ed10b5',
+    partnerId: 'umd'
+  },
+  {
+    datasetId: '71b81fe0-23fc-4154-8601-ba987381594c',
+    partnerId: 'umd'
+  },
+  {
+    datasetId: 'e2869a81-6b83-49b2-a50d-428c54b72593',
+    partnerId: 'umd'
+  },
+  {
+    datasetId: '0448c79d-0ee0-42ff-9331-aeee70cef301',
+    partnerId: 'umd'
+  },
+  {
+    datasetId: 'fc8cf356-f4be-4635-a896-fb468aaaa832',
+    partnerId: 'umd'
+  },
+  {
+    datasetId: 'd4ca3cc4-c162-469c-b341-b52284a73eaa',
+    partnerId: 'undp'
+  },
+  {
+    datasetId: 'bea122ce-1e4b-465d-8b7b-fa11aadd20f7',
+    partnerId: 'undp'
+  },
+  {
+    datasetId: 'a89c95c7-0b82-4162-b9d8-cc0205e9f7ec',
+    partnerId: 'undp'
+  },
+  {
+    datasetId: '11278cb6-b298-49a1-bf71-f1e269f40758',
+    partnerId: 'undp'
+  },
+  {
+    datasetId: '4d7ce999-1e37-418f-b8a6-1816b29e901a',
+    partnerId: 'undp'
+  },
+  {
+    datasetId: '3624554e-b240-4edb-9110-1f010642c3f3',
+    partnerId: 'unep'
+  },
+  {
+    datasetId: 'de452a4c-a55c-464d-9037-8c3e9fe48365',
+    partnerId: 'unep'
+  },
+  {
+    datasetId: '0e565ddf-74fd-4f90-a6b8-c89d747a89ab',
+    partnerId: 'unep'
+  },
+  {
+    datasetId: '6b8442f5-4766-4444-94b4-d6676277fd80',
+    partnerId: 'unep'
+  },
+  {
+    datasetId: '96ce9416-7a34-4c67-a21f-4f9b914d0d45',
+    partnerId: 'unep'
+  },
+  {
+    datasetId: '90cace56-fad5-4f36-816f-605c9f5b48a2',
+    partnerId: 'unep'
+  },
+  {
+    datasetId: '995ec4fe-b3cc-4cf4-bd48-b89d4e3ea072',
+    partnerId: 'unep'
+  },
+  {
+    datasetId: 'c61c364b-1d68-4dd9-ae3d-76c2a0022280',
+    partnerId: 'unep'
+  },
+  {
+    datasetId: '37d5db2e-8ab8-4870-bfcc-534cdd5bdb76',
+    partnerId: 'unep'
+  },
+  {
+    datasetId: '8ab2606d-1b1c-4b71-ab29-c6e0a687e9fd',
+    partnerId: 'unep'
+  },
+  {
+    datasetId: 'cefd2836-3cc1-43dc-a9d1-bfecf79a6252',
+    partnerId: 'vaisala'
+  },
+  {
+    datasetId: '9ea634db-53af-445e-a767-60ec9efc321e',
+    partnerId: 'vaisala'
+  }
+];


### PR DESCRIPTION
## Overview
This PR adds a JSON file where the connections among partners and datasets are stored. It also shows the logo of the partner in the Explore detail page when it corresponds.

## Testing instructions
Check this dataset e.g. --> `c61c364b-1d68-4dd9-ae3d-76c2a0022280`

## [Pivotal task](https://www.pivotaltracker.com/story/show/154807859)

![image](https://user-images.githubusercontent.com/545342/35634383-e2684ed4-06ab-11e8-8996-b63a1b14390a.png)
