### PR TITLE
Feature/real blog posts on home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV GOGGLE_API_TOKEN_SHORTENER AIzaSyAf0lJIKq32sQwrfiOKx0T6yFWnonbfOso
 ENV BING_MAPS_API_KEY PPB0chXATYqlJ5t8oMPp~8SV9SIe2D0Ntc5sW3HExZA~AqTJgLkvvOdot-y1QukRox537t604Je0pxhygfcraTQGVWr7Ko9LwPoS7-MHW0qY
 ENV API_ENV production,preproduction
 ENV GOOGLE_ANALYTICS UA-67196006-1
+ENV BLOG_API_URL https://staging.resourcewatch.org/blog/wp-json/wp/v2
 
 RUN apt-get update && \
     apt-get install -y bash git build-essential \

--- a/Dockerfile-staging
+++ b/Dockerfile-staging
@@ -16,6 +16,7 @@ ENV GOGGLE_API_TOKEN_SHORTENER AIzaSyAf0lJIKq32sQwrfiOKx0T6yFWnonbfOso
 ENV BING_MAPS_API_KEY PPB0chXATYqlJ5t8oMPp~8SV9SIe2D0Ntc5sW3HExZA~AqTJgLkvvOdot-y1QukRox537t604Je0pxhygfcraTQGVWr7Ko9LwPoS7-MHW0qY
 ENV API_ENV production,preproduction
 ENV GOOGLE_ANALYTICS UA-67196006-1
+ENV BLOG_API_URL https://staging.resourcewatch.org/blog/wp-json/wp/v2
 
 RUN apt-get update && \
     apt-get install -y bash git build-essential \

--- a/components/blog/latest-posts/actions.js
+++ b/components/blog/latest-posts/actions.js
@@ -1,0 +1,47 @@
+import 'isomorphic-fetch';
+import { createAction, createThunkAction } from 'redux-tools';
+import moment from 'moment';
+import renderHTML from 'react-render-html';
+
+// Actions
+export const setBlogPostsLatest = createAction('BLOG_POSTS_LATEST_GET');
+export const setLoading = createAction('BLOG_POSTS_LATEST_LOADING');
+export const setError = createAction('BLOG_POSTS_LATEST_ERROR');
+export const setSelected = createAction('BLOG_POSTS_LATEST_SELECTED');
+
+// Async actions
+export const fetchBlogPostsLatest = createThunkAction('BLOG_POSTS_LATEST_FETCH_DATA', (payload = {}) => (dispatch) => {
+  dispatch(setLoading(true));
+  dispatch(setError(null));
+  return fetch(new Request(`${process.env.BLOG_API_URL}/posts?_embed`))
+    .then((response) => {
+      if (response.ok) return response.json();
+      throw new Error(response.statusText);
+    })
+    .then((response) => {
+      const posts = response.slice(0, 3).map((p) => {
+        const author = p._embedded.author && p._embedded.author[0];
+        const media = p._embedded['wp:featuredmedia'] && p._embedded['wp:featuredmedia'][0];
+        return {
+          date: moment(p.date).format('MMM DD, YYYY'),
+          title: renderHTML(p.title.rendered),
+          link: p.link,
+          slug: p.slug,
+          author: author && {
+            img: author.avatar_urls['96'],
+            path: author.link,
+            name: author.name
+          },
+          image: media && media.media_details.sizes.medium.source_url,
+          description: p.except ? p.excerpt.rendered : p.content.rendered
+        };
+      });
+      dispatch(setLoading(false));
+      dispatch(setError(null));
+      dispatch(setBlogPostsLatest(posts));
+    })
+    .catch((err) => {
+      dispatch(setLoading(false));
+      dispatch(setError(err));
+    });
+});

