### PR TITLE
fix/context-layers-info

### DIFF
--- a/layout/pulse/layer-card/component.js
+++ b/layout/pulse/layer-card/component.js
@@ -25,7 +25,8 @@ class LayerCardComponent extends PureComponent {
 
     this.state = {
       showSubscribeToDatasetModal: false,
-      showInfoModal: false
+      showInfoModal: false,
+      showContextLayersInfoModal: false
     };
   }
   componentWillReceiveProps(nextProps) {
@@ -63,7 +64,7 @@ class LayerCardComponent extends PureComponent {
   }
 
   render() {
-    const { showSubscribeToDatasetModal, showInfoModal } = this.state;
+    const { showSubscribeToDatasetModal, showInfoModal, showContextLayersInfoModal } = this.state;
     const { layerMenuPulse, layerCardPulse, activeContextLayers } = this.props;
     const { layerActive, layerPoints } = layerMenuPulse;
     const { dataset, widget } = layerCardPulse;
@@ -144,14 +145,14 @@ class LayerCardComponent extends PureComponent {
                         type="button"
                         className="info"
                         aria-label="More information"
-                        onClick={() => this.setState({ showInfoModal: true })}
+                        onClick={() => this.setState({ showContextLayersInfoModal: true })}
                       >
                         <Icon name="icon-info" />
 
                         <Modal
-                          isOpen={showInfoModal}
+                          isOpen={showContextLayersInfoModal}
                           className="-medium"
-                          onRequestClose={() => this.setState({ showInfoModal: false })}
+                          onRequestClose={() => this.setState({ showContextLayersInfoModal: false })}
                         >
                           <LayerInfoModal
                             data={ctLayer.attributes}


### PR DESCRIPTION
## Overview
We are using the same state to manage every modal info in the legend card. So, I've added a new one for context layers.

## Demo
![info-modal](https://user-images.githubusercontent.com/1432880/38496590-70e43330-3bfe-11e8-8b54-1d95da36ec64.gif)
