### PR TITLE
BUG: fix flexbox issue for responsive widget card

### DIFF
--- a/css/components/widgets/widget_card.scss
+++ b/css/components/widgets/widget_card.scss
@@ -77,7 +77,7 @@
     .actions {
       display: flex;
       justify-content: space-between;
-      height: 30px;
+      flex-wrap: wrap;
 
       .c-button {
         height: 30px;


### PR DESCRIPTION
## Overview
![screen shot 2018-02-22 at 18 15 31](https://user-images.githubusercontent.com/971129/36553457-a4292cc6-17fc-11e8-8817-75fdbe0cc972.png)

we only need to add the wrap property and the buttons will be adjusted, also the `30px height` is already calculated on the button so no need to calculate it again! 

## Pivotal task
https://www.pivotaltracker.com/story/show/155392123