### PR TITLE
Widget creation/edition: remove an error from the console 

### DIFF
--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -316,14 +316,16 @@ class Step1 extends Component {
                   {!widgetTypeEmbed &&
                     <div className="">
                       <Spinner isLoading={loadingVegaChart} className="-light -relative" />
-                      <VegaChart
-                        data={this.state.form.widgetConfig}
-                        theme={getVegaTheme(true)}
-                        showLegend
-                        reloadOnResize
-                        toggleLoading={this.triggerToggleLoadingVegaChart}
-                        getForceUpdate={(func) => { this.forceChartUpdate = func; }}
-                      />
+                      {this.state.form.widgetConfig && this.state.form.widgetConfig.data && (
+                        <VegaChart
+                          data={this.state.form.widgetConfig}
+                          theme={getVegaTheme(true)}
+                          showLegend
+                          reloadOnResize
+                          toggleLoading={this.triggerToggleLoadingVegaChart}
+                          getForceUpdate={(func) => { this.forceChartUpdate = func; }}
+                        />
+                      )}
                       <div className="actions">
                         <button
                           type="button"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-watch",
-  "version": "2.14.7",
+  "version": "2.14.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19,6 +19,11 @@
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
+    },
+    "@esri/arcgis-to-geojson-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-to-geojson-utils/-/arcgis-to-geojson-utils-1.2.0.tgz",
+      "integrity": "sha512-JvHNyTEtvHwaCYv/x5LfXu2g1JifdU+2GPF536lDuS6wwnL1oWQMXrVjhpL225p575VEJRl4ajefR5RhwYxM/g=="
     },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.1",
@@ -547,11 +552,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
-    "arcgis-to-geojson-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arcgis-to-geojson-utils/-/arcgis-to-geojson-utils-1.0.3.tgz",
-      "integrity": "sha512-u29NQHdc8DAHMXsYuOSGFL0yHOrfIkGL1NY3XuvIQqZ4u5fV+xtP7Ns07aoR79HiyurzYOXbs5npOWRUfl2fqA=="
     },
     "archive-type": {
       "version": "3.2.0",
@@ -1257,6 +1257,16 @@
         "babel-template": "6.26.0"
       }
     },
+    "babel-loader": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.1.tgz",
+      "integrity": "sha1-uHE0yLEuPkwqlOBUYIW8aAorhIg=",
+      "requires": {
+        "find-cache-dir": "1.0.0",
+        "loader-utils": "1.1.0",
+        "mkdirp": "0.5.1"
+      }
+    },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -1616,6 +1626,15 @@
         "babel-runtime": "6.25.0"
       }
     },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.22.0.tgz",
+      "integrity": "sha1-HUGbVeaNLk9kpf8zc71n1zyOg7w=",
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.25.0"
+      }
+    },
     "babel-plugin-transform-react-display-name": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
@@ -1652,12 +1671,28 @@
         "babel-runtime": "6.25.0"
       }
     },
+    "babel-plugin-transform-react-remove-prop-types": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.5.tgz",
+      "integrity": "sha1-edGVhDeuI9T7wLEdGgQUmN2yOHc=",
+      "requires": {
+        "babel-traverse": "6.26.0"
+      }
+    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
         "regenerator-transform": "0.10.1"
+      }
+    },
+    "babel-plugin-transform-runtime": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.22.0.tgz",
+      "integrity": "sha1-EJaNdgu/ZRckMIHux3jhD6goVRw=",
+      "requires": {
+        "babel-runtime": "6.25.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -2511,9 +2546,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000823",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000823.tgz",
-      "integrity": "sha1-5o5fjHB4PvQFnS6g3oH1UWUdpvw="
+      "version": "1.0.30000851",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000851.tgz",
+      "integrity": "sha1-ig08pN3nIGhWCsyYus91o1no0+M="
     },
     "caniuse-lite": {
       "version": "1.0.30000823",
@@ -2583,11 +2618,6 @@
         "align-text": "0.1.4",
         "lazy-cache": "1.0.4"
       }
-    },
-    "chain-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
-      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
     },
     "chalk": {
       "version": "2.3.2",
@@ -3765,6 +3795,21 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
       "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
+    },
+    "css-tree": {
+      "version": "1.0.0-alpha17",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha17.tgz",
+      "integrity": "sha1-erlatyxTORevi+VDE/7IGEHFIjo=",
+      "requires": {
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
     },
     "csso": {
       "version": "2.3.2",
@@ -5584,11 +5629,11 @@
       }
     },
     "esri-leaflet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-2.1.1.tgz",
