### PR TITLE
Explore: add new options for the labels and boundaries layers

### DIFF
--- a/components/ui/map/Map.js
+++ b/components/ui/map/Map.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 
-import { LABELS } from 'components/ui/map/constants';
+import { LABELS, BOUNDARIES } from 'components/ui/map/constants';
 
 // Components
 import Spinner from 'components/ui/Spinner';
@@ -70,6 +70,7 @@ class Map extends React.Component {
     this.setMapEventListeners();
 
     this.setLabels(this.props.labels);
+    this.setBoundaries(this.props.boundaries);
 
     // Add layers
     this.setLayerManager();
@@ -138,6 +139,9 @@ class Map extends React.Component {
     if (this.props.labels !== nextProps.labels) {
       this.setLabels(nextProps.labels);
     }
+    if (this.props.boundaries !== nextProps.boundaries) {
+      this.setBoundaries(nextProps.boundaries);
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -199,6 +203,22 @@ class Map extends React.Component {
       const labels = LABELS[labelsId];
 
       this.labelLayer = L.tileLayer(labels.value, labels.options || {})
+        .addTo(this.map)
+        .setZIndex(this.props.layerGroups.length + 2);
+    }
+  }
+
+  /**
+   * Set the boundaries layer
+   * @param {boolean} visible Whether the boundaries are visible or not
+   */
+  setBoundaries(visible) {
+    if (!visible && this.boundariesLayer) {
+      this.boundariesLayer.remove();
+      this.boundariesLayer = undefined;
+    } else if (visible && !this.boundariesLayer) {
+      const boundaries = BOUNDARIES.dark;
+      this.boundariesLayer = L.tileLayer(boundaries.value, boundaries.options || {})
         .addTo(this.map)
         .setZIndex(this.props.layerGroups.length + 1);
     }
@@ -299,6 +319,7 @@ Map.propTypes = {
   // STORE
   basemap: PropTypes.object,
   labels: PropTypes.string,
+  boundaries: PropTypes.bool,
   mapConfig: PropTypes.object,
   filters: PropTypes.object,
   sidebar: PropTypes.object,
@@ -311,6 +332,7 @@ Map.propTypes = {
 const mapStateToProps = state => ({
   basemap: state.explore.basemap,
   labels: state.explore.labels,
+  boundaries: state.explore.boundaries,
   sidebar: state.explore.sidebar
 });
 

--- a/components/ui/map/Map.js
+++ b/components/ui/map/Map.js
@@ -2,14 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 
+import { LABELS } from 'components/ui/map/constants';
+
 // Components
 import Spinner from 'components/ui/Spinner';
 
 // Redux
 import { connect } from 'react-redux';
-
-import { LABELS } from 'components/ui/map/constants';
-
 
 // Leaflet can't be imported on the server because it's not isomorphic
 const L = (typeof window !== 'undefined') ? require('leaflet') : null;
@@ -189,11 +188,17 @@ class Map extends React.Component {
       .setZIndex(0);
   }
 
-  setLabels(enabled) {
-    if (this.labelLayer && !enabled) this.labelLayer.remove();
+  /**
+   * Set the labels layer
+   * @param {string} labelsId
+   */
+  setLabels(labelsId) {
+    if (this.labelLayer) this.labelLayer.remove();
 
-    if (enabled) {
-      this.labelLayer = L.tileLayer(LABELS.value, LABELS.options || {})
+    if (labelsId !== 'none') {
+      const labels = LABELS[labelsId];
+
+      this.labelLayer = L.tileLayer(labels.value, labels.options || {})
         .addTo(this.map)
         .setZIndex(this.props.layerGroups.length + 1);
     }
@@ -293,7 +298,7 @@ Map.propTypes = {
   setMapInstance: PropTypes.func,
   // STORE
   basemap: PropTypes.object,
-  labels: PropTypes.bool,
+  labels: PropTypes.string,
   mapConfig: PropTypes.object,
   filters: PropTypes.object,
   sidebar: PropTypes.object,

--- a/components/ui/map/constants.js
+++ b/components/ui/map/constants.js
@@ -34,9 +34,21 @@ const BASEMAPS = {
 };
 
 const LABELS = {
-  id: 'labels',
-  label: 'Labels',
-  value: 'https://api.mapbox.com/styles/v1/jcawri/cj8lr4oo566da2rqrmuu9btmz/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoiamNhd3JpIiwiYSI6ImNqMDd6N2NybzAwMHcyd29iZWlsems0enEifQ.eIqQeyQn5oCLkyivGtiVLg'
+  none: {
+    id: 'none',
+    label: 'No labels',
+    value: 'no_labels'
+  },
+  light: {
+    id: 'light',
+    label: 'Labels light',
+    value: 'https://api.mapbox.com/styles/v1/prepdata/cjc6dank251222rnm74g4qmin/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoicHJlcGRhdGEiLCJhIjoiY2piZmNrcTRjMXRsdzJxbm9uNm1nOXJtNSJ9.Jm14P-FBGvNxiaB-3mzSPw'
+  },
+  dark: {
+    id: 'dark',
+    label: 'Labels dark',
+    value: 'https://api.mapbox.com/styles/v1/prepdata/cjc6c1e9o4wa42slf54h8ccix/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoicHJlcGRhdGEiLCJhIjoiY2piZmNrcTRjMXRsdzJxbm9uNm1nOXJtNSJ9.Jm14P-FBGvNxiaB-3mzSPw'
+  }
 };
 
 export { BASEMAPS, LABELS };

--- a/components/ui/map/constants.js
+++ b/components/ui/map/constants.js
@@ -51,4 +51,12 @@ const LABELS = {
   }
 };
 
-export { BASEMAPS, LABELS };
+const BOUNDARIES = {
+  dark: {
+    id: 'dark',
+    label: 'Boundaries',
+    value: 'https://api.mapbox.com/styles/v1/prepdata/cjbfcn5o51al72so1u5avqcur/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoicHJlcGRhdGEiLCJhIjoiY2piZmNrcTRjMXRsdzJxbm9uNm1nOXJtNSJ9.Jm14P-FBGvNxiaB-3mzSPw'
+  }
+};
+
+export { BASEMAPS, LABELS, BOUNDARIES };

--- a/components/ui/map/controls/BasemapControl.js
+++ b/components/ui/map/controls/BasemapControl.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { LABELS } from 'components/ui/map/constants';
+
 // Redux
 import { connect } from 'react-redux';
 import { setBasemap, setLabels } from 'redactions/explore';
@@ -8,7 +10,6 @@ import { setBasemap, setLabels } from 'redactions/explore';
 // Components
 import TetherComponent from 'react-tether';
 import Icon from 'components/ui/Icon';
-import Checkbox from 'components/form/Checkbox';
 import RadioGroup from 'components/form/RadioGroup';
 
 class BasemapControl extends React.Component {
@@ -16,16 +17,11 @@ class BasemapControl extends React.Component {
     // STORE
     basemapControl: PropTypes.object,
     basemap: PropTypes.object,
-    labelsVisible: PropTypes.bool,
+    labels: PropTypes.string,
 
     // ACTIONS
     setBasemap: PropTypes.func,
     setLabels: PropTypes.func
-  };
-
-  static defaultProps = {
-    // STORE
-    labelsVisible: false
   };
 
   state = {
@@ -51,8 +47,8 @@ class BasemapControl extends React.Component {
     this.props.setBasemap(basemapControl.basemaps[basemap]);
   }
 
-  onLabelChange = (label) => {
-    this.props.setLabels(label.checked);
+  onLabelChange = (labels) => {
+    this.props.setLabels(labels);
   }
 
   toggleDropdown = (to) => {
@@ -72,7 +68,7 @@ class BasemapControl extends React.Component {
 
   // RENDER
   render() {
-    const { basemap, basemapControl, labelsVisible } = this.props;
+    const { basemap, basemapControl, labels } = this.props;
     const { active } = this.state;
 
     return (
@@ -109,12 +105,14 @@ class BasemapControl extends React.Component {
               onChange={this.onBasemapChange}
             />
             <div className="divisor" />
-            <Checkbox
+            <RadioGroup
+              options={Object.keys(LABELS).map(k => ({
+                label: LABELS[k].label,
+                value: LABELS[k].id
+              }))}
+              name="labels"
               properties={{
-                name: 'labels',
-                title: 'Labels',
-                value: 'labels',
-                checked: labelsVisible
+                default: labels
               }}
               onChange={this.onLabelChange}
             />
@@ -129,7 +127,7 @@ export default (connect(
   state => ({
     basemap: state.explore.basemap,
     basemapControl: state.explore.basemapControl,
-    labelsVisible: state.explore.labels
+    labels: state.explore.labels
   }),
   {
     setBasemap,

--- a/components/ui/map/controls/BasemapControl.js
+++ b/components/ui/map/controls/BasemapControl.js
@@ -5,12 +5,13 @@ import { LABELS } from 'components/ui/map/constants';
 
 // Redux
 import { connect } from 'react-redux';
-import { setBasemap, setLabels } from 'redactions/explore';
+import { setBasemap, setLabels, setBoundaries } from 'redactions/explore';
 
 // Components
 import TetherComponent from 'react-tether';
 import Icon from 'components/ui/Icon';
 import RadioGroup from 'components/form/RadioGroup';
+import Checkbox from 'components/form/Checkbox';
 
 class BasemapControl extends React.Component {
   static propTypes = {
@@ -18,10 +19,12 @@ class BasemapControl extends React.Component {
     basemapControl: PropTypes.object,
     basemap: PropTypes.object,
     labels: PropTypes.string,
+    boundaries: PropTypes.bool,
 
     // ACTIONS
     setBasemap: PropTypes.func,
-    setLabels: PropTypes.func
+    setLabels: PropTypes.func,
+    setBoundaries: PropTypes.func
   };
 
   state = {
@@ -51,6 +54,10 @@ class BasemapControl extends React.Component {
     this.props.setLabels(labels);
   }
 
+  onBoundariesChange = (boundaries) => {
+    this.props.setBoundaries(boundaries.checked);
+  }
+
   toggleDropdown = (to) => {
     const active = (typeof to !== 'undefined' && to !== null) ? to : !this.state.active;
 
@@ -68,7 +75,7 @@ class BasemapControl extends React.Component {
 
   // RENDER
   render() {
-    const { basemap, basemapControl, labels } = this.props;
+    const { basemap, basemapControl, labels, boundaries } = this.props;
     const { active } = this.state;
 
     return (
@@ -116,6 +123,16 @@ class BasemapControl extends React.Component {
               }}
               onChange={this.onLabelChange}
             />
+            <div className="divisor" />
+            <Checkbox
+              properties={{
+                name: 'boundaries',
+                title: 'Boundaries',
+                value: 'boundaries',
+                checked: boundaries
+              }}
+              onChange={this.onBoundariesChange}
+            />
           </div>
         }
       </TetherComponent>
@@ -127,10 +144,12 @@ export default (connect(
   state => ({
     basemap: state.explore.basemap,
     basemapControl: state.explore.basemapControl,
-    labels: state.explore.labels
+    labels: state.explore.labels,
+    boundaries: state.explore.boundaries
   }),
   {
     setBasemap,
-    setLabels
+    setLabels,
+    setBoundaries
   }
 )(BasemapControl));

--- a/redactions/explore.js
+++ b/redactions/explore.js
@@ -44,6 +44,7 @@ const SET_ZOOM = 'explore/SET_ZOOM';
 const SET_LATLNG = 'explore/SET_LATLNG';
 const SET_BASEMAP = 'explore/SET_BASEMAP';
 const SET_LABELS = 'explore/SET_LABELS';
+const SET_BOUNDARIES = 'explore/SET_BOUNDARIES';
 
 /**
  * Layer
@@ -105,6 +106,7 @@ const initialState = {
   dataTypeTree: null,
   /** @type {string} labels */
   labels: 'none',
+  boundaries: false,
   sorting: {
     /** @type {'modified'|'viewed'|'favourited'} order */
     order: 'modified',
@@ -251,6 +253,12 @@ export default function (state = initialState, action) {
     case SET_LABELS: {
       return Object.assign({}, state, {
         labels: action.payload
+      });
+    }
+
+    case SET_BOUNDARIES: {
+      return Object.assign({}, state, {
+        boundaries: action.payload
       });
     }
 
@@ -623,6 +631,13 @@ export function setLabels(labelEnabled) {
   return {
     type: SET_LABELS,
     payload: labelEnabled
+  };
+}
+
+export function setBoundaries(boundaries) {
+  return {
+    type: SET_BOUNDARIES,
+    payload: boundaries
   };
 }
 

--- a/redactions/explore.js
+++ b/redactions/explore.js
@@ -103,7 +103,8 @@ const initialState = {
   geographiesTree: null,
   topicsTree: null,
   dataTypeTree: null,
-  labels: false,
+  /** @type {string} labels */
+  labels: 'none',
   sorting: {
     /** @type {'modified'|'viewed'|'favourited'} order */
     order: 'modified',


### PR DESCRIPTION
## Overview
This PR let the user choose between a light and dark themed labels layer on the Explore map and let them toggle a new boundaries layer.

## Testing instructions
Go to the Explore page, toggle on and off the labels and boundaries.

## Pivotal task
[Task](https://www.pivotaltracker.com/story/show/155029294)
