### PR TITLE
Update dashboard styles

### DIFF
--- a/css/components/form/wysiwyg.scss
+++ b/css/components/form/wysiwyg.scss
@@ -63,8 +63,6 @@
           font-family: $body-font-family;
           line-height: $global-lineheight;
 
-          max-width: 1080px * 0.66667;
-
           > a {
               color: $link-font-color;
               text-decoration: underline;

--- a/css/components/form/wysiwyg.scss
+++ b/css/components/form/wysiwyg.scss
@@ -37,6 +37,8 @@
           font-size: $font-size-h2 / 2;
           color: $color-primary;
           font-weight: $font-weight-light;
+          font-family: $body-font-family;
+          margin-bottom: $font-size-h2 * 0.5;
 
           @media screen and (min-width: map-get($breakpoints, medium)) {
             font-size: $font-size-h2;
@@ -47,6 +49,8 @@
           font-size: $font-size-h3 / 2;
           color: $color-primary;
           font-weight: $font-weight-light;
+          font-family: $body-font-family;
+          margin-bottom: $font-size-h3 * 0.5;
 
           @media screen and (min-width: map-get($breakpoints, medium)) {
             font-size: $font-size-h3;
@@ -54,7 +58,20 @@
         }
 
         p {
-          font-size: $font-size-default;
+          color: $body-font-color;
+          font-size: $global-font-size;
+          font-family: $body-font-family;
+          line-height: $global-lineheight;
+
+          max-width: 1080px * 0.66667;
+
+          > a {
+              color: $link-font-color;
+              text-decoration: underline;
+          }
+          &:last-child {
+              margin-bottom: 0;
+          }
         }
 
         ul {


### PR DESCRIPTION
## Overview
Added CSS to overwrite quill styles with the base styles to update the dashboards/topic pages to use Lato and base fonts, colors, line height.

## Testing instructions
View any topics page. Inline styles will need to be manually stripped in editor (e.g. black text).

## Pivotal task
NA
