### PR TITLE
Updates to static pages across site

### DIFF
--- a/components/app/common/Banner.js
+++ b/components/app/common/Banner.js
@@ -21,7 +21,7 @@ function Banner(props) {
       style={styles}
     >
       {props.viel && <div className="c-viel" />}
-      <div>
+      <div className="l-container">
         {props.children}
       </div>
     </section>

--- a/components/app/common/CardApp.js
+++ b/components/app/common/CardApp.js
@@ -42,10 +42,10 @@ function CardApp(props) {
         </div>
 
         <div className="card-footer">
-          {!!link && link.external &&
+          {!!link &&
             <a
               href={link.route}
-              target="_blank"
+              target={!!link.external && "_blank" || "_self"}
               className={`c-button ${buttonClasses} -fullwidth`}
             >
               {link.label}

--- a/components/app/common/ContactUs/ContactUsForm.js
+++ b/components/app/common/ContactUs/ContactUsForm.js
@@ -9,9 +9,13 @@ import Spinner from 'components/ui/Spinner';
 import Field from 'components/form/Field';
 import Input from 'components/form/Input';
 import TextArea from 'components/form/TextArea';
+import Select from 'components/form/SelectInput';
+
+import Modal from 'components/modal/modal-component';
+import SubmitModalComponent from 'components/modal/submit-modal';
 
 // Constants
-import { FORM_ELEMENTS, STATE_DEFAULT } from './constants';
+import { FORM_ELEMENTS, STATE_DEFAULT, FORM_TOPICS } from './constants';
 
 
 class ContactUsForm extends React.Component {
@@ -19,7 +23,8 @@ class ContactUsForm extends React.Component {
     super(props);
 
     this.state = Object.assign({}, STATE_DEFAULT, {
-      form: STATE_DEFAULT.form
+      form: STATE_DEFAULT.form,
+      showSubmitModal: false
     });
 
     this.service = new ContactUsService();
@@ -48,7 +53,7 @@ class ContactUsForm extends React.Component {
         })
           .then(() => {
             this.setState({ submitting: false });
-            toastr.success('Success', 'Your message has been sent!');
+            this.handleToggleModal(true);
           })
           .catch(() => {
             this.setState({ submitting: false });
@@ -65,12 +70,33 @@ class ContactUsForm extends React.Component {
     this.setState({ form });
   }
 
+  handleToggleModal = (bool) => {
+    this.setState({ showSubmitModal: bool });
+  }
+
   render() {
     const { submitting } = this.state;
 
     return (
       <div className="c-contact-us">
         <form className="c-form" onSubmit={this.onSubmit} noValidate>
+          <Field
+            ref={(c) => { if (c) FORM_ELEMENTS.elements.topic = c; }}
+            onChange={value => this.onChange({ topic: value })}
+            validations={['required']}
+            className="-fluid"
+            options={ FORM_TOPICS.options }
+            properties={{
+              name: 'topic',
+              label: 'Topic',
+              type: 'text',
+              required: true,
+              default: this.state.form.topic
+            }}
+          >
+            {Select}
+          </Field>
+
           <Field
             ref={(c) => { if (c) FORM_ELEMENTS.elements.email = c; }}
             onChange={value => this.onChange({ email: value })}
@@ -81,6 +107,7 @@ class ContactUsForm extends React.Component {
               label: 'Email',
               type: 'email',
               required: true,
+              placeholder: 'Your Email',
               default: this.state.form.email
             }}
           >
@@ -96,6 +123,7 @@ class ContactUsForm extends React.Component {
               name: 'text',
               label: 'Message',
               required: true,
+              placeholder: 'Tell us how we can help.',
               default: this.state.form.text
             }}
           >
@@ -109,6 +137,16 @@ class ContactUsForm extends React.Component {
             </button>
           </div>
         </form>
+        <Modal
+          isOpen={this.state.showSubmitModal}
+          className="-medium"
+          onRequestClose={() => this.handleToggleModal(false)}
+          >
+          <SubmitModalComponent
+            header='Thanks for your message.'
+            text='Someone from our team will be in touch shortly.'
+            />
+        </Modal>
       </div>
     );
   }

--- a/components/app/common/ContactUs/constants.js
+++ b/components/app/common/ContactUs/constants.js
@@ -2,9 +2,32 @@ export const STATE_DEFAULT = {
   submitting: false,
   submitted: false,
   form: {
+    topic: 'General question or feedback',
     email: '',
     text: ''
   }
+};
+
+export const FORM_TOPICS = {
+  options: [
+    {
+      value: 'General question or feedback',
+      label: 'General question or feedback'
+    },
+    { value: 'Bug report',
+      label: 'Bug report'
+    },
+    {
+      value: 'Data request or suggestion',
+      label: 'Data request or suggestion'
+    },
+    { value: 'Media inquiry',
+      label: 'Media inquiry'
+    },
+    { value: 'Other',
+      label: 'Other'
+    }
+  ]
 };
 
 export const FORM_ELEMENTS = {

--- a/components/app/static-pages/get-involved/post-content/Apps.js
+++ b/components/app/static-pages/get-involved/post-content/Apps.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Link } from 'routes';
 import { connect } from 'react-redux';
 import { getTools, setFilters } from 'redactions/admin/tools';
 
 import CardApp from 'components/app/common/CardApp';
+import Banner from 'components/app/common/Banner';
 
 class Apps extends React.Component {
   componentDidMount() {
@@ -14,9 +16,10 @@ class Apps extends React.Component {
 
   render() {
     return (
-      <div className="l-section">
-        <div className="l-container">
-          <div className="row">
+      <div>
+        <div className="l-section">
+          <div className="l-container">
+            <div className="row">
             {this.props.tools.list.map(app => (
               <div key={app.id} className="column small-12 medium-4 c-card-column">
                 <CardApp
@@ -31,8 +34,26 @@ class Apps extends React.Component {
                 />
               </div>
             ))}
+            </div>
           </div>
         </div>
+        <aside className="l-postcontent">
+          <div className="l-container">
+            <div className="row align-center">
+              <div className="column small-12">
+                <Banner className="-text-center" bgImage="/static/images/backgrounds/planet-pulse.jpg">
+                  <p className="-claim">
+                    View near-real-time data <br />
+                    on the Planet
+                  </p>
+                  <Link to="pulse">
+                    <a className="c-button -alt -primary">Launch Planet Pulse</a>
+                  </Link>
+                </Banner>
+              </div>
+            </div>
+          </div>
+        </aside>
       </div>
     );
   }

--- a/components/app/static-pages/get-involved/post-content/ContributeData.js
+++ b/components/app/static-pages/get-involved/post-content/ContributeData.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 // Components
 import CardApp from 'components/app/common/CardApp';
+import Banner from 'components/app/common/Banner';
 
 // Next components
 import { Link } from 'routes';
@@ -11,7 +12,7 @@ function ContributeData() {
     {
       id: 'request-data',
       title: 'Request data',
-      description: 'Know of a dataset that you’d like to see on resource watch or have a specific area of interest you’d like us to cover?',
+      description: 'Know of a data set that you’d like to see on Resource Watch or have a specific area of interest you’d like us to cover?',
       link: {
         route: 'https://docs.google.com/forms/d/e/1FAIpQLSfXsPGQxM6p8KloU920t5Tfhx9FYFOq8-Rjml07UDH9EvsI1w/viewform?usp=sf_link',
         label: 'Request data',
@@ -21,7 +22,7 @@ function ContributeData() {
     {
       id: 'submit-data',
       title: 'Submit data for Resource Watch',
-      description: 'Have a dataset that you’d like to submit to see on Resource Watch?',
+      description: 'Have a data set that you’d like to submit to see on Resource Watch?',
       link: {
         route: 'https://docs.google.com/forms/d/e/1FAIpQLSfbVoP6rAfMtxepShok8l7idQdr4KbOV4gK8ZA7_mwGx46kHA/viewform?usp=sf_link',
         label: 'Submit a dataset',
@@ -31,62 +32,79 @@ function ContributeData() {
   ];
 
   return (
-    <aside className="l-postcontent">
-      <div className="l-container">
-        <div className="row align-center">
-          <div className="column small-12">
-            <h3>Guiding principles</h3>
-            <p>
-              We seek to develop and acquire data that cover a diverse range of
-              themes for a wide audience that are:
-            </p>
-            <ul>
-              <li>
-                <strong>Open:</strong> Data that can be freely used, reused, and redistributed
-              </li>
-              <li>
-                <strong>Relevant:</strong> Data that help answer questions to address urgent, global challenges
-              </li>
-              <li>
-                <strong>Reliable:</strong> Peer-reviewed or official government data produced by transparent, established methodologies
-              </li>
-              <li>
-                <strong>Timely:</strong> Most up-to-date, and complete information available
-              </li>
-            </ul>
-          </div>
-        </div>
-        <div className="row align-center">
-          <div className="column small-12">
-            <p>
-              Before submitting a dataset, please make sure to browse our
-              selection and review our data policy and submission <Link route="get_involved_detail" params={{ id: 'data-policy' }}><a>guidelines</a></Link>.
-
-            </p>
-          </div>
-        </div>
-
-        <div className="l-section">
+    <div>
+      <aside className="l-postcontent">
+        <div className="l-container">
           <div className="row">
-            {cards.map(card => (
-              <div key={card.id} className="column small-12 medium-6 large-6 c-card-column">
-                <CardApp
-                  title={card.title}
-                  className="-compact"
-                  description={card.description}
-                  link={{ ...card.link }}
-                  buttonType="primary"
-                />
+            <div className="column small-12">
+              <div className="c-terms">
+                <h3>Guiding principles</h3>
+                <p>
+                  We seek to develop and acquire data that cover a diverse range of
+                  themes for a wide audience that are:
+                </p>
+                <ul>
+                  <li>
+                    <strong>Open:</strong> Data that can be freely used, reused, and redistributed
+                  </li>
+                  <li>
+                    <strong>Relevant:</strong> Data that help answer questions to address urgent, global challenges
+                  </li>
+                  <li>
+                    <strong>Reliable:</strong> Peer-reviewed or official government data produced by transparent, established methodologies
+                  </li>
+                  <li>
+                    <strong>Timely:</strong> Most up-to-date, and complete information available
+                  </li>
+                </ul>
               </div>
-            ))}
+            </div>
+          </div>
+          <div className="row">
+            <div className="column small-12">
+              <p>
+                Before submitting a dataset, please make sure to browse our
+                catalog and review our <Link route="get_involved_detail" params={{ id:"data-policy" }}><a>data policy</a></Link> and submission guidelines.
+              </p>
+            </div>
+          </div>
+
+          <div className="l-section">
+            <div className="row">
+              {cards.map(card => (
+                <div key={card.id} className="column small-12 medium-6 large-6 c-card-column">
+                  <CardApp
+                    title={card.title}
+                    className="-compact"
+                    description={card.description}
+                    link={{ ...card.link }}
+                    buttonType="primary"
+                    />
+                </div>
+              ))}
+
+            </div>
           </div>
         </div>
-        {/* Temporary link to Data Policy */}
-        <Link route="get_involved_detail" params={{ id: 'data-policy' }}>
-          <a>Data Policy</a>
-        </Link>
-      </div>
-    </aside>
+      </aside>
+      <aside className="l-postcontent">
+        <div className="l-container">
+          <div className="row align-center">
+            <div className="column small-12">
+              <Banner className="-text-center" bgImage="/static/images/backgrounds/planet-pulse.jpg">
+                <p className="-claim">
+                  View near-real-time data <br />
+                  on the Planet
+                </p>
+                <Link to="pulse">
+                  <a className="c-button -alt -primary">Launch Planet Pulse</a>
+                </Link>
+              </Banner>
+            </div>
+          </div>
+        </div>
+      </aside>
+    </div>
   );
 }
 

--- a/components/app/static-pages/get-involved/post-content/DevelopYourApp.js
+++ b/components/app/static-pages/get-involved/post-content/DevelopYourApp.js
@@ -30,7 +30,7 @@ function DevelopYourApp() {
     {
       id: 'submit-app',
       title: 'Submit an app',
-      description: 'Share your map or app with the Resource Watch community. Please review our app review [guidelines] before submission.',
+      description: 'Share your map or app with the Resource Watch community. Please review our app review guidelines before submission.',
       link: {
         route: 'https://docs.google.com/forms/d/e/1FAIpQLSfZ79GW0jF7BL_-mUjHOgXEUN3U2p95FgiOp-_ZaqqwTfI7Gg/viewform?usp=sf_link',
         label: 'Submit your app',
@@ -56,10 +56,6 @@ function DevelopYourApp() {
               </div>
               ))}
           </div>
-          {/* Temporary link to App Review Policy */}
-          <Link route="get_involved_detail" params={{ id: 'app-review-policy' }}>
-            <a>App Review Policy</a>
-          </Link>
         </div>
       </aside>
       <aside className="l-postcontent">
@@ -69,7 +65,7 @@ function DevelopYourApp() {
               <Banner className="-text-center" bgImage="/static/images/backgrounds/bg-partner-maryland.jpg">
                 <p className="-claim">
                   Explore maps and apps curated <br />
-                  by the Resource Watch community of this team?
+                  by the Resource Watch community.
                 </p>
                 <Link route="get_involved_detail" params={{ id: 'apps' }}>
                   <a className="c-button -primary -alt">

--- a/components/app/static-pages/get-involved/post-content/JoinCommunity.js
+++ b/components/app/static-pages/get-involved/post-content/JoinCommunity.js
@@ -3,6 +3,7 @@ import { Link } from 'routes';
 
 // Components
 import CardApp from 'components/app/common/CardApp';
+import Banner from 'components/app/common/Banner';
 
 function JoinCommunity() {
   const cards = [
@@ -11,9 +12,9 @@ function JoinCommunity() {
       title: '',
       description: 'Reach out with comments, questions, or suggestions.',
       link: {
-        route: 'about_contact-us',
+        route: '/about/contact-us',
         label: 'Contact us',
-        external: true
+        external: false
       }
     },
     {
@@ -31,57 +32,49 @@ function JoinCommunity() {
       title: '',
       description: 'Sign up for our newsletter to receive highlights and updates.',
       link: {
-        route: '',
-        label: 'Subscribe to our Newsletter',
-        external: true
-      }
-    },
-    {
-      id: 'partner',
-      title: '',
-      description: 'Thinking of a partnership? Let’s see what we can do together.',
-      link: {
-        route: 'https://docs.google.com/forms/d/e/1FAIpQLSdr-dUO07dUNas6XYhq_Hmy_lsRQRtW6U6tsp0Ie4jx7dyFJA/viewform?usp=sf_link',
-        label: 'Apply to be a partner',
-        external: true
+        route: '/about/contact-us',
+        label: 'Subscribe to our newsletter',
+        external: false
       }
     }
   ];
 
   return (
-    <aside className="l-postcontent">
-      <div className="l-container">
-        <div className="l-section">
+    <div>
+      <aside className="l-postcontent">
+        <div className="l-container">
+          <div className="row">
+            {cards.map(card => (
+              <div key={card.id} className="column small-12 medium-4 large-4 c-card-column">
+                <CardApp
+                  title={card.title}
+                  className="-compact"
+                  description={card.description}
+                  link={{ ...card.link }}
+                  buttonType="primary"
+                  />
+              </div>
+            ))}
+          </div>
+        </div>
+      </aside>
+      <aside>
+        <div className="l-container">
           <div className="row align-center">
             <div className="column small-12">
-              <p>
-                Have questions about Resource Watch or suggestions for how improve the
-                platform? How about an idea for a bold new data partnership? We want to
-                hear from you. Join us in the movement to build a more sustainable
-                future.
-              </p>
+              <Banner className="-text-center" bgImage={'/static/images/backgrounds/partners-02@2x.jpg'}>
+                <p className="-claim">
+                  Let&rsquo;s build a more sustainable<br /> world together.
+                </p>
+                <Link to="about_partners">
+                  <a className="c-btn -primary">Partners</a>
+                </Link>
+              </Banner>
             </div>
           </div>
         </div>
-        <div className="row">
-          {cards.map(card => (
-            <div key={card.id} className="column small-12 medium-6 large-6 c-card-column">
-              <CardApp
-                title={card.title}
-                className="-compact"
-                description={card.description}
-                link={{ ...card.link }}
-                buttonType="primary"
-              />
-            </div>
-            ))}
-        </div>
-        {/* Temporary link to Partner Application Guidelines */}
-        <Link route="get_involved_detail" params={{ id: 'partner-application-guidelines' }}>
-          <a>Partner Application Guidelines</a>
-        </Link>
-      </div>
-    </aside>
+      </aside>
+    </div>
   );
 }
 

--- a/components/app/static-pages/get-involved/post-content/SuggestStoryPost.js
+++ b/components/app/static-pages/get-involved/post-content/SuggestStoryPost.js
@@ -5,6 +5,7 @@ import { Link } from 'routes';
 // Components
 import CardStatic from 'components/app/common/CardStatic';
 import Rating from 'components/app/common/Rating';
+import Banner from 'components/app/common/Banner';
 
 function SuggestStoryPost({ insights }) {
   const insightsCardsStatic = insightsData => insightsData.map(c =>
@@ -43,30 +44,32 @@ function SuggestStoryPost({ insights }) {
   const insightCards = insightsCardsStatic(insights);
 
   return (
-    <aside className="l-postcontent">
-      <section id="discoverIsights" className="l-section">
+    <div>
+      <aside>
         <div className="l-container">
-          <div className="l-section">
-            <div className="row align-center">
-              <div className="column small-12">
-                <p>
-                  See a connection in the data worth exploring? Let us know about
-                  it. We might craft a story around on the lead you sent. Send us
-                  what you see, and someone from Resource Watch may be in touch.
-                </p>
-                <div className="buttons -align-center">
-                  <a
-                    className="c-button -secondary"
-                    href="https://docs.google.com/forms/d/e/1FAIpQLSeOiKYcmW6-SD2ScKHJ5gfq5X28sf3HtJkPDXJ90nWdpgPGuQ/viewform?usp=sf_link"
-                    target="_blank"
-                    rel="noopener noreferrer"
+          <div className="row">
+            <div className="column small-12 medium-8">
+              <h2>Latest stories</h2>
+            </div>
+          </div>
+          <div className="row align-center">
+            <div className="column small-12">
+              <div className="buttons">
+                <a
+                  className="c-button -secondary"
+                  href="https://docs.google.com/forms/d/e/1FAIpQLSeOiKYcmW6-SD2ScKHJ5gfq5X28sf3HtJkPDXJ90nWdpgPGuQ/viewform?usp=sf_link"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   >
-                    Suggest a story
-                  </a>
-                </div>
+                  Suggest a story
+                </a>
               </div>
             </div>
           </div>
+        </div>
+      </aside>
+      <aside className="l-postcontent">
+        <section id="discoverIsights" className="l-section">
           <div className="insight-cards">
             <div className="row">
               <div className="column small-12 medium-8">
@@ -85,15 +88,32 @@ function SuggestStoryPost({ insights }) {
               <div className="column small-12 medium-4">
                 <Link
                   route="insights"
-                >
+                  >
                   <a className="c-button -primary -fullwidth">More stories</a>
                 </Link>
               </div>
             </div>
           </div>
+        </section>
+      </aside>
+      <aside className="l-postcontent">
+        <div className="l-container">
+          <div className="row align-center">
+            <div className="column small-12">
+              <Banner className="-text-center" bgImage="/static/images/backgrounds/partners-02@2x.jpg">
+                <p className="-claim">
+                  Questions, comments, or feedback? <br />
+                  Help us improve Resource Watch.
+                </p>
+                <Link to="about_contact-us">
+                  <a className="c-button -alt -primary">Contact us</a>
+                </Link>
+              </Banner>
+            </div>
+          </div>
         </div>
-      </section>
-    </aside>
+      </aside>
+    </div>
   );
 }
 

--- a/components/modal/submit-modal/index.js
+++ b/components/modal/submit-modal/index.js
@@ -1,0 +1,3 @@
+import SubmitModalComponent from './submit-modal-component';
+
+export default SubmitModalComponent;

--- a/components/modal/submit-modal/submit-modal-component.js
+++ b/components/modal/submit-modal/submit-modal-component.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function SubmitModalComponent(props) {
+  return (
+    <div className="c-submit-modal">
+      <div className="row">
+        <div className="header-div">
+          <h2>{props.header || 'Thank you for your submission.'}</h2>
+          <p>{props.text}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+SubmitModalComponent.propTypes = {
+  text: PropTypes.string.isRequired
+};
+
+export default SubmitModalComponent;

--- a/layout/footer/footer-component.js
+++ b/layout/footer/footer-component.js
@@ -14,18 +14,19 @@ import NewsletterModal from 'components/modal/newsletter-modal';
 const data = [
   { name: 'Data', route: 'explore' },
   { name: 'Explore Datasets', route: 'explore' },
-  { name: 'Planet Pulse', anchor: '/data/pulse' }
+  { name: 'Planet Pulse', route: 'pulse' },
+  { name: 'App Gallery', route: 'get_involved_detail', params: { id: 'apps' } }
 ];
 
 const topics = [
   { name: 'Topics', route: 'topics' },
-  { name: 'Biodiversity', route: 'topics_detail', params: { id: 'biodiversity' } },
   { name: 'Cities', route: 'topics_detail', params: { id: 'cities' } },
   { name: 'Climate', route: 'topics_detail', params: { id: 'climate' } },
-  { name: 'Commerce', route: 'topics_detail', params: { id: 'commerce' } },
   { name: 'Energy', route: 'topics_detail', params: { id: 'energy' } },
   { name: 'Food and Agriculture', route: 'topics_detail', params: { id: 'food-and-agriculture' } },
   { name: 'Forests', route: 'topics_detail', params: { id: 'forests' } },
+  { name: 'Oceans', route: 'topics_detail', params: { id: 'oceans' } },
+  { name: 'Society', route: 'topics_detail', params: { id: 'society' } },
   { name: 'Water', route: 'topics_detail', params: { id: 'water' } }
 ];
 
@@ -33,14 +34,14 @@ const about = [
   { name: 'About', route: 'about' },
   { name: 'Partners', route: 'about_partners' },
   { name: 'FAQs', route: 'about_faqs' },
+  { name: 'How To', route: 'about_howto' },
+  { name: 'Contact Us', route: 'about_contact-us' },
   { name: 'Terms of Service', route: 'terms-of-service' },
-  { name: 'Privacy', route: 'privacy-policy' }
+  { name: 'Privacy Policy', route: 'privacy-policy' }
 ];
 
 const blog = [
-  { name: 'Blog', route: 'insights' },
-  { name: 'Recent Signals', route: 'insights' },
-  { name: 'Highlighted Signals', route: 'insights' }
+  { name: 'Blog', route: 'insights' }
 ];
 
 const getInvolved = [
@@ -48,7 +49,7 @@ const getInvolved = [
   { name: 'Submit a Story', route: 'get_involved_detail', params: { id: 'submit-an-insight' } },
   { name: 'Contribute Data', route: 'get_involved_detail', params: { id: 'contribute-data' } },
   { name: 'Join the Community', route: 'get_involved_detail', params: { id: 'join-community' } },
-  { name: 'App Gallery', route: 'get_involved_detail', params: { id: 'apps' } }
+  { name: 'Develop Your App', route: 'get_involved_detail', params: { id: 'develop-your-app' } }
 ];
 
 class Footer extends React.Component {
@@ -121,7 +122,7 @@ class Footer extends React.Component {
                       className="c-button -secondary join-us-button"
                       onClick={() => this.handleToggleShareModal(true)}
                     >
-                      Subscribe to our Newsletter
+                      Subscribe to our newsletter
                       <Modal
                         isOpen={this.state.showNewsletterModal}
                         className="-medium"
@@ -139,16 +140,6 @@ class Footer extends React.Component {
                       rel="noopener noreferrer"
                     >
                       <Icon name="icon-twitter" />
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      className="c-button -secondary"
-                      href="https://www.facebook.com/ResourceWatch/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <Icon name="icon-facebook" />
                     </a>
                   </li>
                 </ul>

--- a/layout/get-involved-detail/get-involved-detail-actions.js
+++ b/layout/get-involved-detail/get-involved-detail-actions.js
@@ -4,13 +4,14 @@ import { createAction, createThunkAction } from 'redux-tools';
 
 // The pages have chnged titles and lookup required to match to old slug
 const lookup = {
-  'suggest-a-story': 'submit-an-insight',
+  'suggest-a-story': 'suggest-a-story',
   'contribute-data': 'contribute-data',
   'join-the-community': 'join-community',
   'develop-your-app': 'develop-app',
   'app-review-policy': 'app-review-policy',
   'partner-application-guidelines': 'partner-application-guidelines',
-  'data-policy': 'data-policy'
+  'data-policy': 'data-policy',
+  'apps': 'app-gallery'
 };
 
 // Actions

--- a/layout/get-involved/get-involved-component.js
+++ b/layout/get-involved/get-involved-component.js
@@ -111,12 +111,12 @@ class GetInvolvedComponent extends React.PureComponent {
               <div className="column small-12">
                 <Banner className="-text-center" bgImage="/static/images/backgrounds/partners-02@2x.jpg">
                   <p className="-claim">
-                    Let’s build a more sustainable <br />
-                    world together
+                    Questions, comments, or feedback? <br />
+                    Help us improve Resource Watch.
                   </p>
-                  <button className="c-button -primary -alt">
-                    Contact us
-                  </button>
+                  <Link to="about_contact-us">
+                    <a className="c-button -alt -primary">Contact us</a>
+                  </Link>
                 </Banner>
               </div>
             </div>

--- a/layout/get-involved/get-involved-default-state.js
+++ b/layout/get-involved/get-involved-default-state.js
@@ -5,34 +5,6 @@ export default {
   cards: [
     // TODO: No action or reducer for cards
     {
-      id: 'insights',
-      title: 'Suggest a story',
-      intro: ['Have you uncovered an interesting connection in the data we should tell a story about?'],
-      buttons: [
-        {
-          text: 'Suggest a story',
-          route: 'get_involved_detail',
-          params: { id: 'suggest-a-story' },
-          className: '-primary -alt'
-        }
-      ],
-      className: 'insights'
-    },
-    {
-      id: 'data',
-      title: 'Contribute data',
-      intro: ['Extend the reach and impact of your datasets. Upload for private or public use, and see how many are using it.'],
-      buttons: [
-        {
-          text: 'Contribute data',
-          route: 'get_involved_detail',
-          params: { id: 'contribute-data' },
-          className: '-primary -alt'
-        }
-      ],
-      className: 'contribute'
-    },
-    {
       id: 'join',
       title: 'Join the community',
       intro: ['Resource Watch is an open platform for everyone to explore data and insights about our planet.'],
@@ -45,6 +17,34 @@ export default {
         }
       ],
       className: 'join'
+    },
+    {
+      id: 'data',
+      title: 'Contribute data',
+      intro: ['Extend the reach and impact of your data sets. Upload for private or public use, and see how many are using it.'],
+      buttons: [
+        {
+          text: 'Contribute data',
+          route: 'get_involved_detail',
+          params: { id: 'contribute-data' },
+          className: '-primary -alt'
+        }
+      ],
+      className: 'contribute'
+    },
+    {
+      id: 'insights',
+      title: 'Suggest a story',
+      intro: ['Have you uncovered an interesting connection in the data we should tell a story about?'],
+      buttons: [
+        {
+          text: 'Suggest a story',
+          route: 'get_involved_detail',
+          params: { id: 'suggest-a-story' },
+          className: '-primary -alt'
+        }
+      ],
+      className: 'insights'
     },
     {
       id: 'app',

--- a/layout/static-content/static-content-component.js
+++ b/layout/static-content/static-content-component.js
@@ -13,7 +13,9 @@ const StaticContentComponent = ({ content }) => {
         <div className="l-container">
           <div className="row align-center">
             <div className="column small-12 medium-8">
-              { renderHTML(content) }
+              <div className="c-terms">
+                { renderHTML(content) }
+              </div>
             </div>
           </div>
         </div>

--- a/layout/topics/topics-component.js
+++ b/layout/topics/topics-component.js
@@ -22,7 +22,9 @@ class TopicsComponent extends React.PureComponent {
               <div className="column small-12">
                 <div className="page-header-content">
                   <h1>Topics</h1>
-                  <p>Find facts and figures on people and the enviornment, or see the latest data on the world today.</p>
+                  <div className="page-header-info">
+                    <p>Find facts and figures on people and the enviornment, or see the latest data on the world today.</p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/layout/topics/topics-component.js
+++ b/layout/topics/topics-component.js
@@ -22,6 +22,7 @@ class TopicsComponent extends React.PureComponent {
               <div className="column small-12">
                 <div className="page-header-content">
                   <h1>Topics</h1>
+                  <p>Find facts and figures on people and the enviornment, or see the latest data on the world today.</p>
                 </div>
               </div>
             </div>

--- a/pages/app/About.js
+++ b/pages/app/About.js
@@ -67,8 +67,9 @@ class About extends Page {
         title:'More',
         description:'Learn what you can do with Resource Watch.',
         link: {
-          route: '/about/how-to',
+          route: 'about_howto',
           label: 'Learn more',
+          className: '-primary',
           external: false
         }
       }

--- a/pages/app/About.js
+++ b/pages/app/About.js
@@ -11,6 +11,7 @@ import { Link } from 'routes';
 import Page from 'layout/page';
 import Layout from 'layout/layout/layout-app';
 import Banner from 'components/app/common/Banner';
+import CardApp from 'components/app/common/CardApp';
 
 class About extends Page {
   static async getInitialProps(context) {
@@ -34,7 +35,77 @@ class About extends Page {
     const styles = {};
     if (data && data.photo) {
       styles.backgroundImage = `url(${process.env.STATIC_SERVER_URL}${data.photo.cover})`;
-    }
+    };
+    const userCards = [
+      {
+        id: 'government-staff',
+        title: 'Government Staff',
+        description: 'Use dashboards and alerts to monitor the conditions of the environment and its relevance to citizens.  Find reliable data to inform policies to advance your agenda.',
+      },
+      {
+        id: 'business-analysts',
+        title: 'Business Analysts',
+        description: 'Track and visualize business risks and opportunities across your global operations for multiple issues or pull data into your own systems for analysis.',
+      },
+      {
+        id:'journalists',
+        title:'Journalists',
+        description:'Find out what’s happening in the world right now and access trustworthy data to discover new insights and inform stories.',
+      },
+      {
+        id:'researchers',
+        title:'Researchers',
+        description:'Find robust data for your analysis or share your own data and insights with others who can act on them.',
+      },
+      {
+        id:'citizens',
+        title:'Citizens',
+        description:'Understand the issues affecting your community, identify sustainable options, and share your findings to inspire action and hold decision-makers accountable.',
+      },
+      {
+        id:'more',
+        title:'More',
+        description:'Learn what you can do with Resource Watch.',
+        link: {
+          route: '/about/how-to',
+          label: 'Learn more',
+          external: false
+        }
+      }
+    ];
+
+    const valuesCards = [
+      {
+        id: 'reliability',
+        title: 'Reliability',
+        description: 'Resource Watch data are curated by World Resources Institute’s independent, nonpartisan experts, drawing from the best peer-reviewed and authoritative sources on the issues that matter the most. Learn more about our data curation process.',
+        link: {
+            label: 'Data policy',
+            route: '/get-involved/data-policy',
+            className: '-primary'
+        }
+      },
+      {
+        id: 'openness',
+        title: 'Openness',
+        description: 'We are committed to making information accessible and usable. Whenever possible, our data are made publicly available under open licenses, and the Resource Watch platform is open source for others to use and build upon.',
+        link: {
+          label: 'Explore data',
+          route: 'explore',
+          className: '-primary'
+        }
+      },
+      {
+        id: 'community',
+        title: 'Community',
+        description: 'A sustainable future is only possible when we work together. Resource Watch is a global partnership of public, private, and civil society organizations, supported by a growing community of users, including you. Learn more about how you can help.',
+        link: {
+            label: 'Get involved',
+            route: 'get_involved',
+            className: '-primary'
+        }
+      }
+    ];
 
     return (
       <Layout
@@ -69,13 +140,82 @@ class About extends Page {
           </article>
         </section>
 
+
+          <article className="l-section -secondary">
+            <div className="l-container">
+              <div className="row align-center">
+                <div className="column small-12 medium-8">
+                  <h2 className="-text-center">What can I do with Resource Watch?</h2>
+                </div>
+              </div>
+              <div className="row">
+                {userCards.map(card => (
+                  <div key={card.id} className="column small-12 medium-6 large-4 c-card-column">
+                    <CardApp
+                      title={card.title}
+                      className="-compact"
+                      description={card.description}
+                      buttonType="primary"
+                        />
+                  </div>))}
+              </div>
+            </div>
+          </article>
+          <article className="l-section">
+            <div className="l-container">
+              <div className="row align-center">
+                <div className="column small-12">
+                  <h2 className="-text-center">Our values</h2>
+                </div>
+              </div>
+              <div className="row align-center">
+                {valuesCards.map(card => (
+                  <div key={card.id} className="column small-12 medium-6 large-4 c-card-column">
+                    <CardApp
+                      title={card.title}
+                      className="-compact"
+                      description={card.description}
+                      link={{ ...card.link }}
+                      buttonType="primary"
+                      />
+                  </div>))}
+              </div>
+            </div>
+          </article>
+          <article className="l-section -secondary">
+            <div className="l-container">
+              <div className="row align-center">
+                <div className="column small-12 medium-8">
+                  <h2 className="-text-center">Our supporters</h2>
+                  <p>
+                    Resource Watch is hosted and convened by the World Resources Institute (WRI). Financial support for Resource Watch comes from a generous anchor grant from DOB Ecology and a start-up grant from The Tilia Fund. Resource Watch has supporting grants from Skoll Global Threats Fund and Bloomberg Philanthropies, as well as institutional grants to the World Resources Institute from the Ministry of Foreign Affairs of the Netherlands, the Royal Danish Ministry of Foreign Affairs, and the Swedish International Development Cooperation Agency.
+                  </p>
+                  <p>
+                    Resource Watch would not be possible without the generous contributions of our partners.
+                  </p>
+                  <div className="-text-center">
+                    <Link to="about_partners">
+                      <a className="c-button -primary">Partners</a>
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </article>
+
+
         <aside className="l-postcontent">
           <div className="l-container">
             <div className="row align-center">
               <div className="column small-12">
                 <Banner className="-text-center" bgImage="/static/images/backgrounds/partners-02@2x.jpg">
-                  <p className="-claim">Let’s build a more <br /> sustainable world together.</p>
-                  <Link to="about_partners"><a className="c-button -alt -primary">Partners</a></Link>
+                  <p className="-claim">
+                    Questions, comments, or feedback? <br />
+                    Help us strengthen Resource Watch.
+                  </p>
+                  <Link to="about_contact-us">
+                    <a className="c-button -alt -primary">Contact us</a>
+                  </Link>
                 </Banner>
               </div>
             </div>

--- a/pages/app/ContactUs.js
+++ b/pages/app/ContactUs.js
@@ -10,7 +10,7 @@ import Layout from 'layout/layout/layout-app';
 import Banner from 'components/app/common/Banner';
 import Breadcrumbs from 'components/ui/Breadcrumbs';
 import ContactUsForm from 'components/app/common/ContactUs/ContactUsForm';
-
+import { Link } from 'routes';
 
 class ContactUs extends Page {
   render() {
@@ -36,40 +36,25 @@ class ContactUs extends Page {
             </div>
           </div>
         </div>
-
-        <section className="l-section -secondary">
-          <header className="l-section-header">
-            <div className="l-container">
-              <div className="row">
-                <div className="column small-12">
-                  <h2>Let’s build a more sustainable world together.</h2>
-                  <p className="-columnize">
-                    Resource Watch connects leading technology companies and
-                    data providers dedicated to broadening access to timely,
-                    relevant natural resource information. This powerful
-                    partnership brings together trusted data sets from remote
-                    sensing systems, peer-reviewed research, and other
-                    reputable sources, making new data streams actionable for
-                    the first time. Open-access web and mobile apps deliver
-                    insights and information to decision-makers and passionate
-                    citizens working to make a difference.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </header>
-        </section>
-
         <section className="l-section">
           <div className="l-container">
-            <div className="row">
-              <div className="column small-12">
-                <h2 className="-text-center">Contact us</h2>
+            <div className="row align-center">
+              <div className="column small-12 medium-8">
+                <h2>
+                  Questions, comments, or feedback?
+                  Help us strengthen Resource Watch.
+                </h2>
               </div>
             </div>
             <div className="row align-center">
-              <div className="column small-12 medium-6">
+              <div className="column small-12 medium-8 large-6">
                 <ContactUsForm />
+              </div>
+            </div>
+            <div className="row align-center">
+              <div className="column small-12 medium-8">
+                <h2>Media inquiries</h2>
+                <p>Please contact Rose Gilroy at <a href="mailto://rose.gilroy@wri.org">rose.gilroy@wri.org</a> or Lauren Zelin at <a href="mailto://lzelin@wri.org">lzelin@wri.org</a> for media inquiries.</p>
               </div>
             </div>
           </div>
@@ -81,11 +66,11 @@ class ContactUs extends Page {
               <div className="column small-12">
                 <Banner className="-text-center" bgImage={'/static/images/backgrounds/partners-02@2x.jpg'}>
                   <p className="-claim">
-                    See yourself as part<br /> of this team?
+                    Let&rsquo;s build a more sustainable<br /> world together.
                   </p>
-                  <button className="c-btn -primary -alt">
-                    Get in touch
-                  </button>
+                  <Link to="about_partners">
+                    <a className="c-btn -primary">Partners</a>
+                  </Link>
                 </Banner>
               </div>
             </div>

--- a/pages/app/Faqs.js
+++ b/pages/app/Faqs.js
@@ -6,6 +6,7 @@ import sortBy from 'lodash/sortBy';
 import withRedux from 'next-redux-wrapper';
 import { initStore } from 'store';
 import { getFaqs } from 'redactions/admin/faqs';
+import { Link } from 'routes';
 
 // Components
 import Page from 'layout/page';
@@ -51,40 +52,11 @@ class Faqs extends Page {
           </div>
         </div>
 
-        <section className="l-section -secondary">
-          <header className="l-section-header">
-            <div className="l-container">
-              <div className="row">
-                <div className="column small-12">
-                  <h2>Let’s build a more sustainable world together.</h2>
-                  <p className="-columnize">
-                    Resource Watch connects leading technology companies and
-                    data providers dedicated to broadening access to timely,
-                    relevant natural resource information. This powerful
-                    partnership brings together trusted data sets from remote
-                    sensing systems, peer-reviewed research, and other
-                    reputable sources, making new data streams actionable for
-                    the first time. Open-access web and mobile apps deliver
-                    insights and information to decision-makers and passionate
-                    citizens working to make a difference.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </header>
-        </section>
-
         <section className="l-section">
           <div className="l-container">
-            <div className="row">
-              <div className="column small-12">
-                <h2 className="-text-center">FAQs</h2>
-              </div>
-            </div>
-
             {orderedFaqs.map(faq =>
-              (<div className="row" key={faq.id}>
-                <div className="column small-12">
+              (<div className="row align-center" key={faq.id}>
+                <div className="column small-12 medium-8">
                   <FaqBlock item={faq} />
                 </div>
               </div>)
@@ -98,11 +70,12 @@ class Faqs extends Page {
               <div className="column small-12">
                 <Banner className="-text-center" bgImage={'/static/images/backgrounds/partners-02@2x.jpg'}>
                   <p className="-claim">
-                    See yourself as part<br /> of this team?
+                    Questions, comments, or feedback? <br />
+                    Help us improve Resource Watch.
                   </p>
-                  <button className="c-btn -primary -alt">
-                    Get in touch
-                  </button>
+                  <Link to="about_contact-us">
+                    <a className="c-button -alt -primary">Contact us</a>
+                  </Link>
                 </Banner>
               </div>
             </div>

--- a/pages/app/Home.js
+++ b/pages/app/Home.js
@@ -24,12 +24,26 @@ import NewsletterModal from 'components/modal/newsletter-modal';
 
 const exploreCards = [
   {
+    tag: 'Planet Pulse',
+    title: 'View near-real-time data on the planet',
+    intro: '',
+    buttons: [
+      {
+        text: 'Launch Planet Pulse',
+        path: '/data/pulse',
+        anchor: true,
+        className: '-primary'
+      }
+    ],
+    background: 'url(/static/images/homepage/home-data-bg4.png) 67% center'
+  },
+  {
     tag: 'Explore Data',
-    title: 'Check data on the map',
+    title: 'Access data on the map',
     intro: 'Identify patterns between data sets on the map or download data for analysis.',
     buttons: [
       {
-        text: 'Explore datasets',
+        text: 'Explore data',
         path: 'explore',
         className: '-primary'
       }
@@ -39,7 +53,7 @@ const exploreCards = [
   {
     tag: 'Dashboards',
     title: 'Create and share visualizations',
-    intro: 'Create and share custom visualizations using out collection of datasets related to natural resources.',
+    intro: 'Create overlays, share visualizations, and subscribe to updates on your favorite issues.',
     buttons: [
       {
         text: 'Create a dashboard',
@@ -50,32 +64,18 @@ const exploreCards = [
     background: 'url(/static/images/homepage/home-data-bg2.png)'
   },
   {
-    tag: 'Subscriptions',
-    title: 'Track indicators over time',
-    intro: 'Subscribe to near-real-time updates in key datasets in the areas you care about.',
+    tag: 'Alerts',
+    title: 'Track data in near-real-time',
+    intro: 'Get updates on world events as they unfold.',
     buttons: [
       {
-        text: 'Sign up for Alerts',
+        text: 'Sign up for alerts',
         path: '/myrw/areas',
         anchor: true,
         className: '-primary'
       }
     ],
     background: 'url(/static/images/homepage/home-data-bg3.png) 67% center'
-  },
-  {
-    tag: 'Planet Pulse',
-    title: 'Take the pulse of our planet',
-    intro: 'A global snapshot of key impacts on livelihoods from the latest data.',
-    buttons: [
-      {
-        text: 'Launch Planet Pulse',
-        path: '/data/pulse',
-        anchor: true,
-        className: '-primary'
-      }
-    ],
-    background: 'url(/static/images/homepage/home-data-bg4.png) 67% center'
   }
 ];
 
@@ -181,7 +181,7 @@ class Home extends Page {
     return (
       <Layout
         title="Resource Watch"
-        description="Resource Watch description"
+        description="Monitoring the Planet’s Pulse"
         url={this.props.url}
         user={this.props.user}
         className="page-home"
@@ -201,13 +201,13 @@ class Home extends Page {
           </div>
           <div className="video-text">
             <div>
-              <h1>Monitoring the Planet&apos;s Pulse</h1>
-              <p>Resource Watch provides timely and trusted data to monitor the Earth for a sustainable future</p>
+              <h1>Monitoring the Planet&rsquo;s Pulse</h1>
+              <p>Resource Watch provides trusted and timely data for a sustainable future.</p>
               <Link route="explore">
                 <a
                   className="c-button -secondary"
                 >
-                  Explore Data
+                  Explore data
                 </a>
               </Link>
             </div>
@@ -219,8 +219,8 @@ class Home extends Page {
             <header>
               <div className="row">
                 <div className="column small-12 medium-8">
-                  <h2>Discover Stories</h2>
-                  <p>Read the latest  analysis from our community or submit your own original story</p>
+                  <h2>Latest stories</h2>
+                  <p>Discover data insights on the Resource Watch blog.</p>
                 </div>
               </div>
             </header>
@@ -247,7 +247,7 @@ class Home extends Page {
                       className="c-button -secondary join-us-button"
                       onClick={() => this.handleToggleShareModal(true)}
                     >
-                      Subscribe to our Newsletter
+                      Subscribe to our newsletter
                       <Modal
                         isOpen={this.state.showNewsletterModal}
                         className="-medium"
@@ -257,7 +257,7 @@ class Home extends Page {
                       </Modal>
                     </button>
                     <Link route="insights">
-                      <a className="c-btn -primary">More Stories</a>
+                      <a className="c-btn -primary">More stories</a>
                     </Link>
                   </div>
                 </div>
@@ -272,7 +272,10 @@ class Home extends Page {
               <div className="row">
                 <div className="column small-12 medium-8">
                   <h2>Topics</h2>
-                  <p>Find facts and figures on people and the enviornment, or see the latest data on the world today.</p>
+                  <p>
+                    Find facts and figures on people and the environment, <br/>
+                    or visualize the latest data on the world today.
+                  </p>
                 </div>
               </div>
             </header>
@@ -301,7 +304,7 @@ class Home extends Page {
               <div className="row">
                 <div className="column small-12 medium-8">
                   <h2>Dive into the data</h2>
-                  <p>Discover data, create visualizations, and subscribe to updates on key datasets.</p>
+                  <p>Create overlays, share visualizations, and subscribe to updates on your favorite issues.</p>
                 </div>
               </div>
             </header>
@@ -314,29 +317,27 @@ class Home extends Page {
           </div>
         </section>
 
+
         <Banner className="get-involved" bgImage={'/static/images/backgrounds/mod_getInvolved.jpg'}>
           <div className="l-container">
             <div className="l-row row">
-              <div className="column small-12 medium-6">
+              <div className="column small-12 medium-8">
                 <h2>Get involved</h2>
                 <p>
-                  We{'’'}ve brought together the best datasets related to natural resources,
-                  so you can find new insights, influence decisions and change the world.
-                  There{'’'}s a world of opportunity to take this futher. Here are
-                  some ideas to get you started.
+                  Use data to drive change in your community and around the world.
                 </p>
               </div>
             </div>
             <div className="buttons">
               <div className="l-row row">
                 <div className="column small-12 medium-3">
-                  <Link route="get_involved_detail" params={{ id: 'contribute-data', source: 'home' }}><a className="c-btn -b -alt -fullwidth">Contribute data</a></Link>
-                </div>
-                <div className="column small-12 medium-3">
                   <Link route="get_involved_detail" params={{ id: 'join-community', source: 'home' }}><a className="c-btn -b -alt -fullwidth">Join the community</a></Link>
                 </div>
                 <div className="column small-12 medium-3">
-                  <Link route="get_involved_detail" params={{ id: 'submit-an-insight', source: 'home' }}><a className="c-btn -b -alt -fullwidth">Submit a story</a></Link>
+                  <Link route="get_involved_detail" params={{ id: 'contribute-data', source: 'home' }}><a className="c-btn -b -alt -fullwidth">Contribute data</a></Link>
+                </div>
+                <div className="column small-12 medium-3">
+                  <Link route="get_involved_detail" params={{ id: 'submit-an-insight', source: 'home' }}><a className="c-btn -b -alt -fullwidth">Suggest a story</a></Link>
                 </div>
                 <div className="column small-12 medium-3">
                   <Link route="get_involved_detail" params={{ id: 'develop-app', source: 'home' }}><a className="c-btn -b -alt -fullwidth">Develop your app</a></Link>
@@ -345,6 +346,8 @@ class Home extends Page {
             </div>
           </div>
         </Banner>
+
+
 
       </Layout>
     );

--- a/pages/app/PartnerDetail.js
+++ b/pages/app/PartnerDetail.js
@@ -98,40 +98,50 @@ class PartnerDetail extends Page {
               </div>
             </div>
           </Banner>
-          <div className="l-container">
-            <div className="row  align-center">
-              <div className="column small-12 datasets-container">
-                <h3>{`Datasets by ${data.name}`}</h3>
-                <Spinner isLoading={loading} className="-light -relative" />
-                {list && list.length > 0 &&
-                  <DatasetList
-                    active={[]}
-                    list={list}
-                    mode="grid"
-                    showActions={false}
-                    onTagSelected={this.handleTagSelected}
-                  />
-                }
+          <section className="l-section">
+            <div className="l-container">
+              <div className="row align-center">
+                <div className="column small-12 medium-8">
+                  <p>{data.body}</p>
+                </div>
+              </div>
+              <div className="row align-center">
+                <div className="column small-12 datasets-container">
+                  <Spinner isLoading={loading} className="-light -relative" />
+                  {list && list.length > 0 &&
+                    <div>
+                      <h3>{`Datasets by ${data.name}`}</h3>
+                      <DatasetList
+                          active={[]}
+                          list={list}
+                          mode="grid"
+                          showActions={false}
+                          onTagSelected={this.handleTagSelected}
+                          />
+                    </div>
+                  }
+                </div>
               </div>
             </div>
-          </div>
-        </div>
+          </section>
 
-        <div className="l-container learn-more">
-          <div className="row align-center">
-            <div className="column small-12">
-              <Banner className="-text-center">
-                <p className="-claim">
-                  Important work,<br /> beautifully crafted
-                </p>
-                <a
-                  className="c-btn -primary -filled"
-                  href={data.website}
-                  target="_blank"
-                >
-                  LEARN ABOUT OUR WORK
-                </a>
-              </Banner>
+          <div className="l-container learn-more">
+            <div className="row align-center">
+              <div className="column small-12">
+                <Banner className="-text-center">
+                  <p className="-claim">
+                    Learn more about <br />
+                    {data.name}
+                  </p>
+                  <a
+                    className="c-btn -primary -alt"
+                    href={data.website}
+                    target="_blank"
+                    >
+                    Our work
+                  </a>
+                </Banner>
+              </div>
             </div>
           </div>
         </div>

--- a/pages/app/Partners.js
+++ b/pages/app/Partners.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'routes';
 
 // Redux
 import withRedux from 'next-redux-wrapper';
@@ -53,8 +54,8 @@ class Partners extends Page {
               <div className="row">
                 <div className="column small-12">
                   <h2>Let’s build a more sustainable world together.</h2>
-                  <p className="-columnize">
-                    Resource Watch connects leading technology companies and data providers dedicated to broadening access to timely, relevant natural resource information. This powerful partnership brings together trusted data sets from remote sensing systems, peer-reviewed research, and other reputable sources, making new data streams actionable for the first time. Open-access web and mobile apps deliver insights and information to decision-makers and passionate citizens working to make a difference.
+                  <p>
+                    We couldn’t do this on our own. Resource Watch is a global partnership of public, private, and civil society organizations convened by World Resources Institute to provide trusted and timely data for a sustainable future.
                   </p>
                 </div>
               </div>
@@ -100,7 +101,10 @@ class Partners extends Page {
           <div className="l-container">
             <div className="row">
               <div className="column small-12">
-                <h2 className="-text-center">Partners</h2>
+                <h2 className="-text-center">Data providers</h2>
+                <p>
+                  The following data providers have been active in helping us access and interpret data that would otherwise not be available on Resource Watch. We also thank the many governments and institutions, not listed here, that have made their data widely open and accessible.
+                </p>
               </div>
             </div>
             <div className="row">
@@ -113,17 +117,50 @@ class Partners extends Page {
           </div>
         </section>
 
+        <aside>
+          <div className="l-container">
+            <div className="row align-center">
+              <div className="column small-12 medium-8">
+                <div className="c-terms">
+              <h2 className="-text-center">About the partnership</h2>
+              <p>Partners support Resource Watch by</p>
+              <ul>
+                <li>
+                  <strong>Providing technical resources</strong> such as storage, computing, and technical expertise,
+                </li>
+                <li>
+                  <strong>Contributing data and insights</strong> on what’s happening around the world and how data can be used to drive action,
+                </li>
+                <li>
+                  <strong>Guiding system design</strong> to ensure Resource Watch is useful to a wide variety of users,
+                </li>
+                <li>
+                  <strong>Supporting the use of Resource Watch</strong> in specific communities who can utilize the data to advance a more sustainable future,
+                </li>
+                <li>
+                  <strong>Building on Resource Watch</strong> to create custom products and applications, and
+                </li>
+                <li>
+                  <strong>Providing financial support</strong> to enable Resource Watch to stay up to date and provide free information to people around the globe.
+                </li>
+              </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </aside>
         <aside className="l-postcontent">
           <div className="l-container">
             <div className="row align-center">
               <div className="column small-12">
                 <Banner className="-text-center" bgImage={'/static/images/backgrounds/partners-02@2x.jpg'}>
                   <p className="-claim">
-                    See yourself as part<br /> of this team?
+                    Questions, comments, or feedback? <br />
+                    Help us improve Resource Watch.
                   </p>
-                  <button className="c-btn -primary -alt">
-                    Get in touch
-                  </button>
+                  <Link to="/about/contact-us">
+                    <a className="c-button -alt -primary">Contact us</a>
+                  </Link>
                 </Banner>
               </div>
             </div>


### PR DESCRIPTION
## Overview
Here are a bunch of updates to static pages to bring them in line with the our [final text](http://drive.google.com/drive/u/0/folders/1vOUKEkkPZm-yh70zWgQTtL6ZNtRLcd1-) and structure.

Other minor updates:
 - Update routes for get-involved pages that changed when the titles/slugs were edited.
 - Update footer links; remove FB (we've decided not to use the FB account but focus on Twitter)
 - Update post-content banner for most pages
 - Partner detail page now shows description and only shows datasets header if there are datasets
 - Add success popup and topics to contact-us

Comments:
 - Styles on About page could be improved

## Testing instructions
Visit pages and test links

## Pivotal task
NA
