### PR TITLE
FIX / partner state saved if entering another dataset

### DIFF
--- a/css/components/explore-detail/explore-detail-actions.scss
+++ b/css/components/explore-detail/explore-detail-actions.scss
@@ -24,8 +24,6 @@
 
     .partner-logo-container {
       display: flex;
-      justify-content: center;
-      align-items: center;
     }
   }
 }

--- a/layout/explore-detail/explore-detail-buttons/explore-detail-buttons-component.js
+++ b/layout/explore-detail/explore-detail-buttons/explore-detail-buttons-component.js
@@ -62,7 +62,7 @@ class ExploreDetailButtons extends PureComponent {
 
     return (
       <div className="c-explore-detail-actions">
-        {partner.logo &&
+        {partner && partner.logo &&
           <div className="partner-container">
             <div className="partner-text-container">
               Partner:

--- a/layout/explore-detail/explore-detail-reducers.js
+++ b/layout/explore-detail/explore-detail-reducers.js
@@ -18,10 +18,10 @@ export default {
   // PARTNER
   //
   [actions.setPartner]: (state, action) => {
-    const partner = {
+    const partner = state.partner ? {
       ...state.partner,
       data: action.payload
-    };
+    } : {};
 
     return ({ ...state, partner });
   },

--- a/pages/app/explore-detail/index.js
+++ b/pages/app/explore-detail/index.js
@@ -44,6 +44,9 @@ class ExploreDetailPage extends Page {
     const partnerConnection = PARTNERS_CONNECTIONS.find(pc => pc.datasetId === id);
     if (partnerConnection) {
       await store.dispatch(actions.fetchPartner({ id: partnerConnection.partnerId }));
+    } else {
+      // If we dont have a partner connection, make sure to remove the previous one if isset
+      store.dispatch(actions.setPartner(null));
     }
 
     // Set tools and load connected tools


### PR DESCRIPTION
## Overview
On explore detail, if partner was present in the sidebar and you go back to explore, enter another dataset, the previous partner was present. 

## Testing instructions
- Go to explore
- Enter a dataset with a partner
- Go back to explore
- Enter another one without a partner bound to it, or another partner

Expected result: It should not show the previous partner in the sidebar. 

## Pivotal task
https://www.pivotaltracker.com/story/show/155626424

