### PR TITLE
Pulse: fix dataset title shown in the subscription modal

### DIFF
--- a/components/modal/SubscribeToDatasetModal.js
+++ b/components/modal/SubscribeToDatasetModal.js
@@ -306,11 +306,12 @@ class SubscribeToDatasetModal extends React.Component {
       saved
     } = this.state;
     const { dataset } = this.props;
+    const datasetName = (dataset.metadata && dataset.metadata.info && dataset.metadata.info.name) || (dataset.name);
     let headerText;
     if (saved) {
       headerText = 'Subscription saved!';
     } else if (dataset) {
-      headerText = `Subscribe to ${dataset.name || dataset.attributes.name}`;
+      headerText = `Subscribe to ${datasetName}`;
     }
     const paragraphText = saved ?
       (<p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/38608881-e7d077c2-3d7c-11e8-94e6-ab5dcb7e6234.png)

## Overview
This PR fixes the title shown in the subscription modal, it now shows the metadata title as the first option.

## Testing instructions
Go to `localhost:3000/data/pulse`, select a subscribable dataset such as Fires and click on the subscriptions button.

## [Pivotal task](https://www.pivotaltracker.com/story/show/151937644)