### PR TITLE
Feature/responsive modals

### DIFF
--- a/css/components/modal/share-modal.scss
+++ b/css/components/modal/share-modal.scss
@@ -2,23 +2,41 @@
   .share-input-container {
     position: relative;
     display: flex;
+    flex-direction: column;
     justify-content: space-between;
-    align-items: center;
-    border: 1px solid $border-color-1;
-    border-radius: 4px;
-    padding: 0 15px;
+    align-items: flex-start;
 
-    > * {
-      margin: 0 0 0 10px;
+    @media screen and (min-width: map-get($breakpoints, medium)) {
+      flex-direction: row;
+      align-items: center;
+      padding: 0 15px;
+      border: 1px solid $border-color-1;
+      border-radius: 4px;
 
-      &:first-child { margin: 0 }
+      > * {
+        margin: 0 0 0 10px;
+
+        &:first-child { margin: 0 }
+      }
     }
+
 
     .share-input {
       border: none;
       flex-grow: 1;
       height: 45px;
       max-width: 300px;
+      border: 1px solid $border-color-1;
+      border-radius: 4px;
+      width: 100%;
+      padding: 0 15px;
+      margin-bottom: 10px;
+
+      @media screen and (min-width: map-get($breakpoints, medium)) {
+        border: 0;
+        margin-bottom: 0;
+        padding: 0;
+      }
     }
 
     .share-buttons {

--- a/css/components/modal/share-modal.scss
+++ b/css/components/modal/share-modal.scss
@@ -26,6 +26,7 @@
       flex-grow: 1;
       height: 45px;
       max-width: 300px;
+      min-width: 250px;
       border: 1px solid $border-color-1;
       border-radius: 4px;
       width: 100%;

--- a/css/components/ui/modal.scss
+++ b/css/components/ui/modal.scss
@@ -53,9 +53,13 @@
     max-height: 85vh; // Be careful with iOS devices
     min-height: 150px;
     overflow: auto;
-    padding: $space-1 * 9;
+    padding: $space-1 * 3;
     -webkit-overflow-scrolling: touch;
     box-shadow: 0 7px 15px 0 rgba(0, 0, 0, 0.15);
+
+    @media screen and (min-width: map-get($breakpoints, medium)) {
+      padding: $space-1 * 9;
+    }
   }
 
   .modal-close {
@@ -93,7 +97,11 @@
     }
 
     .modal-content {
-      padding: ($space-1 * 8);
+      padding: ($space-1 * 3);
+
+      @media screen and (min-width: map-get($breakpoints, medium)) {
+        padding: $space-1 * 8;
+      }
     }
 
     .modal-close {

--- a/css/components/ui/modal2.scss
+++ b/css/components/ui/modal2.scss
@@ -16,6 +16,7 @@
   z-index: 100000; // Just to be sure that is over all the content
 
   @media screen and (min-width: map-get($breakpoints, medium)) {
+    width: calc(100% - 50px);
     padding: 20px 0 40px;
   }
 }

--- a/css/components/ui/modal2.scss
+++ b/css/components/ui/modal2.scss
@@ -33,9 +33,13 @@
     max-height: 85vh; // Be careful with iOS devices
     min-height: 150px;
     overflow: auto;
-    padding: $space-1 * 6;
+    padding: $space-1 * 3;
     -webkit-overflow-scrolling: touch;
     box-shadow: $thick-shadow;
+
+    @media screen and (min-width: map-get($breakpoints, medium)) {
+      padding: $space-1 * 6;
+    }
   }
 
   .modal-close {

--- a/css/components/ui/modal2.scss
+++ b/css/components/ui/modal2.scss
@@ -16,7 +16,6 @@
   z-index: 100000; // Just to be sure that is over all the content
 
   @media screen and (min-width: map-get($breakpoints, medium)) {
-    width: calc(100% - 50px);
     padding: 20px 0 40px;
   }
 }
@@ -38,6 +37,10 @@
   z-index: 1;
   max-width: $max-width-modal;
 
+  @media screen and (min-width: map-get($breakpoints, medium)) {
+    width: calc(100% - 50px);
+  }
+  
   .modal-content {
     position: relative;
     background: white;

--- a/css/components/ui/modal2.scss
+++ b/css/components/ui/modal2.scss
@@ -1,53 +1,63 @@
 .c-modal2-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background-color: rgba(17, 55, 80, 0.4);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: rgba(71, 44, 184, 0.1) 0px 5px 15px 0px;
+  overflow: auto;
   background: rgba($color-black, .5);
   transition: all $animation-time $ease-in-sine;
   z-index: 100000; // Just to be sure that is over all the content
-  visibility: visible;
-  opacity: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+
+  @media screen and (min-width: map-get($breakpoints, medium)) {
+    padding: 20px 0 40px;
+  }
 }
 
 .c-modal2 {
   transition: transform $animation-time-2 $ease-out-cubic;
   transform: translateY(-15px);
-  display: flex;
   position: relative;
-  width: calc(100% - 50px);
-  max-width: $max-width-modal;
-  background: white;
-  box-shadow: 0 1px 1px rgba(0,0,0,.15);
-  z-index: 1;
+  top: auto;
+  left: auto;
+  right: auto;
+  bottom: auto;
+  border: none;
+  overflow: auto;
+  border-radius: 0px;
   outline: none;
-  border-radius: 4px;
+  padding: 0px;
+  margin: auto;
+  z-index: 1;
+  max-width: $max-width-modal;
 
   .modal-content {
     position: relative;
+    background: white;
     width: 100%;
-    max-height: 85vh; // Be careful with iOS devices
     min-height: 150px;
-    overflow: auto;
     padding: $space-1 * 3;
     -webkit-overflow-scrolling: touch;
     box-shadow: $thick-shadow;
 
     @media screen and (min-width: map-get($breakpoints, medium)) {
       padding: $space-1 * 6;
+      margin-top: 30px;
+      border-radius: 4px;
     }
   }
 
   .modal-close {
-    fill: $color-white;
     display: block;
     position: absolute;
-    bottom: 100%;
-    right: 0;
+    top: 10px;
+    right: 10px;
     width: 30px;
     height: 30px;
     padding: 0;
@@ -55,6 +65,12 @@
     background-color: transparent;
     cursor: pointer;
     z-index: 2; /* Otherwise, it won't be reachable */
+
+    @media screen and (min-width: map-get($breakpoints, medium)) {
+      fill: $color-white;
+      top: 0;
+      right: 0;
+    }
 
     &:hover {
       svg { fill: $color-primary; }


### PR DESCRIPTION
## Overview
There are two parts to this PR:
1. Update the parent modal component styles to handle responsive screen sizes. This covers:
- Content larger than 100% screen height, in which case the modal overlay becomes scrollable, maintaining a full page modal content.
- The close icon is then contained within the modal to allow full page modal controls.

2. The share input component was not responsive. Now the social buttons and copy link appear beneath the input on small screens for better access.

## Pivotal task
https://www.pivotaltracker.com/story/show/155221080