-      "integrity": "sha512-NBKCgNa1ZEQXyA+fN2xPsNlAD3xJ6aRGhCwGini+D5Me3fwJbTurZ4cxFgBBXnqZqw6DJ5GyPCzTw1TrUO7ocw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-2.1.4.tgz",
+      "integrity": "sha512-cwHnvwMoQRcamUPsbmTRTgLFmZfK8pUdj3ozETXEwWZGdS8dH+gi/Wn63H/fYBaKTDl+iWQTJTab9036FlsM6A==",
       "requires": {
-        "arcgis-to-geojson-utils": "1.0.3",
+        "@esri/arcgis-to-geojson-utils": "1.2.0",
         "leaflet-virtual-grid": "1.0.6",
         "tiny-binary-search": "1.0.3"
       }
@@ -6282,6 +6327,40 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
       "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+    },
+    "friendly-errors-webpack-plugin": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.5.0.tgz",
+      "integrity": "sha1-8ogliQkk1sPw2OxTRpdoaIMpBUo=",
+      "requires": {
+        "chalk": "1.1.3",
+        "error-stack-parser": "2.0.1",
+        "string-length": "1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
     },
     "from": {
       "version": "0.1.7",
@@ -7749,6 +7828,11 @@
           }
         }
       }
+    },
+    "glob-promise": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.1.0.tgz",
+      "integrity": "sha1-GYiCo4F759wsVfkmI6qeez+C0es="
     },
     "glob-stream": {
       "version": "5.3.5",
@@ -9476,9 +9560,9 @@
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
     },
     "leaflet": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.0.3.tgz",
-      "integrity": "sha1-H0AbmLRcgZITTGyNaWhiU4BQB8g="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.3.1.tgz",
+      "integrity": "sha512-adQOIzh+bfdridLM1xIgJ9VnJbAUY3wqs/ueF+ITla+PLQ1z47USdBKUf+iD9FuUA8RtlT6j6hZBfZoA6mW+XQ=="
     },
     "leaflet-utfgrid": {
       "version": "0.3.0",
@@ -9493,7 +9577,7 @@
       "resolved": "https://registry.npmjs.org/leaflet-virtual-grid/-/leaflet-virtual-grid-1.0.6.tgz",
       "integrity": "sha512-hbAfom/aWjm1fZH1859XgiapPsLvSkhimqSIgvGDXGwGKr89P3gAJGSUZJ28bQwgvNOCDKW0PKKeEQOtZoZNDQ==",
       "requires": {
-        "leaflet": "1.0.3"
+        "leaflet": "1.3.1"
       }
     },
     "levn": {
@@ -9895,6 +9979,11 @@
         "arrify": "1.0.1",
         "minimatch": "3.0.4"
       }
+    },
+    "md5-file": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-3.1.1.tgz",
+      "integrity": "sha1-2zySwJu9pcLeiD+lSQ3XEf3burk="
     },
     "md5.js": {
       "version": "1.3.4",
@@ -10321,6 +10410,16 @@
             "glob": "6.0.4"
           }
         }
+      }
+    },
+    "mz": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.6.0.tgz",
+      "integrity": "sha1-yLhSHZWN8KTydoAl22nHGe5O8c4=",
+      "requires": {
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
       }
     },
     "nan": {
@@ -11928,7 +12027,7 @@
         "error-stack-parser": "1.3.6",
         "loglevel": "1.6.1",
         "stack-generator": "1.1.0",
-        "url-parse": "1.2.0"
+        "url-parse": "1.4.1"
       },
       "dependencies": {
         "error-stack-parser": {
@@ -12565,9 +12664,9 @@
       }
     },
     "peer-deps-externals-webpack-plugin": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/peer-deps-externals-webpack-plugin/-/peer-deps-externals-webpack-plugin-1.0.2.tgz",
