### PR TITLE
clickable cards use standard hover styles

### DIFF
--- a/css/components/app/pages/home.scss
+++ b/css/components/app/pages/home.scss
@@ -87,11 +87,31 @@
       bottom: 0;
       right: 0;
       background-color: rgba(0, 0, 0, .7);
+      border-radius: 4px;
     }
 
     div {
       z-index: 1;
     };
+
+    h3 {
+      font-weight: 600;
+      font-size: 20px;
+    }
+
+    h4 {
+      font-weight: 600;
+      font-size: 11px;
+      text-transform: uppercase;
+    }
+
+    a:hover {
+      text-decoration: none;
+    }
+
+    .source-name a:hover {
+      text-decoration: underline;
+    }
   }
 
   .dual {

--- a/css/components/topics/topics-thumbnail-list.scss
+++ b/css/components/topics/topics-thumbnail-list.scss
@@ -14,6 +14,7 @@
     background-position: center center;
     outline: none;
     padding: 0;
+    transition: all .3s;
 
     &:nth-of-type(6n) {
       margin-right: 0;
@@ -47,12 +48,13 @@
     }
 
     &:hover {
-      background-color: transparent;
-      box-shadow: 0 0 0 1px $color-secondary;
+      box-shadow: 0 20px 30px rgba($black, .2);
+      transform: translateY(-4px);
+      cursor: pointer;
 
-      .content {
-        background-color: rgba($color-secondary, .25);
-      }
+      // .content {
+      //   background-color: rgba($color-secondary, .25);
+      // }
     }
 
     &.-active {

--- a/css/components/topics/topics-thumbnail-list.scss
+++ b/css/components/topics/topics-thumbnail-list.scss
@@ -51,10 +51,6 @@
       box-shadow: 0 20px 30px rgba($black, .2);
       transform: translateY(-4px);
       cursor: pointer;
-
-      // .content {
-      //   background-color: rgba($color-secondary, .25);
-      // }
     }
 
     &.-active {

--- a/pages/app/Home.js
+++ b/pages/app/Home.js
@@ -129,7 +129,7 @@ class Home extends Page {
     return exploreCards.map(c =>
       (<div key={`explore-card-${c.title}`} className="column small-12 medium-6">
         <CardStatic
-          className="-alt"
+          className="-alt -clickable"
           background={c.background}
           clickable
           route={c.buttons[0].path}


### PR DESCRIPTION
Addresses issues from this task: https://www.pivotaltracker.com/story/show/156273102

Update all cards in the home page that are fully clickable to use the box shadow and displacement hover effect, removing old hover effect. 

Update styles on the Stories section title and subtitle.