### PR TITLE
Add Similar datasets to topic pages

### DIFF
--- a/layout/topics-detail/topics-detail-component.js
+++ b/layout/topics-detail/topics-detail-component.js
@@ -1,11 +1,14 @@
 /* eslint max-len: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
+import compact from 'lodash/compact';
+import flatten from 'lodash/flatten';
 
 import { Router } from 'routes';
 
 // Components
 import Layout from 'layout/layout/layout-app';
+import SimilarDatasets from 'components/datasets/similar-datasets/similar-datasets';
 
 // Topic Detail Component
 import TopicDetailHeader from 'layout/topics-detail/topics-detail-header';
@@ -18,6 +21,32 @@ class TopicDetailComponent extends React.Component {
   static propTypes = {
     topicsDetail: PropTypes.object
   };
+
+  getDatasetIds() {
+    const { topicsDetail } = this.props;
+
+    const content = JSON.parse(topicsDetail.data.content);
+
+    const datasetIds = content.map((block) => {
+      if (block.type === 'widget') {
+        return block.content.datasetId;
+      }
+
+      if (block.type === 'grid') {
+        return block.content.map((b) => {
+          if (b.type === 'widget') {
+            return b.content.datasetId;
+          }
+
+          return null;
+        });
+      }
+
+      return null;
+    });
+
+    return compact(flatten(datasetIds));
+  }
 
   render() {
     const {
@@ -71,6 +100,23 @@ class TopicDetailComponent extends React.Component {
                           window.scrollTo(0, 0);
                         });
                     }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="l-section">
+            <div className="l-container">
+              <div className="row">
+                <div className="column small-12">
+                  <Title className="-extrabig -secondary -p-secondary">
+                    Similar datasets
+                  </Title>
+
+                  <SimilarDatasets
+                    datasetIds={this.getDatasetIds()}
+                    onTagSelected={this.handleTagSelected}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Overview
This PR adds a "Similar datasets" section to topic pages.

## Testing instructions
Check the bottom of any topic page.

## [Pivotal task](https://www.pivotaltracker.com/story/show/155973240)