-      "integrity": "sha512-4tf122hxHWm+XcHhvkK8HRBp/IVu1uCP+pBcRwjI2B2gnUE57/VBh5MZ17dTxsIIDOMzLFgdlaCSGR/6CCLrvg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/peer-deps-externals-webpack-plugin/-/peer-deps-externals-webpack-plugin-1.0.3.tgz",
+      "integrity": "sha512-Gp4ZXtOkSqOYf1/HQZqxhjSO8JQQAKMj1jsAB8Vtmh8jIaoTRICrREMuHFPi851e6ErLkt8S6+vQjqpDSdP5jg=="
     },
     "pend": {
       "version": "1.2.0",
@@ -13274,6 +13373,15 @@
         "object-assign": "4.1.1"
       }
     },
+    "prop-types-exact": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.1.2.tgz",
+      "integrity": "sha512-3x4BWv7w2luSStiHwSzrhK9U1sm+vHwSyg9le2RfY41pZyJdiPKDOKh6TCQywwl++SCr7MMKu7POp4LU/L/eIA==",
+      "requires": {
+        "has": "1.0.1",
+        "object.assign": "4.1.0"
+      }
+    },
     "propagating-hammerjs": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/propagating-hammerjs/-/propagating-hammerjs-1.4.6.tgz",
@@ -13381,9 +13489,9 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "querystringify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-      "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -13785,10 +13893,10 @@
         "circular-json": "0.4.0",
         "classnames": "2.2.5",
         "prop-types": "15.6.1",
-        "react-redux": "5.0.7",
+        "react-redux": "5.0.6",
         "redux": "3.7.2",
         "redux-logger": "3.0.6",
-        "redux-thunk": "2.2.0"
+        "redux-thunk": "2.3.0"
       },
       "dependencies": {
         "babel-runtime": {
@@ -13805,44 +13913,10 @@
           "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.4.0.tgz",
           "integrity": "sha512-tKV502ADgm9Z37s6B1QOohegjJJrCl2iyMMb1+8ITHrh1fquW8Jdbkb4s5r4Iwutr1UfL1qvkqvc1wZZlLvwow=="
         },
-        "hoist-non-react-statics": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
-          "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
-        },
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-        },
-        "react-redux": {
-          "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
-          "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
-          "requires": {
-            "hoist-non-react-statics": "2.5.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.5",
-            "lodash-es": "4.17.8",
-            "loose-envify": "1.3.1",
-            "prop-types": "15.6.1"
-          }
-        },
-        "redux": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
-          "requires": {
-            "lodash": "4.17.5",
-            "lodash-es": "4.17.8",
-            "loose-envify": "1.3.1",
-            "symbol-observable": "1.2.0"
-          }
-        },
         "redux-thunk": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
-          "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+          "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
         },
         "regenerator-runtime": {
           "version": "0.11.1",
@@ -13894,6 +13968,29 @@
       "integrity": "sha1-vB7Z6e99oFcWP7FpzhKRe21sp9g=",
       "requires": {
         "hammerjs": "2.0.8"
+      }
+    },
+    "react-hot-loader": {
+      "version": "3.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-3.0.0-beta.7.tgz",
+      "integrity": "sha1-1YR7gWXXMcTVsw2G1dRxYieg+oM=",
+      "requires": {
+        "babel-template": "6.26.0",
+        "global": "4.3.2",
+        "react-deep-force-update": "2.1.1",
+        "react-proxy": "3.0.0-alpha.1",
+        "redbox-react": "1.5.0",
+        "source-map": "0.4.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
       }
     },
     "react-input-autosize": {
@@ -14116,21 +14213,36 @@
       }
     },
     "react-transition-group": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.0.tgz",
