### PR TITLE
User: save token without modifications

### DIFF
--- a/layout/layout/layout-admin/layout-admin-component.js
+++ b/layout/layout/layout-admin/layout-admin-component.js
@@ -56,7 +56,7 @@ class LayoutAdmin extends React.Component {
       applications: process.env.APPLICATIONS,
       authUrl: process.env.CONTROL_TOWER_URL,
       assetsPath: '/static/images/widget-editor/',
-      userToken: props.user.token,
+      userToken: props.user.token2,
       userEmail: props.user.email
     });
   }

--- a/layout/layout/layout-app/layout-app-component.js
+++ b/layout/layout/layout-app/layout-app-component.js
@@ -63,7 +63,7 @@ class LayoutApp extends React.Component {
       applications: process.env.APPLICATIONS,
       authUrl: process.env.CONTROL_TOWER_URL,
       assetsPath: '/static/images/widget-editor/',
-      userToken: props.user.token,
+      userToken: props.user.token2,
       userEmail: props.user.email
     });
   }

--- a/redactions/user.js
+++ b/redactions/user.js
@@ -217,9 +217,9 @@ export function setUser(user) {
     }
 
     const userObj = { ...user };
-    if (userObj.token) {
-      userObj.token = userObj.token.includes('Bearer') ? userObj.token : `Bearer ${userObj.token}`;
-    }
+
+    userObj.token2 = userObj.token.includes('Bearer') ? userObj.token2 : userObj.token;
+    userObj.token = userObj.token.includes('Bearer') ? userObj.token : `Bearer ${userObj.token}`;
 
     dispatch({ type: SET_USER, payload: userObj });
   };
@@ -514,4 +514,3 @@ export const removeUserArea = createThunkAction(
     });
   }
 );
-


### PR DESCRIPTION
## Overview
This PR adds:
- `token2` to user object. This token won't have Bearer incorporated to it
- Use `token2` in the function `setConfig` of the widget-editor

## Testing instructions
Upload some areas and find them in the area dropdown of the widget-editor

## Pivotal task
https://www.pivotaltracker.com/story/show/156269001