### PR TITLE
Fix/authentication redirects

### DIFF
--- a/components/layout/header-admin/header-admin-user/header-admin-user-component.js
+++ b/components/layout/header-admin/header-admin-user/header-admin-user-component.js
@@ -126,17 +126,17 @@ class HeaderUser extends React.Component {
               onMouseLeave={() => this.toggleDropdown(false)}
             >
               <li className="header-dropdown-list-item">
-                <a href={`https://production-api.globalforestwatch.org/auth/facebook?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`}>
+                <a href="/auth/facebook">
                   Facebook
                 </a>
               </li>
               <li className="header-dropdown-list-item">
-                <a href={`https://production-api.globalforestwatch.org/auth/google?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`}>
+                <a href="/auth/google">
                   Google
                 </a>
               </li>
               <li className="header-dropdown-list-item">
-                <a href={`https://production-api.globalforestwatch.org/auth/twitter?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`}>
+                <a href="/auth/twitter">
                   Twitter
                 </a>
               </li>

--- a/components/layout/header/header-user/header-user-component.js
+++ b/components/layout/header/header-user/header-user-component.js
@@ -126,17 +126,17 @@ class HeaderUser extends React.Component {
               onMouseLeave={() => this.toggleDropdown(false)}
             >
               <li className="header-dropdown-list-item">
-                <a href={`https://production-api.globalforestwatch.org/auth/facebook?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`}>
+                <a href="/auth/facebook">
                   Facebook
                 </a>
               </li>
               <li className="header-dropdown-list-item">
-                <a href={`https://production-api.globalforestwatch.org/auth/google?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`}>
+                <a href="/auth/google">
                   Google
                 </a>
               </li>
               <li className="header-dropdown-list-item">
-                <a href={`https://production-api.globalforestwatch.org/auth/twitter?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`}>
+                <a href="/auth/twitter">
                   Twitter
                 </a>
               </li>

--- a/components/modal/login-modal/login-modal-component.js
+++ b/components/modal/login-modal/login-modal-component.js
@@ -14,7 +14,7 @@ function LoginModal(props) {
             <div className="column small-12 medium-4">
               <a
                 className="c-button -google -fullwidth"
-                href={`https://production-api.globalforestwatch.org/auth/google?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`}
+                href="/auth/google"
               >
                 Google
               </a>
@@ -22,7 +22,7 @@ function LoginModal(props) {
             <div className="column small-12 medium-4">
               <a
                 className="c-button -facebook -fullwidth"
-                href={`https://production-api.globalforestwatch.org/auth/facebook?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`}
+                href="/auth/facebook"
               >
                 Facebook
               </a>
@@ -30,7 +30,7 @@ function LoginModal(props) {
             <div className="column small-12 medium-4">
               <a
                 className="c-button -twitter -fullwidth"
-                href={`https://production-api.globalforestwatch.org/auth/twitter?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`}
+                href="/auth/twitter"
               >
                 Twitter
               </a>

--- a/index.js
+++ b/index.js
@@ -153,14 +153,18 @@ app.prepare()
         return res.redirect('/');
       }
 
-      // save the current url for redirect if successfull, set it to expire in 5 min
-      res.cookie('authUrl', req.headers.referer, { maxAge: 3E5 });
+      if (req.cookies.authUrl) {
+        res.clearCookie('authUrl');
+      }
 
+      // save the current url for redirect if successfull, set it to expire in 5 min
+      res.cookie('authUrl', req.headers.referer, { maxAge: 3E5, httpOnly: true });
       return res.redirect(`https://production-api.globalforestwatch.org/auth/${service}?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`);
     });
 
     server.get('/login', auth.login);
     server.get('/logout', (req, res) => {
+      req.session.destroy();
       req.logout();
       res.redirect('/');
     });

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ app.prepare()
 
       // save the current url for redirect if successfull, set it to expire in 5 min
       res.cookie('authUrl', req.headers.referer, { maxAge: 3E5, httpOnly: true });
-      return res.redirect(`https://production-api.globalforestwatch.org/auth/${service}?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`);
+      return res.redirect(`${process.env.CONTROL_TOWER_URL}/auth/${service}?callbackUrl=${process.env.CALLBACK_URL}&applications=rw&token=true`);
     });
 
     server.get('/login', auth.login);


### PR DESCRIPTION
## Overview
Make the authentication a bit easier to manage, now we can authenticate the user just by sending them to 

`auth/facebook|twitter|google` 

Fix some issues where you would not log in, also now you get logged in to the view you where on when making the authentication request. 

## Testing instructions

1. Login on for example the explore page, it should if successful redirect to the same page
2. Login / Logout / change page / then login again, you should be authenticated, this was a bug before that should be fixed now 
3. Logout on for example the explore page, you should stay on the same page but be logged out. 