### PR TITLE
FIX/table sorting on datasets view

### DIFF
--- a/components/ui/customtable/CustomTable.js
+++ b/components/ui/customtable/CustomTable.js
@@ -51,6 +51,7 @@ export default class CustomTable extends React.Component {
       pagination: props.pagination,
       // Sort
       sort: props.sort,
+      initialSort: props.sort,
       // Search
       search: {},
       // Columns
@@ -179,11 +180,18 @@ export default class CustomTable extends React.Component {
   }
 
   onSort(s) {
-    const sort = {
-      field: s.field,
-      value: s.value
-    };
-    this.setState({ sort }, () => this.onChangePage(0));
+    const { sort, initialSort } = this.state;
+
+    // check if we are trying to sort on the same as before, then return to initial sorting
+    if (isEqual(s, sort)) {
+      this.setState({ sort: initialSort }, () => this.onChangePage(0));
+    } else {
+      const newSortingRule = {
+        field: s.field,
+        value: s.value
+      };
+      this.setState({ sort: newSortingRule }, () => this.onChangePage(0));
+    }
   }
 
   onSearch(s) {

--- a/components/ui/customtable/header/TableSorts.js
+++ b/components/ui/customtable/header/TableSorts.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import Icon from '../../Icon';
 
 function TableSorts(props) {
-  const { field, sort } = props;
+  const { field, sort, onSort } = props;
 
   return (
     <div>
@@ -12,8 +12,8 @@ function TableSorts(props) {
         className={classnames({
           '-active': sort.field === field && sort.value === 1
         })}
-        onClick={() => this.props.onSort && this.props.onSort({
-          field: this.props.field,
+        onClick={() => onSort && onSort({
+          field,
           value: 1
         })}
       >
@@ -24,8 +24,8 @@ function TableSorts(props) {
         className={classnames({
           '-active': sort.field === field && sort.value === -1
         })}
-        onClick={() => this.props.onSort && this.props.onSort({
-          field: this.props.field,
+        onClick={() => onSort && onSort({
+          field,
           value: -1
         })}
       >
@@ -37,12 +37,8 @@ function TableSorts(props) {
 
 TableSorts.propTypes = {
   field: PropTypes.string.isRequired,
+  onSort: PropTypes.func.isRequired,
   sort: PropTypes.object
-};
-
-TableSorts.defaultProps = {
-  onChange: null,
-  selected: null
 };
 
 export default TableSorts;


### PR DESCRIPTION
## Overview
Table sorting arrows did not work as expected, now they should return the correct sorting. Also if you click the same we reset to the original state.

## Testing instructions
Make sure you can sort datasets by anything defined in the header

## Pivotal task
https://www.pivotaltracker.com/story/show/155221178
