### PR TITLE
Update edit and delete authorisations for widgets and datasets

### DIFF
--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
@@ -97,15 +97,18 @@ class DatasetsListCard extends PureComponent {
             }
           </div>
 
-          <div className="actions">
-            <a
-              role="button"
-              tabIndex={0}
-              onClick={this.handleDelete}
-            >
-              Delete
-            </a>
-          </div>
+          { (dataset.userId === user.id) &&
+            <div className="actions">
+              <a
+                role="button"
+                className="c-button -tertiary -compressed"
+                tabIndex={0}
+                onClick={this.handleDelete}
+              >
+                Delete
+              </a>
+            </div>
+          }
         </div>
       </div>
     );

--- a/components/widgets/list/WidgetActionsTooltip.js
+++ b/components/widgets/list/WidgetActionsTooltip.js
@@ -52,11 +52,13 @@ class WidgetActionsTooltip extends React.Component {
     return (
       <div className="c-widget-actions-tooltip">
         <ul>
-          <li>
-            <button onClick={() => this.handleClick('edit_widget')}>
-              Edit widget
-            </button>
-          </li>
+          { this.props.isWidgetOwner &&
+            <li>
+              <button onClick={() => this.handleClick('edit_widget')}>
+                Edit widget
+              </button>
+            </li>
+          }
           <li>
             <button onClick={() => this.handleClick('share_embed')}>
               Share/Embed
@@ -91,6 +93,7 @@ class WidgetActionsTooltip extends React.Component {
 }
 
 WidgetActionsTooltip.propTypes = {
+  isWidgetOwner: PropTypes.bool,
   widgetLinks: PropTypes.array,
   toggleTooltip: PropTypes.func.isRequired,
   // Callbacks

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -71,7 +71,7 @@ class WidgetCard extends PureComponent {
    * @returns {boolean}
    */
   static isMapWidget(widget) {
-    return !!(widget
+    return !!(widget && widget.widgetConfig
       // Some widgets have not been created with the widget editor
       // so the paramsConfig attribute doesn't exist
       && (
@@ -95,7 +95,7 @@ class WidgetCard extends PureComponent {
    * @returns {boolean}
    */
   static isEmbedWidget(widget) {
-    return !!(widget
+    return !!(widget && widget.widgetConfig
       // Some widgets have not been created with the widget editor
       // so the paramsConfig attribute doesn't exist
       && (
@@ -119,7 +119,7 @@ class WidgetCard extends PureComponent {
    * @returns {boolean}
    */
   static isTextualWidget(widget) {
-    return !!(widget
+    return !!(widget && widget.widgetConfig
       // The widgets that are created through the widget editor
       // don't have any "type" attribute
       && widget.widgetConfig.type
@@ -151,7 +151,6 @@ class WidgetCard extends PureComponent {
     this.handleEditWidget = this.handleEditWidget.bind(this);
     this.handleGoToDataset = this.handleGoToDataset.bind(this);
     this.handleDownloadPDF = this.handleDownloadPDF.bind(this);
-    this.handleWidgetActionsClick = this.handleWidgetActionsClick.bind(this);
     // ----------------------------------------------------------
   }
 
@@ -373,7 +372,7 @@ class WidgetCard extends PureComponent {
     link.dispatchEvent(event);
   }
 
-  handleWidgetActionsClick(event) {
+  handleWidgetActionsClick(event, isWidgetOwner) {
     const { widget } = this.props;
     const widgetAtts = widget;
     const widgetLinks = (widgetAtts.metadata && widgetAtts.metadata.length > 0 &&
@@ -391,7 +390,8 @@ class WidgetCard extends PureComponent {
         onGoToDataset: this.handleGoToDataset,
         onEditWidget: this.handleEditWidget,
         onDownloadPDF: this.handleDownloadPDF,
-        widgetLinks
+        widgetLinks,
+        isWidgetOwner
       }
     });
   }
@@ -468,12 +468,12 @@ class WidgetCard extends PureComponent {
               {showActions &&
                 <button
                   className="c-button -secondary widget-actions"
-                  onClick={this.handleWidgetActionsClick}
+                  onClick={e => this.handleWidgetActionsClick(e, (widget.userId === user.id))}
                 >
                   Widget actions
                 </button>
               }
-              {showRemove &&
+              {showRemove && (widget.userId === user.id) &&
                 <button
                   className="c-button -tertiary"
                   onClick={this.handleRemoveWidget}


### PR DESCRIPTION
## Overview
Allows users to only show *edit* or *remove* buttons for widgets and datasets when they are the creator of those resources.

## Testing instructions

**Create widget and datasets (options available):**
![image](https://user-images.githubusercontent.com/8505382/35918701-0beaaf1a-0c13-11e8-904d-29c1fcc5f8f5.png)

**Favourite the widgets and datasets of other users (options unavailable):**
![image](https://user-images.githubusercontent.com/8505382/35918769-3ef6ed92-0c13-11e8-97d6-8ab3af00b336.png)


## Pivotal task

[Parallel Prep app task](https://www.pivotaltracker.com/n/projects/1598595/stories/154366562)

