### PR TITLE
Homepage recent posts (check before merging)

### DIFF
--- a/components/blog/latest-posts/actions.js
+++ b/components/blog/latest-posts/actions.js
@@ -5,21 +5,25 @@ import renderHTML from 'react-render-html';
 
 // Actions
 export const setBlogPostsLatest = createAction('BLOG_POSTS_LATEST_GET');
+export const setBlogPostsSpotlightLatest = createAction('BLOG_POSTS_SPOTLIGHT_LATEST_GET');
 export const setLoading = createAction('BLOG_POSTS_LATEST_LOADING');
 export const setError = createAction('BLOG_POSTS_LATEST_ERROR');
 export const setSelected = createAction('BLOG_POSTS_LATEST_SELECTED');
+
+// Featured posts
+const SPOTLIGHT_CATEGORY = 15;
 
 // Async actions
 export const fetchBlogPostsLatest = createThunkAction('BLOG_POSTS_LATEST_FETCH_DATA', (payload = {}) => (dispatch) => {
   dispatch(setLoading(true));
   dispatch(setError(null));
-  return fetch(new Request(`${process.env.BLOG_API_URL}/posts?_embed&per_page=3`))
+  return fetch(new Request(`${process.env.BLOG_API_URL}/posts?_embed&per_page=3&categories_exclude=${SPOTLIGHT_CATEGORY}`))
     .then((response) => {
       if (response.ok) return response.json();
       throw new Error(response.statusText);
     })
     .then((response) => {
-      const posts = response.slice(0, 3).map((p) => {
+      const posts = response.map((p) => {
         const author = p._embedded.author && p._embedded.author[0];
         const media = p._embedded['wp:featuredmedia'] && p._embedded['wp:featuredmedia'][0];
         return {
@@ -32,13 +36,49 @@ export const fetchBlogPostsLatest = createThunkAction('BLOG_POSTS_LATEST_FETCH_D
             path: author.link,
             name: author.name
           },
-          image: media && media.media_details.sizes.medium.source_url,
+          image: media && media.media_details.sizes.medium_large.source_url,
           description: p.except ? p.excerpt.rendered : p.content.rendered
         };
       });
       dispatch(setLoading(false));
       dispatch(setError(null));
       dispatch(setBlogPostsLatest(posts));
+    })
+    .catch((err) => {
+      dispatch(setLoading(false));
+      dispatch(setError(err));
+    });
+});
+
+export const fetchBlogPostsSpotlightLatest = createThunkAction('BLOG_POSTS_LATEST_SPOTLIGHT_FETCH_DATA', (payload = {}) => (dispatch) => {
+  dispatch(setLoading(true));
+  dispatch(setError(null));
+  return fetch(new Request(`${process.env.BLOG_API_URL}/posts?_embed&per_page=3&categories=${SPOTLIGHT_CATEGORY}`))
+    .then((response) => {
+      if (response.ok) return response.json();
+      throw new Error(response.statusText);
+    })
+    .then((response) => {
+      const posts = response.map((p) => {
+        const author = p._embedded.author && p._embedded.author[0];
+        const media = p._embedded['wp:featuredmedia'] && p._embedded['wp:featuredmedia'][0];
+        return {
+          date: moment(p.date).format('MMM DD, YYYY'),
+          title: renderHTML(p.title.rendered),
+          link: p.link,
+          slug: p.slug,
+          author: author && {
+            img: author.avatar_urls['96'],
+            path: author.link,
+            name: author.name
+          },
+          image: media && media.media_details.sizes.large.source_url,
+          description: p.except ? p.excerpt.rendered : p.content.rendered
+        };
+      });
+      dispatch(setLoading(false));
+      dispatch(setError(null));
+      dispatch(setBlogPostsSpotlightLatest(posts));
     })
     .catch((err) => {
       dispatch(setLoading(false));

--- a/components/blog/latest-posts/component.js
+++ b/components/blog/latest-posts/component.js
@@ -7,8 +7,9 @@ import Spinner from 'components/ui/Spinner';
 
 class BlogPostsLatest extends React.Component {
   componentDidMount() {
-    const { fetchBlogPostsLatest } = this.props;
+    const { fetchBlogPostsLatest, fetchBlogPostsSpotlightLatest } = this.props;
     fetchBlogPostsLatest();
+    fetchBlogPostsSpotlightLatest();
   }
 
   getCard = p => (
@@ -38,7 +39,7 @@ class BlogPostsLatest extends React.Component {
   );
 
   render() {
-    const { posts, loading } = this.props;
+    const { posts, postsSpotlight, loading } = this.props;
     return (
       <div className="c-blog-latest-posts insight-cards">
         {loading &&
@@ -47,12 +48,15 @@ class BlogPostsLatest extends React.Component {
         {!loading && posts.length > 0 &&
           <div className="row">
             <div className="column small-12 medium-8">
-              {this.getCard(posts[0])}
+              {postsSpotlight.length > 0 &&
+                this.getCard(postsSpotlight[0]) ||
+                this.getCard(posts[2])
+              }
             </div>
             <div className="column small-12 medium-4">
               <div className="dual">
+                {this.getCard(posts[0])}
                 {this.getCard(posts[1])}
-                {this.getCard(posts[2])}
               </div>
             </div>
           </div>
@@ -65,6 +69,7 @@ class BlogPostsLatest extends React.Component {
 BlogPostsLatest.propTypes = {
   posts: PropTypes.array,
   fetchBlogPostsLatest: PropTypes.func,
+  fetchBlogPostsSpotlightLatest: PropTypes.func,
   loading: PropTypes.bool
 };
 

--- a/components/blog/latest-posts/default-state.js
+++ b/components/blog/latest-posts/default-state.js
@@ -1,5 +1,6 @@
 export default {
   posts: [],
+  postsSpotlight: [],
   loading: false,
   error: null
 };

--- a/components/blog/latest-posts/index.js
+++ b/components/blog/latest-posts/index.js
@@ -13,6 +13,7 @@ export {
 export default connect(
   ({ latestBlogPosts }) => ({
     posts: latestBlogPosts && latestBlogPosts.posts,
+    postsSpotlight: latestBlogPosts && latestBlogPosts.postsSpotlight,
     loading: latestBlogPosts.loading
   }),
   actions

--- a/components/blog/latest-posts/reducers.js
+++ b/components/blog/latest-posts/reducers.js
@@ -4,6 +4,9 @@ export default {
   [actions.setBlogPostsLatest]: (state, action) =>
     ({ ...state, posts: action.payload }),
 
+  [actions.setBlogPostsSpotlightLatest]: (state, action) =>
+    ({ ...state, postsSpotlight: action.payload }),
+
   [actions.setLoading]: (state, action) =>
     ({ ...state, loading: action.payload }),
 

--- a/css/components/app/pages/home.scss
+++ b/css/components/app/pages/home.scss
@@ -103,8 +103,8 @@
       left: 0;
       bottom: 0;
       right: 0;
-      background-color: rgba(0, 0, 0, .7);
       border-radius: 4px;
+      background-image: linear-gradient(180deg, rgba(22, 22, 22, .5) 0%, rgba(22, 22, 22, .1) 50%);
     }
 
     div {


### PR DESCRIPTION
## Overview
Update styles for homepage blog cards and pull separate featured "spotlight" posts vs regular posts. 

Posts aren't showing up on resourcewatch.org right now, and my development environment isn't set up to debug. If this PR doesn't work, the two style changes that are worth making regardless are:

css/components/app/pages/home.scss
```
-      background-color: rgba(0, 0, 0, .7);
+      background-image: linear-gradient(180deg, rgba(22, 22, 22, .5) 0%, rgba(22, 22, 22, .1) 50%);
```

components/blog/latest-posts/actions.js
```
-          image: media && media.media_details.sizes.medium.source_url,
+          image: media && media.media_details.sizes.large.source_url,
```

## Testing instructions
Load homepage

## Pivotal task
https://www.pivotaltracker.com/story/show/156642319

