### PR TITLE
Switch order ot appearance of results on the Explore Search

### DIFF
--- a/components/datasets/search/search-component.js
+++ b/components/datasets/search/search-component.js
@@ -182,15 +182,15 @@ class SearchComponent extends React.Component {
     const { value } = e.currentTarget;
 
     const filteredList = (value.length > 2) ? sortBy(this.fuse.search(value), 'label') : [];
-
+    const newGroupFilteredList = omit(groupBy(filteredList, (l) => {
+      const group = l.labels && l.labels[1];
+      return group || 'undefined';
+    }), ['undefined', 'GEOGRAPHY']);
     this.setState({
-      index: 0,
+      index: Object.keys(newGroupFilteredList).length > 0 ? 1 : 0,
       value,
       filteredList,
-      groupedFilteredList: omit(groupBy(filteredList, (l) => {
-        const group = l.labels && l.labels[1];
-        return group || 'undefined';
-      }), ['undefined', 'GEOGRAPHY'])
+      groupedFilteredList: newGroupFilteredList
     });
   }
 
@@ -219,7 +219,6 @@ class SearchComponent extends React.Component {
   render() {
     const { open, search, options, selected, tab, list } = this.props;
     const { index, value, groupedFilteredList } = this.state;
-
     let groupedFilteredListIndex = 0;
 
     const tabs = this.getTabs();
@@ -315,25 +314,6 @@ class SearchComponent extends React.Component {
         {open && value &&
           <div className="search-dropdown">
             <div className="search-dropdown-list">
-              <div className="search-dropdown-list-item">
-                <h4>Search by text:</h4>
-
-                <ul className="list-item-results">
-                  <li>
-                    <button
-                      type="button"
-                      className={classnames({
-                        '-active': index === 0
-                      })}
-                      onClick={() => this.props.onChangeSearch(value)}
-                      onMouseOver={() => this.onListItemMouseOver(0)}
-                    >
-                      {value}
-                    </button>
-                  </li>
-                </ul>
-              </div>
-
               {Object.keys(groupedFilteredList).map(g => (
                 <div className="search-dropdown-list-item" key={g}>
                   {!!g && g.toLowerCase &&
@@ -351,7 +331,7 @@ class SearchComponent extends React.Component {
                           <button
                             type="button"
                             className={classnames({
-                              '-active': index === currentIndex
+                              '-active': index === 1 && currentIndex === 1
                             })}
                             onClick={() => {
                               this.props.onToggleSelected({
@@ -371,6 +351,24 @@ class SearchComponent extends React.Component {
                   </ul>
                 </div>
               ))}
+              <div className="search-dropdown-list-item">
+                <h4>Search by text:</h4>
+
+                <ul className="list-item-results">
+                  <li>
+                    <button
+                      type="button"
+                      className={classnames({
+                        '-active': index === 0
+                      })}
+                      onClick={() => this.props.onChangeSearch(value)}
+                      onMouseOver={() => this.onListItemMouseOver(0)}
+                    >
+                      {value}
+                    </button>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
         }


### PR DESCRIPTION
## Overview
This PR updates the Explore search drop down so that the type of search used by default is the graph filter instead of the text search - of course this only applies to the cases where concepts are found for the text entered by the user.

## Testing instructions
Go to the Explore page and search for any given value that will produce concept results.

## [Pivotal task](https://www.pivotaltracker.com/story/show/159495903)

![image](https://user-images.githubusercontent.com/545342/43894267-e212651c-9bd1-11e8-8004-b657c8c74cd8.png)