-      "integrity": "sha512-OU3/swEL8y233u5ajTn3FIcQQ/b3XWjLXB6e2LnM1OK5JATtsyfJvPTZ8c/dawHNqjUltcdHRSpgMtPe7v07pw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
+      "integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
       "requires": {
-        "chain-function": "1.0.0",
         "dom-helpers": "3.3.1",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.1",
-        "warning": "3.0.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-upload-file": {
       "version": "2.0.0-beta.6",
       "resolved": "https://registry.npmjs.org/react-upload-file/-/react-upload-file-2.0.0-beta.6.tgz",
-      "integrity": "sha1-cPOZDfEB6jed6q4rT+bgk4tUF7k="
+      "integrity": "sha1-cPOZDfEB6jed6q4rT+bgk4tUF7k=",
+      "requires": {
+        "react": "15.6.2"
+      },
+      "dependencies": {
+        "react": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+          "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+          "requires": {
+            "create-react-class": "15.6.3",
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        }
+      }
     },
     "react-vega": {
       "version": "3.1.2",
@@ -14269,6 +14381,57 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
           "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+        }
+      }
+    },
+    "recursive-copy": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/recursive-copy/-/recursive-copy-2.0.9.tgz",
+      "integrity": "sha512-0AkHV+QtfS/1jW01z3m2t/TRTW56Fpc+xYbsoa/bqn8BCYPwmsaNjlYmUU/dyGg9w8MmGoUWihU5W+s+qjxvBQ==",
+      "requires": {
+        "del": "2.2.2",
+        "emitter-mixin": "0.0.3",
+        "errno": "0.1.7",
+        "graceful-fs": "4.1.11",
+        "junk": "1.0.3",
+        "maximatch": "0.1.0",
+        "mkdirp": "0.5.1",
+        "pify": "2.3.0",
+        "promise": "7.3.1",
+        "slash": "1.0.0"
+      },
+      "dependencies": {
+        "del": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+          "requires": {
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
@@ -16581,6 +16744,11 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
+    "string-hash": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.1.tgz",
+      "integrity": "sha1-joW+0pHgdjuPaAnZwzaP6gSNs9w="
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -16709,6 +16877,72 @@
       "requires": {
         "escape-string-regexp": "1.0.5"
       }
+    },
+    "styled-jsx": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-1.0.11.tgz",
+      "integrity": "sha1-hFTwaRbZ1Xoumu1qnC5pUXeCIEU=",
+      "requires": {
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-traverse": "6.21.0",
+        "babel-types": "6.23.0",
+        "babylon": "6.14.1",
+        "convert-source-map": "1.3.0",
+        "css-tree": "1.0.0-alpha17",
+        "escape-string-regexp": "1.0.5",
+        "source-map": "0.5.6",
+        "string-hash": "1.1.1",
+        "stylis": "3.2.18"
+      },
+      "dependencies": {
+        "babel-traverse": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
+          "integrity": "sha1-acY2WATxpPaesSE/hbAKgYuMIa0=",
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.25.0",
+            "babel-types": "6.23.0",
+            "babylon": "6.14.1",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
+          "integrity": "sha1-uxcXnXU4utOM0MnhFdNA935+ms8=",
+          "requires": {
+            "babel-runtime": "6.25.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.14.1",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+          "integrity": "sha1-lWJ1+rcnU62bNDXXr+WPi/CimBU="
+        },
+        "convert-source-map": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
+          "integrity": "sha1-6fPpxuJyjvwmdmlqcOs4L3MQamc="
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stylis": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.2.18.tgz",
+      "integrity": "sha512-Zd5jC5rqBLp0xoq/m7r2tYsJNIIikN6mTbfrD7qfvwOzbUOk16nI7U/rrJ/dkLiVnSMGxGcsW5R4DQhW8kt0eA=="
     },
     "stylis-rule-sheet": {
       "version": "0.0.7",
@@ -17227,9 +17461,9 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tslib": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
-      "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
+      "integrity": "sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -17583,11 +17817,11 @@
       }
     },
     "url-parse": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
-      "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
+      "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
       "requires": {
-        "querystringify": "1.0.0",
+        "querystringify": "2.0.0",
         "requires-port": "1.0.0"
       }
     },
@@ -17877,6 +18111,11 @@
         }
       }
     },
+    "vega-event-selector": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.0.tgz",
+      "integrity": "sha512-EZeStM/7LNfJiRuop0lvhOR52Q1l9i/EIYUnm/XddhjR+UqhPkeCmZcffMTr41z3aGm/zciVLlKanUWNT+jQ1A=="
+    },
     "vega-force": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-2.0.0.tgz",
@@ -17945,15 +18184,15 @@
       }
     },
     "vega-lite": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-2.4.3.tgz",
