### PR TITLE
Fix issue with LayerInfoModal "More info" button

### DIFF
--- a/components/modal/layer-info-modal/component.js
+++ b/components/modal/layer-info-modal/component.js
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 
 class LayerInfoModal extends React.Component {
   handleMoreInfo = () => {
-    this.props.onRequestClose(false);
     Router.pushRoute('explore_detail', { id: this.props.data.dataset });
   }
 

--- a/components/modal/layer-info-modal/component.js
+++ b/components/modal/layer-info-modal/component.js
@@ -45,7 +45,6 @@ class LayerInfoModal extends React.Component {
 }
 
 LayerInfoModal.propTypes = {
-  onRequestClose: PropTypes.func.isRequired,
   data: PropTypes.object,
   embed: PropTypes.bool
 };

--- a/components/modal/layer-info-modal/index.js
+++ b/components/modal/layer-info-modal/index.js
@@ -1,0 +1,3 @@
+import LayerInfoModalComponent from './component';
+
+export default LayerInfoModalComponent;

--- a/components/ui/legend/legend-list/legend-item/legend-item-buttons/legend-item-button-info/legend-item-button-info-component.js
+++ b/components/ui/legend/legend-list/legend-item/legend-item-buttons/legend-item-button-info/legend-item-button-info-component.js
@@ -9,7 +9,7 @@ import Tooltip from 'rc-tooltip/dist/rc-tooltip';
 
 // Modal
 import Modal from 'components/modal/modal-component';
-import LayerInfoModal from 'components/modal/LayerInfoModal';
+import LayerInfoModal from 'components/modal/layer-info-modal';
 
 class LegendItemButtonInfo extends PureComponent {
   static propTypes = {


### PR DESCRIPTION
## Overview
This PR fixes the issue that prevented going to the Explore detail page from a Layer info modal.

## Testing instructions
Check the info modal window of any layer added to the Explore map

## [Pivotal task](https://www.pivotaltracker.com/story/show/156122391)