### PR TITLE
Fixes URL generation in my widget embed

### DIFF
--- a/components/modal/EmbedMyWidgetModal.js
+++ b/components/modal/EmbedMyWidgetModal.js
@@ -76,7 +76,7 @@ class EmbedMyWidgetModal extends React.Component {
                   <Icon name="icon-facebook" className="-medium" />
                 </a>
                 <a
-                  href={`https://twitter.com/share?url=${url}&text=${encodeURIComponent(widget.attributes.name)}`}
+                  href={`https://twitter.com/share?url=${url}&text=${encodeURIComponent(widget.name)}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={() => logEvent('Share', `Share a specific widget: ${this.props.widget.id}`, 'Twitter')}


### PR DESCRIPTION
## Overview
Fixes URL generation in my widget embed. The issue was the way to access the attributes of the widget as we changed the parse previously.

## Testing instructions
MyRW > widgets > select a widget and click on `share/embed`

## Pivotal task
https://www.pivotaltracker.com/story/show/154918499

---

## Checklist before submitting
[ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
[ ] Meaningful commits and code rebased on `develop`.
