### PR TITLE
Remove 'and' from Food and Agriculture links in header and footer

### DIFF
--- a/layout/footer/footer-component.js
+++ b/layout/footer/footer-component.js
@@ -23,7 +23,7 @@ const topics = [
   { name: 'Cities', route: 'topics_detail', params: { id: 'cities' } },
   { name: 'Climate', route: 'topics_detail', params: { id: 'climate' } },
   { name: 'Energy', route: 'topics_detail', params: { id: 'energy' } },
-  { name: 'Food and Agriculture', route: 'topics_detail', params: { id: 'food-and-agriculture' } },
+  { name: 'Food and Agriculture', route: 'topics_detail', params: { id: 'food-agriculture' } },
   { name: 'Forests', route: 'topics_detail', params: { id: 'forests' } },
   { name: 'Oceans', route: 'topics_detail', params: { id: 'oceans' } },
   { name: 'Society', route: 'topics_detail', params: { id: 'society' } },

--- a/layout/header/header-default-state.js
+++ b/layout/header/header-default-state.js
@@ -31,7 +31,7 @@ export default {
         { label: 'Climate', route: 'topics_detail', params: { id: 'climate' } },
         { label: 'Commerce', route: 'topics_detail', params: { id: 'commerce' } },
         { label: 'Energy', route: 'topics_detail', params: { id: 'energy' } },
-        { label: 'Food and Agriculture', route: 'topics_detail', params: { id: 'food-and-agriculture' } },
+        { label: 'Food and Agriculture', route: 'topics_detail', params: { id: 'food-agriculture' } },
         { label: 'Forests', route: 'topics_detail', params: { id: 'forests' } },
         { label: 'Water', route: 'topics_detail', params: { id: 'water' } }
       ]


### PR DESCRIPTION
Remove the '-and-' from the header and footer links to the topic page.