### PR TITLE
FIX / issues with partner pages not showing their corresponding datasets

### DIFF
--- a/components/datasets/list/component.js
+++ b/components/datasets/list/component.js
@@ -51,10 +51,11 @@ class DatasetList extends PureComponent {
                 >
                   <DatasetListItem
                     dataset={dataset}
-                    widget={dataset.widget.find(w => w.default)}
-                    layer={dataset.layer.find(l => l.default)}
+                    widget={dataset.widget ? dataset.widget.find(w => w.default) : null}
+                    layer={dataset.layer ? dataset.layer.find(l => l.default) : null}
                     metadata={dataset.metadata}
-                    vocabulary={dataset.vocabulary.find(v => v.name === 'knowledge_graph') || {}}
+                    vocabulary={dataset.vocabulary ?
+                      dataset.vocabulary.find(v => v.name === 'knowledge_graph') || {} : null}
                     mode={mode}
                     actions={actions}
                     tags={tags}

--- a/components/datasets/list/list-item/component.js
+++ b/components/datasets/list/list-item/component.js
@@ -27,7 +27,7 @@ class DatasetListItem extends React.Component {
     dataset: PropTypes.object,
     widget: PropTypes.object,
     layer: PropTypes.object,
-    metadata: PropTypes.array,
+    metadata: PropTypes.object,
     mode: PropTypes.string,
     user: PropTypes.object,
     tags: PropTypes.node,

--- a/components/datasets/list/list-item/component.js
+++ b/components/datasets/list/list-item/component.js
@@ -27,12 +27,29 @@ class DatasetListItem extends React.Component {
     dataset: PropTypes.object,
     widget: PropTypes.object,
     layer: PropTypes.object,
-    metadata: PropTypes.object,
+    metadata: PropTypes.array,
     mode: PropTypes.string,
     user: PropTypes.object,
     tags: PropTypes.node,
     actions: PropTypes.node
   };
+
+  /**
+   * HELPER
+   * - getTooltipContainer
+   * - fetchDatasets
+  */
+  getTooltipContainer() {
+    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+      if (document.querySelector('.sidebar-content')) {
+        return document.querySelector('.sidebar-content');
+      }
+
+      return document.body;
+    }
+
+    return null;
+  }
 
   /**
    * HELPER
@@ -70,23 +87,6 @@ class DatasetListItem extends React.Component {
         </Link>
       </div>
     );
-  }
-
-  /**
-   * HELPER
-   * - getTooltipContainer
-   * - fetchDatasets
-  */
-  getTooltipContainer() {
-    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-      if (document.querySelector('.sidebar-content')) {
-        return document.querySelector('.sidebar-content');
-      }
-
-      return document.body;
-    }
-
-    return null;
   }
 
   render() {

--- a/css/components/app/common/partner_block.scss
+++ b/css/components/app/common/partner_block.scss
@@ -9,6 +9,11 @@
     justify-content: center;
     margin-bottom: 35px;
     cursor: pointer;
+
+    img {
+      max-height: 100%;
+    }
+
   }
 
   .description {

--- a/pages/app/PartnerDetail.js
+++ b/pages/app/PartnerDetail.js
@@ -26,11 +26,7 @@ class PartnerDetail extends Page {
 
     return { props };
   }
-  /**
-  * COMPONENT LIFECYCLE
-  * - componentDidMount
-  * - componentWillReceiveProps
-  */
+
   componentDidMount() {
     const datasetIds = PARTNERS_CONNECTIONS
       .filter(p => p.partnerId === this.props.url.query.id).map(elem => elem.datasetId);
@@ -62,11 +58,24 @@ class PartnerDetail extends Page {
     const { loading, list } = datasets;
     const logoPath = data['white-logo'] ? data['white-logo'].medium : '';
     const coverPath = data.cover && data.cover.cover;
+
     const logo = data.website !== '' ?
-      (<a href={data.website} target="_blank" rel="noopener noreferrer">
-        <img src={`${process.env.STATIC_SERVER_URL}${logoPath}`} className="logo" title={data.name} alt={data.name} />
-      </a>) :
-      <img src={`${process.env.STATIC_SERVER_URL}${logoPath}`} className="logo" title={data.name} alt={data.name} />;
+      (
+        <a href={data.website} target="_blank" rel="noopener noreferrer">
+          <img
+            title={data.name}
+            alt={data.name}
+            className="logo"
+            src={`${process.env.STATIC_SERVER_URL}${logoPath}`}
+          />
+        </a>) :
+      (<img
+        title={data.name}
+        alt={data.name}
+        className="logo"
+        src={`${process.env.STATIC_SERVER_URL}${logoPath}`}
+      />);
+
     const backgroundImage = { 'background-image': `url(${process.env.STATIC_SERVER_URL}${coverPath})` };
 
     return (
@@ -108,16 +117,16 @@ class PartnerDetail extends Page {
               <div className="row align-center">
                 <div className="column small-12 datasets-container">
                   <Spinner isLoading={loading} className="-light -relative" />
-                  {list && list.length > 0 &&
+                  {list && list.length &&
                     <div>
                       <h3>{`Datasets by ${data.name}`}</h3>
                       <DatasetList
-                          active={[]}
-                          list={list}
-                          mode="grid"
-                          showActions={false}
-                          onTagSelected={this.handleTagSelected}
-                          />
+                        active={[]}
+                        list={list}
+                        mode="grid"
+                        showActions={false}
+                        onTagSelected={this.handleTagSelected}
+                      />
                     </div>
                   }
                 </div>
@@ -137,7 +146,7 @@ class PartnerDetail extends Page {
                     className="c-btn -primary -alt"
                     href={data.website}
                     target="_blank"
-                    >
+                  >
                     Our work
                   </a>
                 </Banner>

--- a/pages/app/PartnerDetail.js
+++ b/pages/app/PartnerDetail.js
@@ -117,7 +117,7 @@ class PartnerDetail extends Page {
               <div className="row align-center">
                 <div className="column small-12 datasets-container">
                   <Spinner isLoading={loading} className="-light -relative" />
-                  {list && list.length &&
+                  {list && list.length > 0 &&
                     <div>
                       <h3>{`Datasets by ${data.name}`}</h3>
                       <DatasetList

--- a/pages/app/Partners.js
+++ b/pages/app/Partners.js
@@ -72,10 +72,10 @@ class Partners extends Page {
             </div>
             <div className="row">
               {founders.map(p =>
-                (<div className="column small-12 medium-6" key={p.id}>
-                  <PartnerBlock item={p} />
-                </div>)
-              )}
+                (
+                  <div className="column small-12 medium-6" key={p.id}>
+                    <PartnerBlock item={p} />
+                  </div>))}
             </div>
           </div>
         </section>
@@ -89,10 +89,10 @@ class Partners extends Page {
             </div>
             <div className="row">
               {funders.map(p =>
-                (<div className="column small-12 medium-6" key={p.id}>
-                  <PartnerBlock item={p} />
-                </div>)
-              )}
+                (
+                  <div className="column small-12 medium-6" key={p.id}>
+                    <PartnerBlock item={p} />
+                  </div>))}
             </div>
           </div>
         </section>
@@ -109,10 +109,10 @@ class Partners extends Page {
             </div>
             <div className="row">
               {partners.map(p =>
-                (<div className="column small-12 medium-6" key={p.id}>
-                  <PartnerBlock item={p} />
-                </div>)
-              )}
+                (
+                  <div className="column small-12 medium-6" key={p.id}>
+                    <PartnerBlock item={p} />
+                  </div>))}
             </div>
           </div>
         </section>
@@ -122,28 +122,28 @@ class Partners extends Page {
             <div className="row align-center">
               <div className="column small-12 medium-8">
                 <div className="c-terms">
-              <h2 className="-text-center">About the partnership</h2>
-              <p>Partners support Resource Watch by</p>
-              <ul>
-                <li>
-                  <strong>Providing technical resources</strong> such as storage, computing, and technical expertise,
-                </li>
-                <li>
-                  <strong>Contributing data and insights</strong> on what’s happening around the world and how data can be used to drive action,
-                </li>
-                <li>
-                  <strong>Guiding system design</strong> to ensure Resource Watch is useful to a wide variety of users,
-                </li>
-                <li>
-                  <strong>Supporting the use of Resource Watch</strong> in specific communities who can utilize the data to advance a more sustainable future,
-                </li>
-                <li>
-                  <strong>Building on Resource Watch</strong> to create custom products and applications, and
-                </li>
-                <li>
-                  <strong>Providing financial support</strong> to enable Resource Watch to stay up to date and provide free information to people around the globe.
-                </li>
-              </ul>
+                  <h2 className="-text-center">About the partnership</h2>
+                  <p>Partners support Resource Watch by</p>
+                  <ul>
+                    <li>
+                      <strong>Providing technical resources</strong> such as storage, computing, and technical expertise,
+                    </li>
+                    <li>
+                      <strong>Contributing data and insights</strong> on what’s happening around the world and how data can be used to drive action,
+                    </li>
+                    <li>
+                      <strong>Guiding system design</strong> to ensure Resource Watch is useful to a wide variety of users,
+                    </li>
+                    <li>
+                      <strong>Supporting the use of Resource Watch</strong> in specific communities who can utilize the data to advance a more sustainable future,
+                    </li>
+                    <li>
+                      <strong>Building on Resource Watch</strong> to create custom products and applications, and
+                    </li>
+                    <li>
+                      <strong>Providing financial support</strong> to enable Resource Watch to stay up to date and provide free information to people around the globe.
+                    </li>
+                  </ul>
                 </div>
               </div>
             </div>

--- a/redactions/partnerDetail.js
+++ b/redactions/partnerDetail.js
@@ -1,5 +1,6 @@
 /* global config */
 import 'isomorphic-fetch';
+import WRISerializer from 'wri-json-api-serializer';
 
 // Services
 import DatasetService from 'services/DatasetService';
@@ -125,7 +126,7 @@ export function getDatasets(ids) {
       .then((response) => {
         dispatch({
           type: GET_DATASETS_SUCCESS,
-          payload: response
+          payload: WRISerializer({ data: response })
         });
       })
       .catch((error) => {

--- a/redactions/partnerDetail.js
+++ b/redactions/partnerDetail.js
@@ -118,7 +118,9 @@ export function getPartnerData(id) {
 }
 
 export function getDatasets(ids) {
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    const { common } = getState();
+
     // Waiting for fetch from server -> Dispatch loading
     dispatch({ type: GET_DATASETS_LOADING });
 
@@ -126,7 +128,7 @@ export function getDatasets(ids) {
       .then((response) => {
         dispatch({
           type: GET_DATASETS_SUCCESS,
-          payload: WRISerializer({ data: response })
+          payload: WRISerializer({ data: response, locale: common.locale })
         });
       })
       .catch((error) => {


### PR DESCRIPTION
## Overview
- implement **WRISerializer** for partnerDetails, so we have the correct data format for the datasets.
- Add condition checks for widget, layer so the page does not break if `undefined` values are returned, this can happen on load
- Tall partner images overflowed their containers, added max height to prevent that
- Some linting while at it

## Testing instructions
`http://localhost:9000/about/partners/unep` for example, make sure you see the corresponding datasets

## Pivotal task
https://www.pivotaltracker.com/story/show/156482929