--- a/components/blog/latest-posts/actions.js
+++ b/components/blog/latest-posts/actions.js
@@ -13,7 +13,7 @@ export const setSelected = createAction('BLOG_POSTS_LATEST_SELECTED');
 export const fetchBlogPostsLatest = createThunkAction('BLOG_POSTS_LATEST_FETCH_DATA', (payload = {}) => (dispatch) => {
   dispatch(setLoading(true));
   dispatch(setError(null));
-  return fetch(new Request(`${process.env.BLOG_API_URL}/posts?_embed`))
+  return fetch(new Request(`${process.env.BLOG_API_URL}/posts?_embed&per_page=3`))
     .then((response) => {
       if (response.ok) return response.json();
       throw new Error(response.statusText);

--- a/components/blog/latest-posts/component.js
+++ b/components/blog/latest-posts/component.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'routes';
 
 import CardStatic from 'components/app/common/CardStatic';
 import Rating from 'components/app/common/Rating';
+import Spinner from 'components/ui/Spinner';
 
 class BlogPostsLatest extends React.Component {
   componentDidMount() {
@@ -22,15 +22,7 @@ class BlogPostsLatest extends React.Component {
       >
         <div>
           <h4>{p.date}</h4>
-          <h3>
-            { p.link ?
-              <Link route={`/blog/${p.slug}`}>
-                <a>{p.title}</a>
-              </Link>
-              :
-              <span>{p.title}</span>
-            }
-          </h3>
+          <h3>{p.title}</h3>
         </div>
         <div className="footer">
           <div className="source">
@@ -46,28 +38,34 @@ class BlogPostsLatest extends React.Component {
   );
 
   render() {
-    const { posts } = this.props;
-    return posts.length ? (
+    const { posts, loading } = this.props;
+    return (
       <div className="c-blog-latest-posts insight-cards">
-        <div className="row">
-          <div className="column small-12 medium-8">
-            {this.getCard(posts[0])}
-          </div>
-          <div className="column small-12 medium-4">
-            <div className="dual">
-              {this.getCard(posts[1])}
-              {this.getCard(posts[2])}
+        {loading &&
+          <Spinner className="-light" isLoading={loading} />
+        }
+        {!loading && posts.length > 0 &&
+          <div className="row">
+            <div className="column small-12 medium-8">
+              {this.getCard(posts[0])}
+            </div>
+            <div className="column small-12 medium-4">
+              <div className="dual">
+                {this.getCard(posts[1])}
+                {this.getCard(posts[2])}
+              </div>
             </div>
           </div>
-        </div>
+        }
       </div>
-    ) : null;
+    );
   }
 }
 
 BlogPostsLatest.propTypes = {
   posts: PropTypes.array,
-  fetchBlogPostsLatest: PropTypes.func
+  fetchBlogPostsLatest: PropTypes.func,
+  loading: PropTypes.bool
 };
 
 BlogPostsLatest.defaultProps = {

--- a/components/blog/latest-posts/component.js
+++ b/components/blog/latest-posts/component.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'routes';
+
+import CardStatic from 'components/app/common/CardStatic';
+import Rating from 'components/app/common/Rating';
+
+class BlogPostsLatest extends React.Component {
+  componentDidMount() {
+    const { fetchBlogPostsLatest } = this.props;
+    fetchBlogPostsLatest();
+  }
+
+  getCard = p => (
+    p && (
+      <CardStatic
+        key={`insight-card-${p.slug}`}
+        className={`-alt ${p.link ? '-clickable' : ''}`}
+        background={`url(${p.image})`}
+        clickable={!!p.link}
+        route={p.link ? p.link : ''}
+      >
+        <div>
+          <h4>{p.date}</h4>
+          <h3>
+            { p.link ?
+              <Link route={`/blog/${p.slug}`}>
+                <a>{p.title}</a>
+              </Link>
+              :
+              <span>{p.title}</span>
+            }
+          </h3>
+        </div>
+        <div className="footer">
+          <div className="source">
+            <span style={{ backgroundImage: `url(${p.author.img}` }} />
+            <div className="source-name">
+              by <a href={p.author.path} target="_blank">{p.author.name}</a>
+            </div>
+          </div>
+          {p.ranking && <Rating rating={p.ranking} />}
+        </div>
+      </CardStatic>
+    )
+  );
+
+  render() {
+    const { posts } = this.props;
+    return posts.length ? (
+      <div className="c-blog-latest-posts insight-cards">
+        <div className="row">
+          <div className="column small-12 medium-8">
+            {this.getCard(posts[0])}
+          </div>
+          <div className="column small-12 medium-4">
+            <div className="dual">
+              {this.getCard(posts[1])}
+              {this.getCard(posts[2])}
+            </div>
+          </div>
+        </div>
+      </div>
+    ) : null;
+  }
+}
+
+BlogPostsLatest.propTypes = {
+  posts: PropTypes.array,
+  fetchBlogPostsLatest: PropTypes.func
+};
+
+BlogPostsLatest.defaultProps = {
+  posts: []
+};
+
+export default BlogPostsLatest;

--- a/components/blog/latest-posts/default-state.js
+++ b/components/blog/latest-posts/default-state.js
@@ -1,0 +1,5 @@
+export default {
+  posts: [],
+  loading: false,
+  error: null
+};

--- a/components/blog/latest-posts/index.js
+++ b/components/blog/latest-posts/index.js
@@ -11,8 +11,9 @@ export {
 };
 
 export default connect(
-  state => ({
-    posts: state.latestBlogPosts && state.latestBlogPosts.posts
+  ({ latestBlogPosts }) => ({
+    posts: latestBlogPosts && latestBlogPosts.posts,
+    loading: latestBlogPosts.loading
   }),
   actions
 )(BlogLatestPosts);

--- a/components/blog/latest-posts/index.js
+++ b/components/blog/latest-posts/index.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import * as actions from './actions';
+import * as reducers from './reducers';
+import initialState from './default-state';
+
+import BlogLatestPosts from './component';
+
+// Mandatory
+export {
+  actions, reducers, initialState
+};
+
+export default connect(
+  state => ({
+    posts: state.latestBlogPosts && state.latestBlogPosts.posts
+  }),
+  actions
+)(BlogLatestPosts);

--- a/components/blog/latest-posts/reducers.js
+++ b/components/blog/latest-posts/reducers.js
@@ -1,0 +1,12 @@
+import * as actions from './actions';
+
+export default {
+  [actions.setBlogPostsLatest]: (state, action) =>
+    ({ ...state, posts: action.payload }),
+
+  [actions.setLoading]: (state, action) =>
+    ({ ...state, loading: action.payload }),
+
+  [actions.setError]: (state, action) =>
+    ({ ...state, error: action.payload })
+};

--- a/css/components/app/common/card_static.scss
+++ b/css/components/app/common/card_static.scss
@@ -49,10 +49,14 @@
       display: flex;
       align-items: center;
 
-      img {
-        height: 38px;
+      span {
+        height: 40px;
+        width: 40px;
         margin-right: 10px;
         border-radius: 50%;
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: cover;
       }
 
       .source-name {

--- a/css/components/app/pages/home.scss
+++ b/css/components/app/pages/home.scss
@@ -87,6 +87,9 @@
 
 
 .insight-cards {
+  min-height: 590px;
+  position: relative;
+
   .c-card-static {
     margin-top: $margin-size;
     height: 590px;

--- a/css/components/app/pages/home.scss
+++ b/css/components/app/pages/home.scss
@@ -59,6 +59,7 @@
 
       a {
         padding: 20px;
+        text-shadow: none;
       }
     }
 

--- a/next.config.js
+++ b/next.config.js
@@ -62,6 +62,7 @@ module.exports = {
         'process.env.CALLBACK_URL': JSON.stringify(process.env.CALLBACK_URL),
         'process.env.CONTROL_TOWER_URL': JSON.stringify(process.env.CONTROL_TOWER_URL),
         'process.env.WRI_API_URL': JSON.stringify(process.env.WRI_API_URL),
+        'process.env.BLOG_API_URL': JSON.stringify(process.env.BLOG_API_URL),
         'process.env.STATIC_SERVER_URL': JSON.stringify(process.env.STATIC_SERVER_URL),
         'process.env.ADD_SEARCH_KEY': JSON.stringify(process.env.ADD_SEARCH_KEY),
         'process.env.TRANSIFEX_LIVE_API': JSON.stringify(process.env.TRANSIFEX_LIVE_API),

--- a/pages/app/Home.js
+++ b/pages/app/Home.js
@@ -8,7 +8,6 @@ import { breakpoints } from 'utils/responsive';
 // Redux
 import withRedux from 'next-redux-wrapper';
 import { initStore } from 'store';
-import { getInsights } from 'redactions/insights';
 import * as topicsActions from 'layout/topics/topics-actions';
 
 // Layout
@@ -18,8 +17,8 @@ import Layout from 'layout/layout/layout-app';
 // Components
 import Banner from 'components/app/common/Banner';
 import CardStatic from 'components/app/common/CardStatic';
-import Rating from 'components/app/common/Rating';
 import TopicThumbnailList from 'components/topics/thumbnail-list';
+import BlogLatestPosts from 'components/blog/latest-posts';
 import YouTube from 'react-youtube';
 import MediaQuery from 'react-responsive';
 
@@ -97,38 +96,6 @@ class Home extends Page {
 
     return { ...props };
   }
-  static insightsCardsStatic(insightsData) {
-    return insightsData.map(c =>
-      (<CardStatic
-        key={`insight-card-${c.slug}`}
-        className={`-alt ${c.link ? '-clickable' : ''}`}
-        background={c.background}
-        clickable={!!c.link}
-        route={c.link ? c.link : ''}
-      >
-        <div>
-          <h4>{c.tag}</h4>
-          <h3>
-            { c.link ?
-              <Link route={`/blog/${c.slug}`}>
-                <a>{c.title}</a>
-              </Link>
-              :
-              <span>{c.title}</span>
-            }
-          </h3>
-        </div>
-        <div className="footer">
-          <div className="source">
-            <img src={c.source.img || ''} alt={c.slug} />
-            <div className="source-name">
-              by <a href={c.source.path} target="_blank">{c.source.name}</a>
-            </div>
-          </div>
-          {c.ranking && <Rating rating={c.ranking} />}
-        </div>
-      </CardStatic>));
-  }
 
   static exploreCardsStatic() {
     return exploreCards.map(c =>
@@ -173,10 +140,6 @@ class Home extends Page {
     };
   }
 
-  componentDidMount() {
-    this.props.getInsights();
-  }
-
   handleToggleShareModal = (bool) => {
     this.setState({ showNewsletterModal: bool });
   }
@@ -191,9 +154,8 @@ class Home extends Page {
   }
 
   render() {
-    const { insights, responsive } = this.props;
+    const { responsive } = this.props;
     const { videoReady } = this.state;
-    const insightsCardsStatic = Home.insightsCardsStatic(insights);
     const exploreCardsStatic = Home.exploreCardsStatic();
     const videoOpts = {
       playerVars: {
@@ -253,19 +215,7 @@ class Home extends Page {
               </div>
             </header>
 
-            <div className="insight-cards">
-              <div className="row">
-                <div className="column small-12 medium-8">
-                  {insightsCardsStatic[0]}
-                </div>
-                <div className="column small-12 medium-4">
-                  <div className="dual">
-                    {insightsCardsStatic[1]}
-                    {insightsCardsStatic[2]}
-                  </div>
-                </div>
-              </div>
-            </div>
+            <BlogLatestPosts />
 
             <div className="-text-center">
               <div className="row">
@@ -380,12 +330,7 @@ class Home extends Page {
 }
 
 const mapStateToProps = state => ({
-  insights: state.insights.list,
   responsive: state.responsive
 });
 
-const mapDispatchToProps = {
-  getInsights
-};
-
-export default withRedux(initStore, mapStateToProps, mapDispatchToProps)(Home);
+export default withRedux(initStore, mapStateToProps, null)(Home);

--- a/store.js
+++ b/store.js
@@ -48,8 +48,10 @@ import * as globeCesium from 'components/vis/globe-cesium';
 import * as widgetDetail from 'layout/widget-detail';
 
 // Catalog
-
 import * as catalog from 'layout/catalog';
+
+// Blog
+import * as latestBlogPosts from 'components/blog/latest-posts';
 
 // Topic
 import * as topicsIndex from 'layout/topics';
@@ -129,6 +131,9 @@ const reducer = combineReducers({
 
   // Catalog
   catalog: handleModule(catalog),
+
+  // Blog
+  latestBlogPosts: handleModule(latestBlogPosts),
 
   // Topic
   topicsIndex: handleModule(topicsIndex),


### PR DESCRIPTION
Updates the homepage to have REAL blog posts for the ACTUAL BLOG 😱. Following changes:
- New `<BlogLatestPosts>` component that fetches the 3 latests posts
- Reuse old styles and static card component to make the grid
- Updates styles and links for fully clickable cards
- Add loader to give user feedback

Task: https://www.pivotaltracker.com/story/show/156503368

NOTE: new `.env` variable is needed
`BLOG_API_URL=https://staging.resourcewatch.org/blog_/wp-json/wp/v2`