### PR TITLE
FEAT Subscriptions 

### DIFF
--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -83,7 +83,7 @@ class AreasForm extends React.Component {
       name: name || '',
       geostore: geostore || '',
       openUploadAreaModal,
-      geojson: null,
+      geojson: [],
       geoCountrySelected: false
     };
 
@@ -164,15 +164,17 @@ class AreasForm extends React.Component {
     });
   }
 
-  onMapDraw(layer) {
-    this.setState({
-      geojson: {
-        geojson: {
-          type: 'FeatureCollection',
-          features: [layer.toGeoJSON()]
-        }
-      }
+  onMapDraw(layerGroup) {
+    const geoJsonStructure = {
+      type: 'FeatureCollection',
+      features: []
+    };
+
+    layerGroup.eachLayer((l) => {
+      geoJsonStructure.features.push(l.toGeoJSON());
     });
+
+    this.setState({ geojson: { geojson: geoJsonStructure } });
   }
 
   onUploadArea(id) {

--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -233,24 +233,22 @@ class AreasForm extends React.Component {
             </Field>
           </fieldset>
 
-          {mode === 'new' &&
-            <div
-              className="c-field selectors-container"
-            >
-              <Spinner isLoading={loadingAreaOptions || loading} className="-light -small" />
-              <CustomSelect
-                placeholder="Select area"
-                options={areaOptions}
-                onValueChange={this.onChangeSelectedArea}
-                allowNonLeafSelection={false}
-                value={geostore}
-                waitForChangeConfirmation
-                disabled={mode === 'edit'}
-              />
-            </div>
-          }
+          <div
+            className="c-field selectors-container"
+          >
+            <Spinner isLoading={loadingAreaOptions || loading} className="-light -small" />
+            <CustomSelect
+              placeholder="Select area"
+              options={areaOptions}
+              onValueChange={this.onChangeSelectedArea}
+              allowNonLeafSelection={false}
+              value={geostore}
+              waitForChangeConfirmation
+              disabled={mode === 'edit'}
+            />
+          </div>
 
-          {geostore && mode === 'new' && <span className="c-field__helpMessage">If you want to draw a custom area, remove selected area.</span>}
+          {geostore && mode === 'new' && <span className="c-field__helpMessage">If you want to draw/upload a custom area, remove the selected area above.</span>}
 
           {!geostore && <div className="c-field c-field__map">
             <label>Draw Area</label>
@@ -276,7 +274,7 @@ class AreasForm extends React.Component {
             </div>
           </div>}
 
-          <UploadArea />
+          {!geostore && <UploadArea />}
 
           <div className="buttons-div">
             <button type="button" onClick={() => Router.pushRoute('myrw', { tab: 'areas' })} className="c-btn -secondary">

--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -10,6 +10,7 @@ import { toggleModal, setModalOptions } from 'redactions/modal';
 // Components
 import CustomSelect from 'components/ui/CustomSelect';
 import Spinner from 'components/ui/Spinner';
+import Map from 'components/ui/map/Map';
 import Field from 'components/form/Field';
 import Input from 'components/form/Input';
 import UploadAreaIntersectionModal from 'components/modal/UploadAreaIntersectionModal';
@@ -20,6 +21,24 @@ import UserService from 'services/UserService';
 
 // Utils
 import { logEvent } from 'utils/analytics';
+import LayerManager from 'utils/layers/LayerManager';
+
+// Constants
+const MAP_CONFIG = {
+  zoom: 3,
+  latLng: {
+    lat: 0,
+    lng: 0
+  },
+  zoomControl: false
+};
+
+const mapStyles = {
+  display: 'inline-block',
+  height: '410px',
+  position: 'relative',
+  width: '100%'
+};
 
 const FORM_ELEMENTS = {
   elements: {
@@ -87,6 +106,8 @@ class AreasForm extends React.Component {
       geostore: geostore || '',
       openUploadAreaModal
     };
+
+    this.map = null;
 
     // Services
     this.areasService = new AreasService({ apiURL: process.env.WRI_API_URL });
@@ -215,6 +236,8 @@ class AreasForm extends React.Component {
     } = this.state;
     const { mode } = this.props;
 
+    console.log(this);
+
     return (
       <div className="c-areas-form">
         <Spinner loading={loading || loadingAreaOptions} className="-light" />
@@ -252,6 +275,20 @@ class AreasForm extends React.Component {
               />
             </div>
           }
+          <div className="c-field">
+            <label for="input-name" class="label">Draw Area</label>
+            <div style={mapStyles}>
+              <Map
+                LayerManager={LayerManager}
+                mapConfig={MAP_CONFIG}
+                setMapInstance={(map) => { this.map = map; }}
+                layerGroups={[]}
+                canDraw
+              />
+            </div>
+          </div>
+
+
           <div className="buttons-div">
             <button type="button" onClick={() => Router.pushRoute('myrw', { tab: 'areas' })} className="c-btn -secondary">
               Cancel

--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -83,7 +83,7 @@ class AreasForm extends React.Component {
       name: name || '',
       geostore: geostore || '',
       openUploadAreaModal,
-      geojson: [],
+      geojson: null,
       geoCountrySelected: false
     };
 

--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -226,6 +226,10 @@ class AreasForm extends React.Component {
     });
   }
 
+  onMapDraw(layer) {
+    console.log('im drawing', layer);
+  }
+
   render() {
     const {
       areaOptions,
@@ -276,7 +280,7 @@ class AreasForm extends React.Component {
             </div>
           }
           <div className="c-field">
-            <label for="input-name" class="label">Draw Area</label>
+            <label>Draw Area</label>
             <div style={mapStyles}>
               <Map
                 LayerManager={LayerManager}
@@ -284,6 +288,7 @@ class AreasForm extends React.Component {
                 setMapInstance={(map) => { this.map = map; }}
                 layerGroups={[]}
                 canDraw
+                onMapDraw={layer => this.onMapDraw(layer)}
               />
             </div>
           </div>

--- a/components/ui/map/Map.js
+++ b/components/ui/map/Map.js
@@ -53,8 +53,7 @@ class Map extends React.Component {
     canDraw: PropTypes.bool,
     interactionEnabled: PropTypes.bool,
     disableScrollZoom: PropTypes.bool,
-    onMapInstance: PropTypes.func,
-    onMapDraw: PropTypes.func,
+
     // STORE
     mapConfig: PropTypes.object,
     location: PropTypes.object,
@@ -63,14 +62,17 @@ class Map extends React.Component {
     labels: PropTypes.object,
     boundaries: PropTypes.bool,
     filters: PropTypes.object,
+    drawShape: PropTypes.array,
     layerGroups: PropTypes.array, // List of LayerGroup items
     interaction: PropTypes.object,
     interactionSelected: PropTypes.string,
     interactionLatLng: PropTypes.object,
     availableInteractions: PropTypes.array,
-    LayerManager: PropTypes.func,
 
     // ACTIONS
+    onMapInstance: PropTypes.func,
+    onMapDraw: PropTypes.func,
+    LayerManager: PropTypes.func,
     onMapParams: PropTypes.func,
     setLayerInteraction: PropTypes.func,
     setLayerInteractionSelected: PropTypes.func,
@@ -86,6 +88,7 @@ class Map extends React.Component {
     filters: {},
     interaction: {},
     interactionLatLng: {},
+    drawShape: [{}],
 
     boundaries: false,
     swipe: false,
@@ -105,7 +108,7 @@ class Map extends React.Component {
     onMapParams: VOID,
     setLayerInteraction: VOID,
     setLayerInteractionSelected: VOID,
-    setLayerInteractionLatLng: VOID
+    setLayerInteractionLatLng: VOID,
   };
 
   state = {
@@ -140,8 +143,19 @@ class Map extends React.Component {
     }
 
     if (this.props.canDraw) {
+      // For now we only support 1 shape
+      const drawShape = this.props.drawShape[0];
+      console.log('drawshape', drawShape);
+
       // Initialise the FeatureGroup to store editable layers
       const editableLayers = new L.FeatureGroup();
+
+      if (drawShape.layers.length) {
+        const polygon = new L.Polygon(drawShape.layers[0].layerConfig.data.features[0].geometry);
+        polygon.editing.enable();
+        editableLayers.addLayer(polygon);
+      }
+
       this.map.addLayer(editableLayers);
 
       this.drawConfig = {
@@ -545,9 +559,7 @@ class Map extends React.Component {
       bounds = geometry.getBounds();
     }
 
-    this.map.fitBounds(bounds, {
-      padding: [20, 20]
-    });
+    this.map.fitBounds(bounds, { padding: [20, 20] });
   }
 
   removeMapEventListeners() {

--- a/components/ui/map/Map.js
+++ b/components/ui/map/Map.js
@@ -143,19 +143,8 @@ class Map extends React.Component {
     }
 
     if (this.props.canDraw) {
-      // For now we only support 1 shape
-      const drawShape = this.props.drawShape[0];
-      console.log('drawshape', drawShape);
-
       // Initialise the FeatureGroup to store editable layers
       const editableLayers = new L.FeatureGroup();
-
-      if (drawShape.layers.length) {
-        const polygon = new L.Polygon(drawShape.layers[0].layerConfig.data.features[0].geometry);
-        polygon.editing.enable();
-        editableLayers.addLayer(polygon);
-      }
-
       this.map.addLayer(editableLayers);
 
       this.drawConfig = {

--- a/components/ui/map/Map.js
+++ b/components/ui/map/Map.js
@@ -177,7 +177,8 @@ class Map extends React.Component {
       this.map.on(L.Draw.Event.CREATED, (event) => {
         const { layer } = event;
         editableLayers.addLayer(layer);
-        this.props.onMapDraw(layer);
+
+        this.props.onMapDraw(editableLayers);
       });
     }
 

--- a/components/ui/map/Map.js
+++ b/components/ui/map/Map.js
@@ -142,6 +142,7 @@ class Map extends React.Component {
       this.map.scrollWheelZoom.disable();
     }
 
+    // TODO: Move the draw logic to WRI api components
     if (this.props.canDraw) {
       // Initialise the FeatureGroup to store editable layers
       const editableLayers = new L.FeatureGroup();
@@ -152,7 +153,8 @@ class Map extends React.Component {
         draw: {
           polygon: {
             allowIntersection: false,
-            showArea: true
+            showArea: true,
+            shapeOptions: { color: '#c32d7b' }
           },
           polyline: false,
           circle: false,

--- a/css/components/areas/upload_area.scss
+++ b/css/components/areas/upload_area.scss
@@ -1,18 +1,20 @@
-.c-upload-area-intersection-modal {
+.c-upload-area {
   p a {
     color: $color-secondary;
     text-decoration: none;
   }
 
   .c-dropzone {
-    margin: 40px 0;
+    margin: 20px 0;
   }
 
   .dropzone-file-input {
     display: flex;
     height: 45px;
-    margin-top: 40px;
+
+    margin: 10px 0 20px 0;
     padding: 5px;
+
     border: 1px solid $border-color-2;
     border-radius: 4px;
 
@@ -33,8 +35,12 @@
 
   .dropzone-file-errors {
     width: 100%;
+
     padding: 10px 20px;
+    margin: 0 0 40px 0;
+
     list-style: none;
+
     background-color: rgba(250,183,46,0.2);
     border-radius: 4px;
 
@@ -42,19 +48,19 @@
       display: inline-block;
       margin-right: 5px;
       padding: 2px 8px;
+
       color: $color-white;
       background-color: $color-mango;
+
       border-radius: 4px;
     }
   }
 
   .complementary-info {
-    margin-top: 40px;
+    margin-top: 20px;
     font-size: $font-size-default;
 
-    p {
-      margin: 0;
-    }
+    p { margin: 0; }
 
     ul {
       margin: 10px 0;

--- a/css/components/form/field.scss
+++ b/css/components/form/field.scss
@@ -26,6 +26,16 @@
     }
   }
 
+  &__map {
+    margin: 20px 0 0 0;
+    &--container {
+      display: inline-block;
+      height: 410px;
+      position: relative;
+      width: 100%;
+    }
+  }
+
   .hint {
     font-style: italic;
     padding: 0 0 5px;

--- a/css/components/form/field.scss
+++ b/css/components/form/field.scss
@@ -26,6 +26,14 @@
     }
   }
 
+  &__helpMessage {
+    display: block;
+    font-size: 13px;
+    color: #989898;
+    position: relative;
+    top: -15px;
+  }
+
   &__map {
     margin: 20px 0 0 0;
     &--container {

--- a/css/index.scss
+++ b/css/index.scss
@@ -94,7 +94,6 @@
 @import "./components/modal/share_modal_explore";
 @import "./components/modal/embed_layer_modal";
 @import "./components/modal/embed_table_modal";
-@import "./components/modal/upload_area_intersection_modal";
 @import "./components/modal/subscribe_to_dataset_modal";
 @import "./components/modal/area_subscription_modal";
 @import "./components/modal/layer_info_modal";
@@ -105,6 +104,8 @@
 @import "./components/areas/areas_list";
 @import "./components/areas/area_card";
 @import "./components/areas/area_actions_tooltip";
+@import "./components/areas/upload_area";
+
 
 // collections
 @import "./components/collections/collections-panel";

--- a/layout/head/app.js
+++ b/layout/head/app.js
@@ -175,9 +175,18 @@ class Head extends React.PureComponent {
           integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ=="
           crossOrigin=""
         />
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.3/leaflet.draw.css"
+          crossOrigin=""
+        />
         <script
           src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"
           integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw=="
+          crossOrigin=""
+        />
+        <script
+          src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.3/leaflet.draw.js"
           crossOrigin=""
         />
         <script

--- a/layout/head/app.js
+++ b/layout/head/app.js
@@ -177,7 +177,7 @@ class Head extends React.PureComponent {
         />
         <link
           rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.3/leaflet.draw.css"
+          href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css"
           crossOrigin=""
         />
         <script
@@ -186,7 +186,7 @@ class Head extends React.PureComponent {
           crossOrigin=""
         />
         <script
-          src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.3/leaflet.draw.js"
+          src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"
           crossOrigin=""
         />
         <script

--- a/services/AreasService.js
+++ b/services/AreasService.js
@@ -39,4 +39,16 @@ export default class AreasService {
     return fetch(`${this.opts.apiURL}/geostore/${id}`)
       .then(response => response.json());
   }
+
+  createGeostore(geojson) {
+    console.log(geojson);
+    return fetch(`${this.opts.apiURL}/geostore`, {
+      method: 'POST',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      body: JSON.stringify(geojson)
+    }).then((response) => {
+      if (!response.ok) throw new Error('The file couldn\'t be processed correctly. Try again in a few minutes.');
+      return response.json();
+    }).then(({ data }) => data.id);
+  }
 }

--- a/services/AreasService.js
+++ b/services/AreasService.js
@@ -40,15 +40,15 @@ export default class AreasService {
       .then(response => response.json());
   }
 
-  createGeostore(geojson) {
-    console.log(geojson);
-    return fetch(`${this.opts.apiURL}/geostore`, {
+  async createGeostore(geojson) {
+    const response = await fetch(`${this.opts.apiURL}/geostore`, {
       method: 'POST',
       headers: new Headers({ 'content-type': 'application/json' }),
       body: JSON.stringify(geojson)
-    }).then((response) => {
-      if (!response.ok) throw new Error('The file couldn\'t be processed correctly. Try again in a few minutes.');
-      return response.json();
-    }).then(({ data }) => data.id);
+    });
+
+    if (!response.ok) throw new Error('The file couldn\'t be processed correctly. Try again in a few minutes.');
+    const { data } = await response.json();
+    return data;
   }
 }

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -275,10 +275,11 @@ export default class UserService {
   /**
   * Update area
   */
-  updateArea(id, name, token) {
+  updateArea(id, name, token, geostore) {
     const bodyObj = {
       name,
-      application: process.env.APPLICATIONS
+      application: process.env.APPLICATIONS,
+      geostore
     };
 
     return fetch(`${this.opts.apiURL}/area/${id}`, {


### PR DESCRIPTION
### Allow users to draw their own subscription area on a map

__Note__: we cant have both the country selector and Upload/Draw values active. So added a new UX element if you select a country from the list. so its clear what action is needed from the user.  Screenshot below:
![screen shot 2018-08-09 at 15 56 14](https://user-images.githubusercontent.com/971129/43903624-28e67666-9bed-11e8-9643-ee66a51ae963.png)

__Another note__: I thought it was a good idea to show the previous selection still in **blue** on the map. This is so you can compare against your previous geo settings while drawing. Screenshot below:

![screen shot 2018-08-09 at 16 30 29](https://user-images.githubusercontent.com/971129/43905563-9a3d656e-9bf1-11e8-8f5a-96e21a2bac2a.png)



Full Feature with (country geo, drawing map, upload) components:
![screen shot 2018-08-09 at 15 58 05](https://user-images.githubusercontent.com/971129/43903574-0c328fa0-9bed-11e8-90b3-2543ae4aeeda.png)

+ Moved the upload modal out and removed the logic for toggling the modal view. as the new mockups don't require a modal window. 

+ Cleaned up styles, and renamed as the upload component is not a modal anymore. 

#### Bug fixes and improvements. 

1. Fix country selector returning null values in list

Before:
![screen shot 2018-08-09 at 13 19 25](https://user-images.githubusercontent.com/971129/43895829-deb2db2c-9bd6-11e8-9038-27aaa389938d.png)

After:
![screen shot 2018-08-09 at 13 18 51](https://user-images.githubusercontent.com/971129/43895846-eb2ed9b4-9bd6-11e8-9f1f-c2b17075b90b.png)

2. When removing selected country area, make sure to remove geostore from state