-      "integrity": "sha512-FH+9e63E4Wa+Sd45990opA8pgA4ugAZRUEytxCfKWg3JFgKOJK/L4GR7QlI5A02hrT0YhQObPz6T7T3pCjtP8Q==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-2.5.2.tgz",
+      "integrity": "sha512-0xlorKrv2PXGCOypNb3qGT1mMYnPpdzDfISMeK4PzWyttIO0TkKr+hH0mSveo1HmuxZtNfEO/ohUEC82RTPbLA==",
       "requires": {
         "@types/json-stable-stringify": "1.0.32",
         "json-stable-stringify": "1.0.1",
-        "tslib": "1.9.1",
+        "tslib": "1.9.2",
         "vega-event-selector": "2.0.0",
-        "vega-typings": "0.2.16",
+        "vega-typings": "0.3.11",
         "vega-util": "1.7.0",
         "yargs": "11.0.0"
       },
@@ -18009,11 +18248,6 @@
           "requires": {
             "ansi-regex": "3.0.0"
           }
-        },
-        "vega-event-selector": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.0.tgz",
-          "integrity": "sha512-EZeStM/7LNfJiRuop0lvhOR52Q1l9i/EIYUnm/XddhjR+UqhPkeCmZcffMTr41z3aGm/zciVLlKanUWNT+jQ1A=="
         },
         "which-module": {
           "version": "2.0.0",
@@ -18229,7 +18463,7 @@
         "d3-selection": "1.3.0",
         "d3-time-format": "2.1.1",
         "vega": "3.1.0",
-        "vega-lite": "2.4.3"
+        "vega-lite": "2.5.2"
       },
       "dependencies": {
         "d3-format": {
@@ -18275,9 +18509,12 @@
       }
     },
     "vega-typings": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.2.16.tgz",
-      "integrity": "sha512-aWQg1nXtAeaSbJcjR3obj8gAXLjeh7L4wpiz16pcsUDGMijueu6esvc4GmkUO0wIpLx0ps61y3+4WnZiE7/0Gg=="
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.3.11.tgz",
+      "integrity": "sha512-AkXIYaIIvB3uCPqiCvLALxy9KG/SmvciVhq7RFN3y7Tu4xAwa+u9q/0DwI0ru04SqlWOx+nPCsRO50BftkZuPw==",
+      "requires": {
+        "vega-util": "1.7.0"
+      }
     },
     "vega-util": {
       "version": "1.7.0",
@@ -18485,9 +18722,9 @@
       }
     },
     "vizz-wysiwyg": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vizz-wysiwyg/-/vizz-wysiwyg-2.0.2.tgz",
-      "integrity": "sha1-MWPm/PG3NVM8MuGs4WfAYUbEhEk=",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/vizz-wysiwyg/-/vizz-wysiwyg-1.1.14.tgz",
+      "integrity": "sha1-YGvfEQjWrMAwq9Laby4OqMkY2Nc=",
       "requires": {
         "autoprefixer": "6.7.6",
         "babel-core": "6.26.3",
@@ -18513,9 +18750,9 @@
         "jsonapi-serializer": "3.5.3",
         "lodash": "4.17.4",
         "lusca": "1.4.1",
-        "next": "4.2.3",
+        "next": "3.0.6",
         "next-redux-wrapper": "1.3.2",
-        "next-routes": "1.4.1",
+        "next-routes": "1.0.40",
         "node-sass": "4.5.3",
         "normalize.css": "7.0.0",
         "now-logs": "0.0.7",
@@ -18526,10 +18763,10 @@
         "postcss-easy-import": "2.0.0",
         "postcss-loader": "1.3.3",
         "postcss-middleware": "1.1.3",
-        "prop-types": "15.6.1",
+        "prop-types": "15.5.7",
         "raw-loader": "0.5.1",
-        "react": "16.3.2",
-        "react-dom": "16.3.2",
+        "react": "15.6.1",
+        "react-dom": "15.6.1",
         "react-dropzone": "4.2.9",
         "react-form": "2.16.3",
         "react-medium-editor": "1.8.1",
@@ -18539,7 +18776,7 @@
         "react-quill": "1.1.0",
         "react-redux": "5.0.5",
         "react-sortable-hoc": "0.6.8",
-        "react-transition-group": "2.3.0",
+        "react-transition-group": "2.3.1",
         "recompose": "0.26.0",
         "redis": "2.8.0",
         "redux": "3.6.0",
@@ -18555,6 +18792,11 @@
         "validate.js": "0.12.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -18566,7 +18808,7 @@
           "integrity": "sha1-APBWVsfvc96dL9m0Zo9u9pBahVo=",
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000823",
+            "caniuse-db": "1.0.30000851",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -18640,7 +18882,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000823",
+            "caniuse-db": "1.0.30000851",
             "electron-to-chromium": "1.3.42"
           }
         },
