### PR TITLE
Feature/implement ui sorter for layer interactivity

### DIFF
--- a/components/admin/layers/form/interactions/interactions-component.js
+++ b/components/admin/layers/form/interactions/interactions-component.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import findIndex from 'lodash/findIndex';
 
+import { arrayMove } from 'react-sortable-hoc';
+
 // Redux
 import { connect } from 'react-redux';
 
@@ -14,6 +16,8 @@ import Select from 'components/form/SelectInput';
 import { getInteractions, modifyInteractions } from 'components/admin/layers/form/interactions/interactions-actions';
 
 import { FORM_ELEMENTS, FORMAT } from 'components/admin/layers/form/constants';
+
+import InteractionsItems from './interactions-items';
 
 const DATA_FORMATS = {
   number: [
@@ -32,6 +36,12 @@ const DATA_FORMATS = {
 class InteractionsComponent extends PureComponent {
   componentWillMount() {
     this.props.dispatch(getInteractions({ ...this.props }));
+  }
+
+  onSortInteractions = ({ oldIndex, newIndex }) => {
+    const { interactions } = this.props;
+    interactions.added = arrayMove(interactions.added, oldIndex, newIndex);
+    this.props.dispatch(modifyInteractions({ ...this.props }, interactions.added));
   }
 
   addInteractions(options) {
@@ -141,8 +151,7 @@ class InteractionsComponent extends PureComponent {
 
     return (
       <div>
-        <div className="c-field preview-container">
-          {interactions.available &&
+        {interactions.available &&
           <Field
             options={interactions.available}
             onChange={value => this.addInteractions(value)}
@@ -159,16 +168,17 @@ class InteractionsComponent extends PureComponent {
             {Select}
           </Field>}
 
-          {interactions.added &&
-            interactions.added.map(data => (
-              <section className="c-field-flex" key={data.column}>
-                {this.renderInteractionFields(data)}
-                {this.renderFormatField(data)}
-                <button type="button" className="c-btn" onClick={() => this.removeInteraction(data)}>Remove</button>
-              </section>
-            ))
-          }
-        </div>
+        <InteractionsItems
+          interactions={interactions}
+          renderInteractionFields={this.renderInteractionFields}
+          renderFormatField={this.renderFormatField}
+          removeInteraction={this.removeInteraction}
+          axis="y"
+          lockAxis="y"
+          useDragHandle
+          onSortEnd={this.onSortInteractions}
+        />
+
       </div>
     );
   }
@@ -181,8 +191,7 @@ const mapStateToProps = state => ({
 
 InteractionsComponent.propTypes = {
   dispatch: PropTypes.func.isRequired,
-  interactions: PropTypes.object.isRequired,
-  form: PropTypes.object.isRequired
+  interactions: PropTypes.object.isRequired
 };
 
 InteractionsComponent.defaultProps = {

--- a/components/admin/layers/form/interactions/interactions-component.js
+++ b/components/admin/layers/form/interactions/interactions-component.js
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
 
 // Components
 import Field from 'components/form/Field';
-import Input from 'components/form/Input';
 import Select from 'components/form/SelectInput';
 
 import { getInteractions, modifyInteractions } from 'components/admin/layers/form/interactions/interactions-actions';
@@ -18,20 +17,6 @@ import { getInteractions, modifyInteractions } from 'components/admin/layers/for
 import { FORM_ELEMENTS, FORMAT } from 'components/admin/layers/form/constants';
 
 import InteractionsItems from './interactions-items';
-
-const DATA_FORMATS = {
-  number: [
-    { label: '00000', value: '00000' },
-    { label: '0,0', value: '0,0' },
-    { label: '0a', value: '0a' }
-  ],
-  date: [
-    { label: 'YYYY/MM/DD', value: 'YYYY/MM/DD' },
-    { label: 'YYYY', value: 'YYYY' },
-    { label: 'MM', value: 'MM' },
-    { label: 'DD', value: 'DD' }
-  ]
-};
 
 class InteractionsComponent extends PureComponent {
   componentWillMount() {
@@ -102,50 +87,6 @@ class InteractionsComponent extends PureComponent {
     this.props.dispatch(modifyInteractions({ ...this.props }, interactions.added));
   }
 
-  renderInteractionFields(data) {
-    return ['Field', 'Label', 'Prefix', 'Suffix'].map((label) => {
-      const validations = label === 'Label' ? ['required'] : [];
-      return (
-        <Field
-          key={data.column + label}
-          ref={(c) => { if (c) FORM_ELEMENTS.elements[label.toLowerCase() + data.column] = c; }}
-          onChange={value => this.editInteraction({ value, key: label, field: data })}
-          validations={validations}
-          properties={{
-            name: label.toLowerCase() + data.column,
-            label,
-            type: 'text',
-            disabled: /Field/.test(label),
-            required: /Label/.test(label),
-            default: data[FORMAT.resolveKey(label)]
-          }}
-        >
-          {Input}
-        </Field>
-      );
-    });
-  }
-
-  renderFormatField(data) {
-    return (
-      <Field
-        key={`${data.column}format`}
-        ref={(c) => { if (c) FORM_ELEMENTS.elements[`format${data.column}`] = c; }}
-        onChange={value => this.editInteraction({ value, key: 'format', field: data })}
-        options={DATA_FORMATS[data.type]}
-        properties={{
-          name: `${data.column}format`,
-          label: 'Format',
-          type: 'text',
-          disabled: /string/.test(data.type),
-          default: data.format
-        }}
-      >
-        {Select}
-      </Field>
-    );
-  }
-
   render() {
     const { interactions } = this.props;
 
@@ -170,9 +111,8 @@ class InteractionsComponent extends PureComponent {
 
         <InteractionsItems
           interactions={interactions}
-          renderInteractionFields={this.renderInteractionFields}
-          renderFormatField={this.renderFormatField}
-          removeInteraction={this.removeInteraction}
+          editInteraction={data => this.editInteraction(data)}
+          removeInteraction={data => this.removeInteraction(data)}
           axis="y"
           lockAxis="y"
           useDragHandle

--- a/components/admin/layers/form/interactions/interactions-component.js
+++ b/components/admin/layers/form/interactions/interactions-component.js
@@ -97,6 +97,7 @@ class InteractionsComponent extends PureComponent {
             options={interactions.available}
             onChange={value => this.addInteractions(value)}
             properties={{
+              className: 'Select--large',
               name: 'selected_columns',
               label: 'Add interactions',
               type: 'text',

--- a/components/admin/layers/form/interactions/interactions-handler.js
+++ b/components/admin/layers/form/interactions/interactions-handler.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { SortableHandle } from 'react-sortable-hoc';
+
+// Components
+import Icon from 'components/ui/Icon';
+
+const InteractionsHandler = () => (
+  <span className="handler">
+    <Icon name="icon-drag-dots" className="-small" />
+  </span>
+);
+
+export default SortableHandle(InteractionsHandler);

--- a/components/admin/layers/form/interactions/interactions-handler.js
+++ b/components/admin/layers/form/interactions/interactions-handler.js
@@ -6,7 +6,7 @@ import { SortableHandle } from 'react-sortable-hoc';
 import Icon from 'components/ui/Icon';
 
 const InteractionsHandler = () => (
-  <span className="handler">
+  <span className="handler -dragger">
     <Icon name="icon-drag-dots" className="-small" />
   </span>
 );

--- a/components/admin/layers/form/interactions/interactions-item.js
+++ b/components/admin/layers/form/interactions/interactions-item.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Drag and drop
+import { SortableElement } from 'react-sortable-hoc';
+
+// Components
+import InteractionsHandler from './interactions-handler';
+
+const InteractionsItem = (props) => {
+  const {
+    interaction,
+    removeInteraction,
+    renderInteractionFields,
+    renderFormatField
+  } = props;
+  return (
+    <li
+      className="c-field-flex c-sortable-row"
+      key={interaction.column}
+    >
+      <InteractionsHandler />
+      {renderInteractionFields(interaction)}
+      {renderFormatField(interaction)}
+      <button type="button" className="c-btn" onClick={() => removeInteraction(interaction)}>Remove</button>
+    </li>);
+};
+
+InteractionsItem.propTypes = {
+  interaction: PropTypes.object.isRequired,
+  removeInteraction: PropTypes.func.isRequired,
+  renderInteractionFields: PropTypes.func.isRequired,
+  renderFormatField: PropTypes.func.isRequired
+};
+
+export default SortableElement(InteractionsItem);

--- a/components/admin/layers/form/interactions/interactions-item.js
+++ b/components/admin/layers/form/interactions/interactions-item.js
@@ -4,15 +4,33 @@ import PropTypes from 'prop-types';
 // Drag and drop
 import { SortableElement } from 'react-sortable-hoc';
 
+import { FORM_ELEMENTS, FORMAT } from 'components/admin/layers/form/constants';
+
 // Components
+import Field from 'components/form/Field';
+import Input from 'components/form/Input';
+import Select from 'components/form/SelectInput';
 import InteractionsHandler from './interactions-handler';
+
+const DATA_FORMATS = {
+  number: [
+    { label: '00000', value: '00000' },
+    { label: '0,0', value: '0,0' },
+    { label: '0a', value: '0a' }
+  ],
+  date: [
+    { label: 'YYYY/MM/DD', value: 'YYYY/MM/DD' },
+    { label: 'YYYY', value: 'YYYY' },
+    { label: 'MM', value: 'MM' },
+    { label: 'DD', value: 'DD' }
+  ]
+};
 
 const InteractionsItem = (props) => {
   const {
     interaction,
     removeInteraction,
-    renderInteractionFields,
-    renderFormatField
+    editInteraction
   } = props;
   return (
     <li
@@ -20,17 +38,53 @@ const InteractionsItem = (props) => {
       key={interaction.column}
     >
       <InteractionsHandler />
-      {renderInteractionFields(interaction)}
-      {renderFormatField(interaction)}
+
+      {['Field', 'Label', 'Prefix', 'Suffix'].map((label) => {
+      const validations = label === 'Label' ? ['required'] : [];
+        return (
+          <Field
+            key={interaction.column + label}
+            ref={(c) => { if (c) FORM_ELEMENTS.elements[label.toLowerCase() + interaction.column] = c; }}
+            onChange={value => editInteraction({ value, key: label, field: interaction })}
+            validations={validations}
+            properties={{
+              name: label.toLowerCase() + interaction.column,
+              label,
+              type: 'text',
+              disabled: /Field/.test(label),
+              required: /Label/.test(label),
+              default: interaction[FORMAT.resolveKey(label)]
+            }}
+          >
+            {Input}
+          </Field>
+        );
+      })}
+
+      <Field
+        key={`${interaction.column}format`}
+        ref={(c) => { if (c) FORM_ELEMENTS.elements[`format${interaction.column}`] = c; }}
+        onChange={value => editInteraction({ value, key: 'format', field: interaction })}
+        options={DATA_FORMATS[interaction.type]}
+        properties={{
+          name: `${interaction.column}format`,
+          label: 'Format',
+          type: 'text',
+          disabled: /string/.test(interaction.type),
+          default: interaction.format
+        }}
+      >
+        {Select}
+      </Field>
+
       <button type="button" className="c-btn" onClick={() => removeInteraction(interaction)}>Remove</button>
     </li>);
 };
 
 InteractionsItem.propTypes = {
   interaction: PropTypes.object.isRequired,
-  removeInteraction: PropTypes.func.isRequired,
-  renderInteractionFields: PropTypes.func.isRequired,
-  renderFormatField: PropTypes.func.isRequired
+  editInteraction: PropTypes.func.isRequired,
+  removeInteraction: PropTypes.func.isRequired
 };
 
 export default SortableElement(InteractionsItem);

--- a/components/admin/layers/form/interactions/interactions-items.js
+++ b/components/admin/layers/form/interactions/interactions-items.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Drag and drop
+import { SortableContainer } from 'react-sortable-hoc';
+
+// Components
+import InteractionsItem from './interactions-item';
+
+const InteractionsItems = (props) => {
+  const {
+    interactions,
+    renderInteractionFields,
+    renderFormatField,
+    removeInteraction
+  } = props;
+
+  return (
+    <ul className="c-field preview-container">
+      {interactions.added && interactions.added.map((interaction, key) =>
+        (
+          <InteractionsItem
+            key={key}
+            index={key}
+            renderInteractionFields={data => renderInteractionFields(data)}
+            renderFormatField={data => renderFormatField(data)}
+            removeInteraction={data => removeInteraction(data)}
+            interaction={interaction}
+          />
+        ))}
+    </ul>
+  );
+};
+
+InteractionsItems.propTypes = {
+  interactions: PropTypes.object.isRequired,
+  removeInteraction: PropTypes.func.isRequired,
+  renderInteractionFields: PropTypes.func.isRequired,
+  renderFormatField: PropTypes.func.isRequired
+};
+
+export default SortableContainer(InteractionsItems);

--- a/components/admin/layers/form/interactions/interactions-items.js
+++ b/components/admin/layers/form/interactions/interactions-items.js
@@ -10,8 +10,7 @@ import InteractionsItem from './interactions-item';
 const InteractionsItems = (props) => {
   const {
     interactions,
-    renderInteractionFields,
-    renderFormatField,
+    editInteraction,
     removeInteraction
   } = props;
 
@@ -20,10 +19,9 @@ const InteractionsItems = (props) => {
       {interactions.added && interactions.added.map((interaction, key) =>
         (
           <InteractionsItem
-            key={key}
+            key={interaction.column + key}
             index={key}
-            renderInteractionFields={data => renderInteractionFields(data)}
-            renderFormatField={data => renderFormatField(data)}
+            editInteraction={data => editInteraction(data)}
             removeInteraction={data => removeInteraction(data)}
             interaction={interaction}
           />
@@ -35,8 +33,7 @@ const InteractionsItems = (props) => {
 InteractionsItems.propTypes = {
   interactions: PropTypes.object.isRequired,
   removeInteraction: PropTypes.func.isRequired,
-  renderInteractionFields: PropTypes.func.isRequired,
-  renderFormatField: PropTypes.func.isRequired
+  editInteraction: PropTypes.func.isRequired
 };
 
 export default SortableContainer(InteractionsItems);

--- a/components/ui/legend/legend-list/legend-list-component.js
+++ b/components/ui/legend/legend-list/legend-list-component.js
@@ -28,6 +28,7 @@ class Legend extends PureComponent {
       <ul className="legend-list">
         {items.map((value, index) => (
           <LegendListItem
+            key={index}
             index={index}
             value={value}
             readonly={this.props.readonly}

--- a/css/_base.scss
+++ b/css/_base.scss
@@ -148,6 +148,10 @@ input, button, select, textarea {
   text-align: center;
 }
 
+.-dragger {
+  cursor: move;
+}
+
 .-columnize {
   @media screen and (min-width: map-get($breakpoints, medium)) {
     columns: 2;

--- a/css/components/form/field.scss
+++ b/css/components/form/field.scss
@@ -1,7 +1,7 @@
 .c-field {
   margin-bottom: 20px;
 
-  // temporary... 
+  // temporary...
   &-flex {
     display: flex;
     justify-content: space-between;
@@ -86,6 +86,12 @@
     }
   }
 
+  .Select {
+    &--large {
+      width: 100%;
+      max-width: none;
+    }
+  }
 
   /**
    * STATES


### PR DESCRIPTION
## Overview

Implement drag and drop UI for layer interactivity, so its possible to change the order of them. 

![screen shot 2018-03-01 at 12 37 56](https://user-images.githubusercontent.com/971129/36842938-9f78df72-1d4d-11e8-90a4-b297e0eaa604.png)


## Testing instructions
Make sure when you change the order that: 

1. The layer preview updates
2. When saving the layer, the order you specified is saved. 
3. All the old , save/delete/update works as expected

## Pivotal task
https://www.pivotaltracker.com/story/show/155618340
