### PR TITLE
fix opbeat errors, planet pulse cashed layers stay visible

### DIFF
--- a/components/modal/LayerInfoModal.js
+++ b/components/modal/LayerInfoModal.js
@@ -7,7 +7,10 @@ import { connect } from 'react-redux';
 
 class LayerInfoModal extends React.Component {
   handleMoreInfo = () => {
-    this.props.onRequestClose(false);
+    const { onRequestClose } = this.props;
+    if (onRequestClose && typeof onRequestClose === 'function') {
+      onRequestClose(false);
+    }
     Router.pushRoute('explore_detail', { id: this.props.data.dataset });
   }
 

--- a/components/vis/globe-cesium/component.js
+++ b/components/vis/globe-cesium/component.js
@@ -156,6 +156,12 @@ class GlobeCesiumComponent extends PureComponent {
     if (nextProps.basemap !== this.props.basemap ||
       nextProps.activeContextLayers !== this.props.activeContextLayers ||
       newMainLayer !== mainLayer) {
+
+      if (this.props.activeContextLayers.length !== 0 &&
+          nextProps.activeContextLayers.length === 0) {
+        this.removeAllContextLayers();
+      }
+
       this.updateLayers(
         nextProps,
         nextProps.basemap !== this.props.basemap,
@@ -407,6 +413,12 @@ class GlobeCesiumComponent extends PureComponent {
       if (this.imageryLayers.get(i).name !== 'mainLayer') {
         this.imageryLayers.remove(this.imageryLayers.get(i), false);
       }
+    }
+  }
+
+  removeAllContextLayers() {
+    for (let i = 1; i < this.imageryLayers.length; i++) {
+      this.imageryLayers.remove(this.imageryLayers.get(i), false);
     }
   }
 

--- a/layout/explore-detail/explore-detail-helpers.js
+++ b/layout/explore-detail/explore-detail-helpers.js
@@ -3,7 +3,7 @@ export function getDatasetMetadata(dataset) {
 }
 
 export function getDatasetName(dataset) {
-  const metadata = dataset.metadata || {};
+  const metadata = dataset && dataset.metadata || {};
   return metadata.info && metadata.info.name ? metadata.info.name : dataset.name;
 }
 

--- a/layout/pulse/layer-card/component.js
+++ b/layout/pulse/layer-card/component.js
@@ -138,7 +138,7 @@ class LayerCardComponent extends PureComponent {
             <div className="context-layers-legends">
               {
                 activeContextLayers.map(ctLayer => (
-                  <div>
+                  <div key={ctLayer.attributes.name}>
                     <div className="layer-container">
                       <span>{ctLayer.attributes.name}</span>
                       <button

--- a/layout/pulse/layer-pill/actions.js
+++ b/layout/pulse/layer-pill/actions.js
@@ -38,6 +38,7 @@ export const toggleContextualLayer = createThunkAction('layer-pill/toggleContext
             },
             true
           );
+          dispatch(setContextLayersLoading(false));
         })
         .catch(error => dispatch(setContextLayersError(error)));
     }

--- a/layout/pulse/layer-pill/component.js
+++ b/layout/pulse/layer-pill/component.js
@@ -19,6 +19,7 @@ class LayerPillComponent extends PureComponent {
     return (
       <button
         className={className}
+        disabled={contextLayersPulse.contextLayersLoading}
         onClick={() => {
           this.props.toggleContextualLayer(layerId);
         }}

--- a/services/LayersService.js
+++ b/services/LayersService.js
@@ -88,11 +88,11 @@ export default class LayersService {
           const fieldsObj = response.fields;
           const parsedData = {
             tableName: response.tableName,
-            fields: (Object.entries(fieldsObj) || []).map(data => ({
-              label: data[0],
-              value: data[0],
-              type: data[1].type
-            }))
+            fields: ((fieldsObj && Object.entries(fieldsObj)) || []).map((data) => {
+              const { label, value } = data && data.length ? data[0] : {};
+              const { type } = data && data.length > 1 ? data[1].type : {};
+              return { label, value, type };
+            })
           };
           resolve({ ...parsedData });
         },


### PR DESCRIPTION
## Overview
Fix general omit errors, and planet pulse cashed layers not disappearing when array of layers gets cashed.

weird planet pulse bug fixed, so when multiple contextual layers are present, something within cecium cashed the old layers, so when there is an array of *0* elements sent, it grabs the last cashed version, so added 1 condition in componentWillMount, that ensures we remove all of the layers. 
https://github.com/resource-watch/resource-watch/pull/708/files#diff-e60c893374bedcee91a4392b6b9215f3R160

What that line does, is that it forces the cache to reset and all contextual layers should be removed

## Pivotal task
https://www.pivotaltracker.com/story/show/156610810
https://www.pivotaltracker.com/n/projects/1374154/stories/155943003