@@ -18667,6 +18909,11 @@
           "version": "3.4.1",
           "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.1.tgz",
           "integrity": "sha1-ZdWDCxolaVV8+zJMDmeZmFIUc+4="
+        },
+        "etag": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+          "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
         },
         "express-session": {
           "version": "1.14.2",
@@ -18713,6 +18960,11 @@
             "loader-utils": "1.1.0"
           }
         },
+        "fresh": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+          "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+        },
         "has-flag": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -18723,10 +18975,15 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
           "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
         },
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "ms": {
           "version": "0.7.1",
@@ -18737,6 +18994,174 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
           "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI="
+        },
+        "next": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/next/-/next-3.0.6.tgz",
+          "integrity": "sha1-FNkzCx9Oq2D9uEUjA0owFvFv5BQ=",
+          "requires": {
+            "ansi-html": "0.0.7",
+            "babel-core": "6.25.0",
+            "babel-generator": "6.25.0",
+            "babel-loader": "7.1.1",
+            "babel-plugin-module-resolver": "2.6.2",
+            "babel-plugin-react-require": "3.0.0",
+            "babel-plugin-syntax-dynamic-import": "6.18.0",
+            "babel-plugin-transform-class-properties": "6.24.1",
+            "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+            "babel-plugin-transform-object-rest-spread": "6.22.0",
+            "babel-plugin-transform-react-jsx-source": "6.22.0",
+            "babel-plugin-transform-react-remove-prop-types": "0.4.5",
+            "babel-plugin-transform-runtime": "6.22.0",
+            "babel-preset-env": "1.6.0",
+            "babel-preset-react": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.25.0",
+            "case-sensitive-paths-webpack-plugin": "2.1.1",
+            "cross-spawn": "5.1.0",
+            "del": "3.0.0",
+            "etag": "1.8.0",
+            "fresh": "0.5.0",
+            "friendly-errors-webpack-plugin": "1.5.0",
+            "glob": "7.1.1",
+            "glob-promise": "3.1.0",
+            "htmlescape": "1.1.1",
+            "http-status": "1.0.1",
+            "json-loader": "0.5.4",
+            "loader-utils": "1.1.0",
+            "md5-file": "3.1.1",
+            "minimist": "1.2.0",
+            "mkdirp-then": "1.2.0",
+            "mv": "2.1.1",
+            "mz": "2.6.0",
+            "path-match": "1.2.4",
+            "pkg-up": "2.0.0",
+            "prop-types": "15.5.10",
+            "prop-types-exact": "1.1.2",
+            "react-hot-loader": "3.0.0-beta.7",
+            "recursive-copy": "2.0.9",
+            "send": "0.15.6",
+            "source-map-support": "0.4.15",
+            "strip-ansi": "4.0.0",
+            "styled-jsx": "1.0.11",
+            "touch": "3.1.0",
+            "unfetch": "3.0.0",
+            "url": "0.11.0",
+            "uuid": "3.1.0",
+            "walk": "2.3.13",
+            "webpack": "3.3.0",
+            "webpack-dev-middleware": "1.11.0",
+            "webpack-hot-middleware": "2.18.2",
+            "write-file-webpack-plugin": "4.1.0",
+            "xss-filters": "1.2.7"
+          },
+          "dependencies": {
+            "babel-core": {
+              "version": "6.25.0",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+              "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+              "requires": {
+                "babel-code-frame": "6.26.0",
+                "babel-generator": "6.25.0",
+                "babel-helpers": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-register": "6.26.0",
+                "babel-runtime": "6.23.0",
+                "babel-template": "6.25.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "convert-source-map": "1.5.1",
+                "debug": "2.6.9",
+                "json5": "0.5.1",
+                "lodash": "4.17.4",
+                "minimatch": "3.0.4",
+                "path-is-absolute": "1.0.1",
+                "private": "0.1.8",
+                "slash": "1.0.0",
+                "source-map": "0.5.7"
+              }
+            },
+            "babel-generator": {
+              "version": "6.25.0",
+              "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+              "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+              "requires": {
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.23.0",
+                "babel-types": "6.26.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.4",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+              "requires": {
+                "core-js": "2.5.4",
+                "regenerator-runtime": "0.10.5"
+              }
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+              "requires": {
+                "babel-runtime": "6.23.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.4"
+              }
+            },
+            "prop-types": {
+              "version": "15.5.10",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+              "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1"
+              }
+            },
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+              "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+              "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+            }
+          }
+        },
+        "next-routes": {
+          "version": "1.0.40",
+          "resolved": "https://registry.npmjs.org/next-routes/-/next-routes-1.0.40.tgz",
+          "integrity": "sha512-epinsnJELR7yztc4rPaPgkLlwxonEvco3Gm0DIsnnGWn1C0QDuuLeTWW+fh4i/ApMuEqZdq24SDDEsHIpuJ0fQ==",
+          "requires": {
+            "path-to-regexp": "1.7.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
         },
         "postcss": {
           "version": "5.2.18",
@@ -18760,6 +19185,14 @@
             "postcss-load-config": "1.2.0"
           }
         },
