### PR TITLE
Splash coral: use grey as background on load

### DIFF
--- a/css/components/app/pages/splash_detail.scss
+++ b/css/components/app/pages/splash_detail.scss
@@ -215,7 +215,7 @@
   .panorama {
     height: 100%;
     width: 100%;
-    background-color: $light-grey;
+    background-color: $charcoal-grey;
 
     .menu-container {
       display: flex;

--- a/css/components/app/pages/splash_detail.scss
+++ b/css/components/app/pages/splash_detail.scss
@@ -1,6 +1,7 @@
 .p-splash-detail {
   width: 100%;
   height: 100vh;
+  background-color: $light-grey;
 
   &.--mobile {
     display: flex;
@@ -214,6 +215,7 @@
   .panorama {
     height: 100%;
     width: 100%;
+    background-color: $light-grey;
 
     .menu-container {
       display: flex;

--- a/pages/app/SplashDetail.js
+++ b/pages/app/SplashDetail.js
@@ -355,7 +355,7 @@ class SplashDetail extends Page {
                 }
                 { /* 360-degree image */ }
                 {!earthMode &&
-                  <a-sky id="panorama-sky" src={skyImage} color="#CACCD0" />
+                  <a-sky id="panorama-sky" src={skyImage} color="#393f44" />
                 }
                 {earthMode &&
                   <a-sky id="panorama-sky" src="../../static/images/splash/earthExperiment.jpg" />

--- a/pages/app/SplashDetail.js
+++ b/pages/app/SplashDetail.js
@@ -36,7 +36,7 @@ class SplashDetail extends Page {
     const earthMode = props.url.query.earthMode;
 
     this.state = {
-      skyLoading: false,
+      skyLoading: true,
       panorama,
       selectedPanorama,
       soundActivated: false,
@@ -353,10 +353,9 @@ class SplashDetail extends Page {
                     }
                   </a-assets>
                 }
-
                 { /* 360-degree image */ }
                 {!earthMode &&
-                  <a-sky id="panorama-sky" src={skyImage} />
+                  <a-sky id="panorama-sky" src={skyImage} color="#CACCD0" />
                 }
                 {earthMode &&
                   <a-sky id="panorama-sky" src="../../static/images/splash/earthExperiment.jpg" />

--- a/pages/app/SplashDetail.js
+++ b/pages/app/SplashDetail.js
@@ -354,8 +354,11 @@ class SplashDetail extends Page {
                   </a-assets>
                 }
                 { /* 360-degree image */ }
-                {!earthMode &&
+                {!earthMode && skyLoading &&
                   <a-sky id="panorama-sky" src={skyImage} color="#393f44" />
+                }
+                {!earthMode && !skyLoading &&
+                  <a-sky id="panorama-sky" src={skyImage}/>
                 }
                 {earthMode &&
                   <a-sky id="panorama-sky" src="../../static/images/splash/earthExperiment.jpg" />


### PR DESCRIPTION
![screen shot 2018-04-02 at 3 54 38 pm](https://user-images.githubusercontent.com/545342/38198737-434e57ae-368e-11e8-92c6-1fd77a8ee479.png)

## Overview
This PR adds a grey background while the 360 images are loaded

## [Pivotal task](https://www.pivotaltracker.com/story/show/156431966)