### PR TITLE
fix/legend-info-mode

### DIFF
--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -115,7 +115,7 @@
       width: 100%;
       height: 100%;
       padding: $margin-size-extra-small;
-      z-index: 3;
+      z-index: 11;
       background-color: $white;
       overflow-x: hidden;
       overflow-y: auto;

--- a/css/components/dashboards/dashboard-card.scss
+++ b/css/components/dashboards/dashboard-card.scss
@@ -88,7 +88,7 @@
       width: 100%;
       height: 100%;
       padding: $margin-size-extra-small;
-      z-index: 3;
+      z-index: 11;
       background-color: $white;
       overflow-x: hidden;
       overflow-y: auto;


### PR DESCRIPTION
## Overview
When switching to "info" mode in map widgets the legend should be disappeared.

## Demo
![legend](https://user-images.githubusercontent.com/1432880/38495800-3894a940-3bfb-11e8-9ac8-f6a113fbe794.gif)