+        "prop-types": {
+          "version": "15.5.7",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.7.tgz",
+          "integrity": "sha1-IxxPKc3YLjVQEdSIk4bKkFlUTdE=",
+          "requires": {
+            "fbjs": "0.8.16"
+          }
+        },
         "qs": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
@@ -18775,6 +19208,53 @@
             "unpipe": "1.0.0"
           }
         },
+        "react": {
+          "version": "15.6.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
+          "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+          "requires": {
+            "create-react-class": "15.6.3",
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          },
+          "dependencies": {
+            "prop-types": {
+              "version": "15.6.1",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            }
+          }
+        },
+        "react-dom": {
+          "version": "15.6.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
+          "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          },
+          "dependencies": {
+            "prop-types": {
+              "version": "15.6.1",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            }
+          }
+        },
         "react-redux": {
           "version": "5.0.5",
           "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.5.tgz",
@@ -18787,6 +19267,18 @@
             "lodash-es": "4.17.8",
             "loose-envify": "1.3.1",
             "prop-types": "15.6.1"
+          },
+          "dependencies": {
+            "prop-types": {
+              "version": "15.6.1",
+              "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+              "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+              "requires": {
+                "fbjs": "0.8.16",
+                "loose-envify": "1.3.1",
+                "object-assign": "4.1.1"
+              }
+            }
           }
         },
         "redux": {
@@ -18805,10 +19297,78 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         },
+        "send": {
+          "version": "0.15.6",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
+          "integrity": "sha1-IPI6nJJbdiq4JwX+L52yUqzkfjQ=",
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "1.6.3",
+            "mime": "1.3.4",
+            "ms": "2.0.0",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "etag": {
+              "version": "1.8.1",
+              "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+              "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+            },
+            "fresh": {
+              "version": "0.5.2",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+              "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+            },
+            "http-errors": {
+              "version": "1.6.3",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+              "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+              "requires": {
+                "depd": "1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": "1.5.0"
+              },
+              "dependencies": {
+                "statuses": {
+                  "version": "1.5.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+                  "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+                }
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-support": {
+          "version": "0.4.15",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+          "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+          "requires": {
+            "source-map": "0.5.7"
+          }
         },
         "sqlite3": {
           "version": "3.1.8",
@@ -19756,6 +20316,11 @@
             }
           }
         },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+        },
         "superagent": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.6.0.tgz",
@@ -19773,6 +20338,11 @@
             "readable-stream": "2.3.6"
           },
           "dependencies": {
+            "mime": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+              "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+            },
             "qs": {
               "version": "6.5.2",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -19792,6 +20362,35 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
           "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+        },
+        "webpack": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.3.0.tgz",
+          "integrity": "sha1-zi+eB2Vmq6kfdIhxM6iD/X2hh7w=",
+          "requires": {
+            "acorn": "5.5.3",
+            "acorn-dynamic-import": "2.0.2",
+            "ajv": "5.5.2",
+            "ajv-keywords": "2.1.1",
+            "async": "2.6.0",
+            "enhanced-resolve": "3.4.1",
+            "escope": "3.6.0",
+            "interpret": "1.1.0",
+            "json-loader": "0.5.4",
+            "json5": "0.5.1",
+            "loader-runner": "2.3.0",
+            "loader-utils": "1.1.0",
+            "memory-fs": "0.4.1",
+            "mkdirp": "0.5.1",
+            "node-libs-browser": "2.1.0",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3",
+            "tapable": "0.2.8",
+            "uglifyjs-webpack-plugin": "0.4.6",
+            "watchpack": "1.5.0",
+            "webpack-sources": "1.1.0",
+            "yargs": "6.6.0"
+          }
         }
       }
     },
