### PR TITLE
disable scrollZoom by default for map widget

### DIFF
--- a/components/ui/map/Map.js
+++ b/components/ui/map/Map.js
@@ -52,7 +52,7 @@ class Map extends React.Component {
 
     if (this.props.setMapInstance) {
       this.props.setMapInstance(this.map);
-    }
+    } 
 
     if (this.props.mapConfig && this.props.mapConfig.bounds) {
       this.fitBounds(this.props.mapConfig.bounds.geometry);
@@ -68,6 +68,10 @@ class Map extends React.Component {
       this.map.keyboard.disable();
     }
 
+    if (this.props.disableScrollZoom) {
+      this.map.scrollWheelZoom.disable();
+    }
+    
     // SETTERS
     this.setAttribution();
     this.setZoomControl();
@@ -357,11 +361,13 @@ class Map extends React.Component {
 
 Map.defaultProps = {
   interactionEnabled: true,
+  disableScrollZoom: true,
   useLightBasemap: false
 };
 
 Map.propTypes = {
   interactionEnabled: PropTypes.bool.isRequired,
+  disableScrollZoom: PropTypes.bool.isRequired,
   setMapInstance: PropTypes.func,
   // STORE
   mapConfig: PropTypes.object,

--- a/pages/app/Explore.js
+++ b/pages/app/Explore.js
@@ -422,6 +422,7 @@ class Explore extends Page {
                   mapConfig={{ zoom, latLng }}
                   setMapParams={params => this.setMapParams(params)}
                   setMapInstance={(map) => { this.map = map; }}
+                  disableScrollZoom={false}
                   // layerManager
                   layerGroups={this.props.layerGroups}
                   LayerManager={LayerManager}


### PR DESCRIPTION
## Overview
This fix will disable scrollZoom for the map component by default, so we do not block the default page scroll. Added property `disableScrollZoom` in case this should be activated in another case. 

## Testing instructions
Scroll over the map on this page: https://staging.resourcewatch.org/data/dashboards/climate for example, scroll should not trigger the map zoom.  

## Pivotal task
https://www.pivotaltracker.com/story/show/155229709
