### PR TITLE
Rename "Widget" to "Visualization" across the app

### DIFF
--- a/components/app/myrw/widgets/my-rw-widgets/my-rw-widgets-component.js
+++ b/components/app/myrw/widgets/my-rw-widgets/my-rw-widgets-component.js
@@ -79,7 +79,14 @@ class MyRWWidgets extends PureComponent {
 
   render() {
     const { mode } = this.state;
-    const { widgets, loading, orderDirection, routes, pagination, filters } = this.props;
+    const {
+      widgets,
+      loading,
+      orderDirection,
+      routes,
+      pagination,
+      filters
+    } = this.props;
     const { page, total, limit } = pagination;
     const nameSearchValue = ((filters.find(filter => filter.key === 'name') || {}).value || '');
 
@@ -92,11 +99,11 @@ class MyRWWidgets extends PureComponent {
       <div className="c-myrw-widgets-my c-my-rw">
         <SearchInput
           input={{
-            placeholder: 'Search dataset',
+            placeholder: 'Search visualization',
             value: nameSearchValue
           }}
           link={{
-            label: 'New widget',
+            label: 'New visualization',
             route: routes.detail,
             params: { tab: 'widgets', id: 'new' }
           }}
@@ -152,7 +159,7 @@ class MyRWWidgets extends PureComponent {
             />}
             {!(widgets.length) &&
               <div className="no-widgets-div">
-                You currently have no widgets
+                You currently have no visualizations
               </div>}
           </div>
         </div>

--- a/components/app/myrw/widgets/pages/index.js
+++ b/components/app/myrw/widgets/pages/index.js
@@ -11,7 +11,7 @@ import MyRWWidgetsMy from 'components/app/myrw/widgets/my-rw-widgets';
 
 // Constants
 const WIDGET_SUBTABS = [{
-  label: 'My widgets',
+  label: 'My visualizations',
   value: 'my_wigets',
   route: 'myrw',
   params: { tab: 'widgets', subtab: 'my_widgets' }

--- a/components/widgets/list/WidgetActionsTooltip.js
+++ b/components/widgets/list/WidgetActionsTooltip.js
@@ -55,7 +55,7 @@ class WidgetActionsTooltip extends React.Component {
           { this.props.isWidgetOwner &&
             <li>
               <button onClick={() => this.handleClick('edit_widget')}>
-                Edit widget
+                Edit visualization
               </button>
             </li>
           }

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -322,7 +322,7 @@ class WidgetCard extends PureComponent {
     const widgetId = this.props.widget.id;
     const widgetName = this.props.widget.name;
     // eslint-disable-next-line no-alert
-    if (confirm(`Are you sure you want to remove the widget: ${widgetName}?`)) {
+    if (confirm(`Are you sure you want to remove the visualization: ${widgetName}?`)) {
       this.widgetService.removeUserWidget(widgetId, this.props.user.token)
         .then(() => this.props.onWidgetRemove())
         .catch(err => toastr.error('Error', err));

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -478,7 +478,7 @@ class WidgetCard extends PureComponent {
                   className="c-button -secondary widget-actions"
                   onClick={e => this.handleWidgetActionsClick(e, (widget.userId === user.id))}
                 >
-                  Widget actions
+                  Visualization actions
                 </button>
               }
               {showRemove && (widget.userId === user.id) &&

--- a/components/wysiwyg/widget-block-edition/widget-block-edition-component.js
+++ b/components/wysiwyg/widget-block-edition/widget-block-edition-component.js
@@ -26,8 +26,8 @@ export default function WidgetBlockEdition({
                   <h1>Select widget</h1>
                   <Tabs
                     options={[
-                      { label: 'My widgets', value: 'my-widgets' },
-                      { label: 'All widgets', value: 'all-widgets' }
+                      { label: 'My visualizations', value: 'my-widgets' },
+                      { label: 'All visualizations', value: 'all-widgets' }
                     ]}
                     defaultSelected={data.tab}
                     selected={data.tab}

--- a/components/wysiwyg/widget-block-edition/widget-block-edition-component.js
+++ b/components/wysiwyg/widget-block-edition/widget-block-edition-component.js
@@ -23,7 +23,7 @@ export default function WidgetBlockEdition({
             <div className="row">
               <div className="column small-12">
                 <div className="page-header-content -with-tabs">
-                  <h1>Select widget</h1>
+                  <h1>Select visualization</h1>
                   <Tabs
                     options={[
                       { label: 'My visualizations', value: 'my-widgets' },
@@ -46,7 +46,7 @@ export default function WidgetBlockEdition({
 
                 <SearchInput
                   input={{
-                    placeholder: 'Search widget'
+                    placeholder: 'Search visualization'
                   }}
                   link={{}}
                   onSearch={onChangeSearch}

--- a/css/components/widgets/widget_card.scss
+++ b/css/components/widgets/widget_card.scss
@@ -1,6 +1,7 @@
 .c-widget-card {
   position: relative;
   width: 100%;
+  min-width: 200px;
   background: $color-tertiary;
   display: flex;
   flex-direction: column;

--- a/pages/app/MyRW.js
+++ b/pages/app/MyRW.js
@@ -31,7 +31,7 @@ const MYRW_TABS = [{
   route: 'myrw',
   params: { tab: 'datasets', subtab: 'my_datasets' }
 }, {
-  label: 'Widgets',
+  label: 'Visualizations',
   value: 'widgets',
   route: 'myrw',
   params: { tab: 'widgets', subtab: 'my_widgets' }


### PR DESCRIPTION
## Overview
This PR renames all 'Widget' labels to 'Visualization`.

## Testing instructions
Just look for any former references to the word `Widget` across the app.

## [Pivotal task](https://www.pivotaltracker.com/story/show/156265592)