### PR TITLE
Topic pages --> support for widgets of type embed

### DIFF
--- a/components/wysiwyg/widget-block/widget-block-component.js
+++ b/components/wysiwyg/widget-block/widget-block-component.js
@@ -98,6 +98,8 @@ class WidgetBlock extends React.Component {
       widget.metadata[0].attributes.info)) || {};
 
     const widgetLinks = metadataInfo.widgetLinks || [];
+    const widgetIsEmbed = widget && widget.widgetConfig && widget.widgetConfig.type === 'embed';
+    const widgetEmbedUrl = widgetIsEmbed && widget.widgetConfig.url;
 
     const caption = metadataInfo && metadataInfo.caption;
 
@@ -106,6 +108,8 @@ class WidgetBlock extends React.Component {
       'icon-star-full': isInACollection,
       'icon-star-empty': !isInACollection
     });
+
+    console.log('widgetIsEmbed', widgetIsEmbed);
 
     return (
       <div className="c-widget-block-card">
@@ -122,8 +126,8 @@ class WidgetBlock extends React.Component {
                   />}
                   overlayClassName="c-rc-tooltip"
                   overlayStyle={{
-                    color: '#fff'
-                  }}
+                        color: '#fff'
+                      }}
                   placement="bottomLeft"
                   trigger="click"
                 >
@@ -172,6 +176,10 @@ class WidgetBlock extends React.Component {
               toggleLoading={loading => onToggleLoading(loading)}
               reloadOnResize
             />
+          }
+
+          {widgetIsEmbed &&
+            <iframe src={widgetEmbedUrl} width="100%" height="100%" frameBorder="0"></iframe>
           }
 
           {!isEmpty(widget) && !widgetLoading && !widgetError && !layersError && widgetType === 'map' && layers && (
@@ -230,7 +238,7 @@ class WidgetBlock extends React.Component {
                           {link.name}
                         </a>
                       </li>
-                    ))}
+                            ))}
                   </ul>
                 </div>
               }

--- a/components/wysiwyg/widget-block/widget-block-component.js
+++ b/components/wysiwyg/widget-block/widget-block-component.js
@@ -109,8 +109,6 @@ class WidgetBlock extends React.Component {
       'icon-star-empty': !isInACollection
     });
 
-    console.log('widgetIsEmbed', widgetIsEmbed);
-
     return (
       <div className="c-widget-block-card">
         <header>

--- a/css/components/dashboards/dashboard-card.scss
+++ b/css/components/dashboards/dashboard-card.scss
@@ -49,6 +49,7 @@
     display: flex;
     padding: 15px;
     min-height: 300px;
+    height: 100%;
     overflow-x: auto;
     overflow-y: hidden;
     flex-grow: 1;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/545342/37827951-bb9f85d6-2e99-11e8-9109-8c4678185840.png)

## Overview
This PR adds support to widgets of type `embed` in the topic pages.

## Testing instructions
Check the forests topic page as an example: http://localhost:3000/topics/forests _Forests cover 42% source watersheds for the largest 100 cities widget_