### PR TITLE
Map info window UI updates

### DIFF
--- a/components/ui/map/Map.js
+++ b/components/ui/map/Map.js
@@ -213,7 +213,11 @@ class Map extends React.Component {
         window.document.createElement('div')
       );
 
-      this.popup = this.popup || L.popup();
+      this.popup = this.popup || L.popup({
+        maxWidth: 400,
+        minWidth: 240
+      });
+
       this.popup
         .setLatLng(nextProps.interactionLatLng)
         .setContent(currentContent)

--- a/components/ui/map/MapPopup.js
+++ b/components/ui/map/MapPopup.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import numeral from 'numeral';
 
+
 function _formatValue(item, data) {
   if (item.type === 'date' && item.format && data) {
     data = moment(data, item.format);
@@ -11,7 +12,14 @@ function _formatValue(item, data) {
     data = numeral(data).format(item.format);
   }
 
-  return `${item.prefix || ''}${data || '-'}${item.suffix || ''}`;
+  // If any html tags are present, remove them
+  // The html is already escaped so no injection can happen here
+  // Simply remove the tags for estetic reasons.
+  function removeHtmlTags(str) {
+    return str.replace(/<\/?[a-z]+>/gi, '');
+  }
+
+  return `${item.prefix || ''}${removeHtmlTags(data) || '-'}${item.suffix || ''}`;
 }
 
 function MapPopup({

--- a/css/components/map/map-popup.scss
+++ b/css/components/map/map-popup.scss
@@ -1,6 +1,5 @@
 .c-map-popup {
-  width: 240px;
-  // border: 1px solid #CCC;
+  width: 100%;
 
   .popup-header {
     border-bottom: 1px solid #CCC;
@@ -23,6 +22,8 @@
   }
 
   .popup-table {
+    width: inherit;
+
     .dt {
       padding: 2px;
       font-weight: $font-weight-bold;
@@ -30,7 +31,8 @@
     }
 
     .dd {
-      padding: 2px;
+      width: 60%; // Make sure data in tooltip always have 60% of the free space
+      padding: 0 0 0 10px;
       vertical-align: baseline;
     }
   }


### PR DESCRIPTION
## Overview
1. Add max width and min width for map info window to support long content & make data take up at-least 60% of the info window so thats the focus for the user. 

2. Remove any html tags passed as data to the info window, they are passed as strings not elements so simply remove them.

## Testing instructions
`/explore` and interact with any layer on the map, make sure to test long data content (a layer with description in the info window should work)

There should not be any html tags leaked as data to the info window, and the data should not overflow the info window

## Pivotal task
https://www.pivotaltracker.com/story/show/156152894