@@ -20064,6 +20663,28 @@
         }
       }
     },
+    "webpack-dev-middleware": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.11.0.tgz",
+      "integrity": "sha1-CWkdCXOjCtH4Ksc6EuIIfwpHVPk=",
+      "requires": {
+        "memory-fs": "0.4.1",
+        "mime": "1.3.4",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0"
+      }
+    },
+    "webpack-hot-middleware": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.18.2.tgz",
+      "integrity": "sha512-dB7uOnUWsojZIAC6Nwi5v3tuaQNd2i7p4vF5LsJRyoTOgr2fRYQdMKQxRZIZZaz0cTPBX8rvcWU1A6/n7JTITg==",
+      "requires": {
+        "ansi-html": "0.0.7",
+        "html-entities": "1.2.1",
+        "querystring": "0.2.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
     "webpack-sources": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
@@ -20110,18 +20731,18 @@
       }
     },
     "widget-editor": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/widget-editor/-/widget-editor-1.2.2.tgz",
-      "integrity": "sha1-TfLSmh2ggMIxMT4q8LSvTNScA1w=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/widget-editor/-/widget-editor-1.3.0.tgz",
+      "integrity": "sha1-Hu5YW2NkneSwWtWonaOx7zPaAMY=",
       "requires": {
         "autobind-decorator": "2.1.0",
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "d3-format": "1.3.0",
         "d3-time-format": "2.1.1",
-        "esri-leaflet": "2.1.1",
+        "esri-leaflet": "2.1.4",
         "lodash": "4.17.4",
-        "peer-deps-externals-webpack-plugin": "1.0.2",
+        "peer-deps-externals-webpack-plugin": "1.0.3",
         "prop-types": "15.6.1",
         "rc-slider": "8.6.1",
         "react-dnd": "2.6.0",
@@ -20278,16 +20899,43 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "wri-api-components": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/wri-api-components/-/wri-api-components-1.0.4.tgz",
-      "integrity": "sha1-Kcz9xnJcrwlqpn4jLfXWk8z/hCc=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/wri-api-components/-/wri-api-components-1.0.5.tgz",
+      "integrity": "sha1-7TPZZehWJXfg201bq+t1NF9unF4=",
       "requires": {
         "prop-types": "15.6.1",
         "rc-tooltip": "3.7.0",
+        "react": "15.6.2",
         "react-css-modules": "4.7.2",
+        "react-dom": "15.6.2",
         "react-input-range": "1.3.0",
         "react-sortable-hoc": "0.6.8",
         "wri-json-api-serializer": "1.0.1"
+      },
+      "dependencies": {
+        "react": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+          "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+          "requires": {
+            "create-react-class": "15.6.3",
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        },
+        "react-dom": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+          "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.1"
+          }
+        }
       }
     },
     "wri-json-api-serializer": {
@@ -20312,6 +20960,43 @@
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
         "slide": "1.1.6"
+      }
+    },
+    "write-file-webpack-plugin": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/write-file-webpack-plugin/-/write-file-webpack-plugin-4.1.0.tgz",
+      "integrity": "sha512-KkFZtNeeuSjig5sACrd0n1ybrpd4CS8P5J2TGEklS7UGGlz+iISAxJf426XwaQ2TTlTAq1LTXRBWTTEYjy5e4A==",
+      "requires": {
+        "chalk": "1.1.3",
+        "debug": "2.6.9",
+        "filesize": "3.6.1",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "moment": "2.22.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
     },
     "ws": {


### PR DESCRIPTION
## Overview
When the textarea of the advanced mode is empty, the  preview fails and displays an error in the console. To prevent this, the  preview is only shown if the widget config contains a "data" object.

## Testing instructions
To test this PR, go to http://localhost:3000/admin/data/widgets/new, select a dataset and choose the advanced mode. You shouldn't see any error related to "data is undefined" in the console.

## Pivotal task
None.