### PR TITLE
add query params to map embed for changing embed settings

### DIFF
--- a/components/ui/legend/legend-component.js
+++ b/components/ui/legend/legend-component.js
@@ -15,6 +15,7 @@ class Legend extends React.PureComponent {
     expanded: PropTypes.bool,
     readonly: PropTypes.bool,
     interaction: PropTypes.bool,
+    hideTimeline: PropTypes.bool,
 
     // ACTIONS
     onChangeLayer: PropTypes.func,
@@ -62,8 +63,7 @@ class Legend extends React.PureComponent {
 
 
   render() {
-    const { layerGroups } = this.props;
-
+    const { layerGroups, hideTimeline } = this.props;
     return (
       <div className="c-legend-map">
         <div
@@ -76,6 +76,7 @@ class Legend extends React.PureComponent {
 
           <LegendList
             items={layerGroups}
+            hideTimeline={hideTimeline}
             helperClass="c-legend-unit -sort"
             onSortEnd={this.onSortEnd}
             axis="y"

--- a/components/ui/legend/legend-list/legend-item/legend-item-component.js
+++ b/components/ui/legend/legend-list/legend-item/legend-item-component.js
@@ -10,7 +10,8 @@ import LegendItemButtons from './legend-item-buttons';
 class LegendItem extends PureComponent {
   static propTypes = {
     dataset: PropTypes.string,
-    layers: PropTypes.array
+    layers: PropTypes.array,
+    hideTimeline: PropTypes.bool
   }
 
   static defaultProps = {
@@ -19,7 +20,7 @@ class LegendItem extends PureComponent {
   }
 
   render() {
-    const { layers } = this.props;
+    const { layers, hideTimeline } = this.props;
     const activeLayer = layers.find(l => l.active);
 
     return (
@@ -40,9 +41,10 @@ class LegendItem extends PureComponent {
             activeLayer={activeLayer}
           />
 
-          <LegendItemTimeline
+          {!hideTimeline && <LegendItemTimeline
             {...this.props}
-          />
+          />}
+
         </div>
 
         <LegendItemDrag />

--- a/components/ui/legend/legend-list/legend-list-component.js
+++ b/components/ui/legend/legend-list/legend-list-component.js
@@ -9,6 +9,7 @@ class Legend extends PureComponent {
     items: PropTypes.array,
     readonly: PropTypes.bool,
     interaction: PropTypes.bool,
+    hideTimeline: PropTypes.bool,
 
     // FUNC
     onChangeLayer: PropTypes.func,
@@ -22,7 +23,7 @@ class Legend extends PureComponent {
   }
 
   render() {
-    const { items } = this.props;
+    const { items, hideTimeline } = this.props;
 
     return (
       <ul className="legend-list">
@@ -31,6 +32,7 @@ class Legend extends PureComponent {
             key={index}
             index={index}
             value={value}
+            hideTimeline={hideTimeline}
             readonly={this.props.readonly}
             interaction={this.props.interaction}
             onChangeLayer={this.props.onChangeLayer}

--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -71,9 +71,12 @@ class EmbedMap extends Page {
 
   render() {
     const {
-      widget, loading, layerGroups, error, zoom, latLng, favourited, user
+      widget, loading, layerGroups, error, zoom, latLng, favourited, user, url
     } = this.props;
+
     const { modalOpened } = this.state;
+
+    const { disableZoom, legendExpanded, hideTimeline } = url.query;
 
     const favouriteIcon = favourited ? 'star-full' : 'star-empty';
 
@@ -153,13 +156,14 @@ class EmbedMap extends Page {
           <div className={classnames('widget-content', { '-external': this.isLoadedExternally() })}>
             <Map
               LayerManager={LayerManager}
-              mapConfig={{ zoom, latLng }}
+              mapConfig={{ zoom, latLng, zoomControl: disableZoom !== '1' }}
               layerGroups={layerGroups}
             />
 
             <Legend
               layerGroups={layerGroups}
-              expanded={false}
+              expanded={legendExpanded === '1'}
+              hideTimeline={hideTimeline === '1'}
               interaction={false}
               readonly
             />

--- a/pages/app/embed/EmbedMap.js
+++ b/pages/app/embed/EmbedMap.js
@@ -19,6 +19,8 @@ import Icon from 'components/ui/Icon';
 
 // Utils
 import LayerManager from 'utils/layers/LayerManager';
+import { paramIsTrue } from 'utils/utils';
+
 
 class EmbedMap extends Page {
   static async getInitialProps(context) {
@@ -156,14 +158,14 @@ class EmbedMap extends Page {
           <div className={classnames('widget-content', { '-external': this.isLoadedExternally() })}>
             <Map
               LayerManager={LayerManager}
-              mapConfig={{ zoom, latLng, zoomControl: disableZoom !== '1' }}
+              mapConfig={{ zoom, latLng, zoomControl: !paramIsTrue(disableZoom) }}
               layerGroups={layerGroups}
             />
 
             <Legend
               layerGroups={layerGroups}
-              expanded={legendExpanded === '1'}
-              hideTimeline={hideTimeline === '1'}
+              expanded={paramIsTrue(legendExpanded)}
+              hideTimeline={paramIsTrue(hideTimeline)}
               interaction={false}
               readonly
             />

--- a/redactions/widget.js
+++ b/redactions/widget.js
@@ -300,7 +300,8 @@ export function checkIfFavorited(widgetId) {
       const userService = new UserService({ apiURL: process.env.WRI_API_URL });
       userService.getFavouriteWidgets(user.token)
         .then((res) => {
-          const favourite = res.find(elem => elem.attributes.resourceId === widgetId);
+          const favourite = res.find && res.find(elem => elem.attributes.resourceId === widgetId);
+
           dispatch({
             type: GET_WIDGET_FAVORITE,
             payload: {

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -29,6 +29,10 @@ export function concatenation(string, params) {
   return str;
 }
 
+export function paramIsTrue(param) {
+  return param && /1|true/.test(param);
+}
+
 export function capitalizeFirstLetter(string) {
   if (typeof string === 'string') {
     return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();


### PR DESCRIPTION
## Overview
Allow these settings to be turned off/on when embedding a map: 

#### Disable map zoom controlls
disableZoom=0|1, defaults to enabled

#### Legend shown or hidden by default
legendExpanded=0|1, defaults to hidden

#### Hide timeline within legend
hideTimeline=0|1 defaults to shown 

example url: `http://localhost:9000/embed/map/8b931d66-cecc-4061-840c-deeaa40294f1?disableZoom=0&legendExpanded=1&hideTimeline=1`

## Testing instructions

Enter one of your widgets and grab the url, then start modifying these parameters `?disableZoom=0&legendExpanded=1&hideTimeline=1`

Make sure the page does not break when removing the parameters or using a weird value

## Pivotal task
https://www.pivotaltracker.com/story/show/155698396
https://www.pivotaltracker.com/story/show/155698328
