### PR TITLE
Widget editor upgrade

### DIFF
--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -22,6 +22,7 @@ import Spinner from 'components/ui/Spinner';
 // Widget editor
 import WidgetEditor, { VegaChart, getVegaTheme } from 'widget-editor';
 
+const defaultTheme = getVegaTheme();
 
 class Step1 extends Component {
   static defaultProps = { showEditor: true };
@@ -100,8 +101,6 @@ class Step1 extends Component {
 
     const editorFieldContainerClass = classnames({ '-expanded': this.props.mode === 'editor' });
     const widgetTypeEmbed = this.state.form.widgetConfig.type === 'embed';
-
-    const theme = getVegaTheme();
 
     return (
       <fieldset className="c-field-container">
@@ -320,7 +319,7 @@ class Step1 extends Component {
                       {this.state.form.widgetConfig && this.state.form.widgetConfig.data && (
                         <VegaChart
                           data={this.state.form.widgetConfig}
-                          theme={theme}
+                          theme={defaultTheme}
                           showLegend
                           reloadOnResize
                           toggleLoading={this.triggerToggleLoadingVegaChart}
@@ -352,7 +351,7 @@ class Step1 extends Component {
             <Spinner isLoading={loadingVegaChart} className="-light -relative" />
             <VegaChart
               data={this.state.form.widgetConfig}
-              theme={theme}
+              theme={defaultTheme}
               showLegend
               reloadOnResize
               toggleLoading={this.triggerToggleLoadingVegaChart}

--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -101,6 +101,8 @@ class Step1 extends Component {
     const editorFieldContainerClass = classnames({ '-expanded': this.props.mode === 'editor' });
     const widgetTypeEmbed = this.state.form.widgetConfig.type === 'embed';
 
+    const theme = getVegaTheme();
+
     return (
       <fieldset className="c-field-container">
         <fieldset className="c-field-container">
@@ -350,7 +352,7 @@ class Step1 extends Component {
             <Spinner isLoading={loadingVegaChart} className="-light -relative" />
             <VegaChart
               data={this.state.form.widgetConfig}
-              theme={getVegaTheme()}
+              theme={theme}
               showLegend
               reloadOnResize
               toggleLoading={this.triggerToggleLoadingVegaChart}

--- a/components/admin/widgets/form/steps/Step1.js
+++ b/components/admin/widgets/form/steps/Step1.js
@@ -320,7 +320,7 @@ class Step1 extends Component {
                       {this.state.form.widgetConfig && this.state.form.widgetConfig.data && (
                         <VegaChart
                           data={this.state.form.widgetConfig}
-                          theme={getVegaTheme(true)}
+                          theme={theme}
                           showLegend
                           reloadOnResize
                           toggleLoading={this.triggerToggleLoadingVegaChart}

--- a/components/charts/widget-chart/index.js
+++ b/components/charts/widget-chart/index.js
@@ -9,6 +9,9 @@ import { VegaChart, getVegaTheme } from 'widget-editor';
 import Spinner from 'components/ui/Spinner';
 import DatasetPlaceholderChart from '../placeholder-chart';
 
+const defaultTheme = getVegaTheme();
+const defaultThumbnailTheme = getVegaTheme(true);
+
 class DatasetWidgetChart extends React.Component {
   static propTypes = {
     widget: PropTypes.object,
@@ -46,7 +49,7 @@ class DatasetWidgetChart extends React.Component {
   render() {
     const { mode, widget } = this.props;
 
-    const themeObj = getVegaTheme(mode === 'thumbnail');
+    const themeObj = mode === 'thumbnail' ? defaultThumbnailTheme : defaultTheme;
     const classname = classnames({
       'c-widget-chart': true,
       '-thumbnail': (mode === 'thumbnail')

--- a/components/wysiwyg/widget-block/widget-block-component.js
+++ b/components/wysiwyg/widget-block/widget-block-component.js
@@ -127,6 +127,8 @@ class WidgetBlock extends React.Component {
       'icon-star-empty': !isInACollection
     });
 
+    const theme = getVegaTheme();
+
     return (
       <div className={classNames}>
         <header>
@@ -215,7 +217,7 @@ class WidgetBlock extends React.Component {
           {!widgetError && widgetType === 'vega' && widget.widgetConfig && widget &&
             <VegaChart
               data={widget.widgetConfig}
-              theme={getVegaTheme()}
+              theme={theme}
               toggleLoading={loading => onToggleLoading(loading)}
               reloadOnResize
             />

--- a/components/wysiwyg/widget-block/widget-block-component.js
+++ b/components/wysiwyg/widget-block/widget-block-component.js
@@ -32,6 +32,8 @@ import { VegaChart, getVegaTheme } from 'widget-editor';
 // helpers
 import { belongsToACollection } from 'components/collections-panel/collections-panel-helpers';
 
+const defaultTheme = getVegaTheme();
+
 class WidgetBlock extends React.Component {
   static propTypes = {
     user: PropTypes.object,
@@ -127,8 +129,6 @@ class WidgetBlock extends React.Component {
       'icon-star-empty': !isInACollection
     });
 
-    const theme = getVegaTheme();
-
     return (
       <div className={classNames}>
         <header>
@@ -217,7 +217,7 @@ class WidgetBlock extends React.Component {
           {!widgetError && widgetType === 'vega' && widget.widgetConfig && widget &&
             <VegaChart
               data={widget.widgetConfig}
-              theme={theme}
+              theme={defaultTheme}
               toggleLoading={loading => onToggleLoading(loading)}
               reloadOnResize
             />

--- a/layout/explore-detail/explore-detail-widget-editor/explore-detail-widget-editor-component.js
+++ b/layout/explore-detail/explore-detail-widget-editor/explore-detail-widget-editor-component.js
@@ -15,6 +15,8 @@ import WidgetEditor, { VegaChart, getVegaTheme } from 'widget-editor';
 import Modal from 'components/modal/modal-component';
 import SaveWidgetModal from 'components/modal/SaveWidgetModal';
 
+const defaultTheme = getVegaTheme();
+
 // Constants
 class ExploreDetailWidgetEditor extends PureComponent {
   static propTypes = {
@@ -33,7 +35,6 @@ class ExploreDetailWidgetEditor extends PureComponent {
   render() {
     const { dataset, responsive } = this.props;
     const defaultEditableWidget = getDatasetDefaultEditableWidget(dataset);
-    const theme = getVegaTheme();
 
     return (
       <div className="c-explore-detail-widget-editor">
@@ -74,7 +75,7 @@ class ExploreDetailWidgetEditor extends PureComponent {
                 <div className="column small-12">
                   <VegaChart
                     data={defaultEditableWidget.widgetConfig}
-                    theme={theme}
+                    theme={defaultTheme}
                     reloadOnResize
                   />
                 </div>

--- a/layout/explore-detail/explore-detail-widget-editor/explore-detail-widget-editor-component.js
+++ b/layout/explore-detail/explore-detail-widget-editor/explore-detail-widget-editor-component.js
@@ -33,6 +33,7 @@ class ExploreDetailWidgetEditor extends PureComponent {
   render() {
     const { dataset, responsive } = this.props;
     const defaultEditableWidget = getDatasetDefaultEditableWidget(dataset);
+    const theme = getVegaTheme();
 
     return (
       <div className="c-explore-detail-widget-editor">
@@ -73,7 +74,7 @@ class ExploreDetailWidgetEditor extends PureComponent {
                 <div className="column small-12">
                   <VegaChart
                     data={defaultEditableWidget.widgetConfig}
-                    theme={getVegaTheme()}
+                    theme={theme}
                     reloadOnResize
                   />
                 </div>

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "vizz-wysiwyg": "2.0.3",
     "webpack": "^3.12.0",
     "whatwg-fetch": "2.0.2",
-    "widget-editor": "^1.3.1",
+    "widget-editor": "^1.3.6",
     "wri-api-components": "1.0.6",
     "wri-json-api-serializer": "1.0.1"
   },

--- a/pages/app/embed/EmbedDataset.js
+++ b/pages/app/embed/EmbedDataset.js
@@ -75,6 +75,7 @@ class EmbedDataset extends Page {
     const datasetDescription = metadataObj && metadataObj.attributes ?
       metadataObj.attributes.description : dataset && dataset.attributes.description;
     let widget = null;
+    const theme = getVegaTheme();
 
     if (widgets) {
       widget = widgets.find(value => value.attributes.default === true);
@@ -103,7 +104,7 @@ class EmbedDataset extends Page {
             <div className="widget-content">
               <VegaChart
                 data={widget.attributes.widgetConfig}
-                theme={getVegaTheme()}
+                theme={theme}
                 toggleLoading={this.triggerToggleLoading}
                 reloadOnResize
               />

--- a/pages/app/embed/EmbedDataset.js
+++ b/pages/app/embed/EmbedDataset.js
@@ -16,6 +16,8 @@ import { VegaChart, getVegaTheme } from 'widget-editor';
 // Services
 import DatasetService from 'services/DatasetService';
 
+const defaultTheme = getVegaTheme();
+
 class EmbedDataset extends Page {
   static async getInitialProps(context) {
     const props = await super.getInitialProps(context);
@@ -75,7 +77,6 @@ class EmbedDataset extends Page {
     const datasetDescription = metadataObj && metadataObj.attributes ?
       metadataObj.attributes.description : dataset && dataset.attributes.description;
     let widget = null;
-    const theme = getVegaTheme();
 
     if (widgets) {
       widget = widgets.find(value => value.attributes.default === true);
@@ -104,7 +105,7 @@ class EmbedDataset extends Page {
             <div className="widget-content">
               <VegaChart
                 data={widget.attributes.widgetConfig}
-                theme={theme}
+                theme={defaultTheme}
                 toggleLoading={this.triggerToggleLoading}
                 reloadOnResize
               />

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -24,6 +24,8 @@ import ShareModal from 'components/modal/share-modal';
 // Widget editor
 import { VegaChart, getVegaTheme } from 'widget-editor';
 
+const defaultTheme = getVegaTheme();
+
 class EmbedWidget extends Page {
   static propTypes = {
     widget: PropTypes.object,
@@ -162,7 +164,6 @@ class EmbedWidget extends Page {
     const widgetLinks = (widgetAtts && widgetAtts.metadata && widgetAtts.metadata.length > 0 &&
       widgetAtts.metadata[0].attributes.info &&
       widgetAtts.metadata[0].attributes.info.widgetLinks) || [];
-    const theme = getVegaTheme();
 
     if (loading) {
       return (
@@ -274,7 +275,7 @@ class EmbedWidget extends Page {
           <div className="widget-content">
             <VegaChart
               data={widget.attributes.widgetConfig}
-              theme={theme}
+              theme={defaultTheme}
               toggleLoading={l => this.setState({ isLoading: l })}
               reloadOnResize
             />

--- a/pages/app/embed/EmbedWidget.js
+++ b/pages/app/embed/EmbedWidget.js
@@ -162,6 +162,7 @@ class EmbedWidget extends Page {
     const widgetLinks = (widgetAtts && widgetAtts.metadata && widgetAtts.metadata.length > 0 &&
       widgetAtts.metadata[0].attributes.info &&
       widgetAtts.metadata[0].attributes.info.widgetLinks) || [];
+    const theme = getVegaTheme();
 
     if (loading) {
       return (
@@ -273,7 +274,7 @@ class EmbedWidget extends Page {
           <div className="widget-content">
             <VegaChart
               data={widget.attributes.widgetConfig}
-              theme={getVegaTheme()}
+              theme={theme}
               toggleLoading={l => this.setState({ isLoading: l })}
               reloadOnResize
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,6 +129,10 @@ acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
+acorn@^5.2.1:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
+
 add-dom-event-listener@1.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/add-dom-event-listener/-/add-dom-event-listener-1.0.2.tgz#8faed2c41008721cf111da1d30d995b85be42bed"
@@ -413,6 +417,10 @@ assign-symbols@^1.0.0:
 ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+
+ast-types@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
 
 async-each-series@^1.1.0:
   version "1.1.0"
@@ -1248,6 +1256,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base62@^1.1.0:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/base62/-/base62-1.2.8.tgz#1264cb0fb848d875792877479dbe8bae6bae3428"
+
 base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
@@ -2027,6 +2039,10 @@ commander@2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^2.5.0:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+
 commander@~2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
@@ -2036,6 +2052,20 @@ commander@~2.8.1:
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+commoner@^0.10.1:
+  version "0.10.8"
+  resolved "https://registry.yarnpkg.com/commoner/-/commoner-0.10.8.tgz#34fc3672cd24393e8bb47e70caa0293811f4f2c5"
+  dependencies:
+    commander "^2.5.0"
+    detective "^4.3.1"
+    glob "^5.0.15"
+    graceful-fs "^4.1.2"
+    iconv-lite "^0.4.5"
+    mkdirp "^0.5.0"
+    private "^0.1.6"
+    q "^1.1.2"
+    recast "^0.11.17"
 
 compare-func@^1.3.1:
   version "1.3.2"
@@ -2260,6 +2290,10 @@ copy-webpack-plugin@^4.3.1:
     p-limit "^1.0.0"
     serialize-javascript "^1.4.0"
 
+core-js@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-0.6.1.tgz#1b4970873e8101bf8c435af095faa9024f4b9b58"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -2426,17 +2460,23 @@ d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0, d3-array@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
 
-d3-collection@1:
+d3-collection@1, d3-collection@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.4.tgz#342dfd12837c90974f33f1cc0a785aea570dcdc2"
 
-d3-color@1:
+d3-color@1, d3-color@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.0.tgz#d1ea19db5859c86854586276ec892cf93148459a"
 
 d3-contour@1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.2.0.tgz#de3ea7991bbb652155ee2a803aeafd084be03b63"
+  dependencies:
+    d3-array "^1.1.1"
+
+d3-contour@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.3.0.tgz#cfb99098c48c46edd77e15ce123162f9e333e846"
   dependencies:
     d3-array "^1.1.1"
 
@@ -2448,7 +2488,7 @@ d3-dsv@0.1:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-0.1.14.tgz#9833cd61a5a3e81e03263a1ce78f74de56a1dbb8"
 
-d3-dsv@1:
+d3-dsv@1, d3-dsv@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.0.8.tgz#907e240d57b386618dc56468bacfe76bf19764ae"
   dependencies:
@@ -2460,7 +2500,7 @@ d3-ease@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.3.tgz#68bfbc349338a380c44d8acc4fbc3304aa2d8c0e"
 
-d3-force@1:
+d3-force@1, d3-force@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.1.0.tgz#cebf3c694f1078fcc3d4daf8e567b2fbd70d4ea3"
   dependencies:
@@ -2473,7 +2513,7 @@ d3-format@0.4:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-0.4.2.tgz#aa759c1e5aae5fa8dabc9ab7819c502fc6b56875"
 
-d3-format@1, d3-format@^1.2.1, d3-format@^1.2.2:
+d3-format@1, d3-format@^1.2.1, d3-format@^1.2.2, d3-format@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.3.0.tgz#a3ac44269a2011cdb87c7b5693040c18cddfff11"
 
@@ -2489,7 +2529,7 @@ d3-geo@1, d3-geo@^1.10.0:
   dependencies:
     d3-array "1"
 
-d3-hierarchy@1:
+d3-hierarchy@1, d3-hierarchy@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.6.tgz#842c1372090f870b7ea013ebae5c0c8d9f56229c"
 
@@ -2542,6 +2582,17 @@ d3-scale@^2.0.0:
     d3-time "1"
     d3-time-format "2"
 
+d3-scale@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.1.0.tgz#8d3fd3e2a7c9080782a523c08507c5248289eef8"
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
 d3-selection@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.3.0.tgz#d53772382d3dc4f7507bfb28bcd2d6aed2a0ad6d"
@@ -2572,11 +2623,11 @@ d3-time@1, d3-time@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.8.tgz#dbd2d6007bf416fe67a76d17947b784bffea1e84"
 
-d3-timer@1, d3-timer@^1.0.4:
+d3-timer@1, d3-timer@^1.0.4, d3-timer@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.7.tgz#df9650ca587f6c96607ff4e60cc38229e8dd8531"
 
-d3-voronoi@1:
+d3-voronoi@1, d3-voronoi@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.2.tgz#1687667e8f13a2d158c80c1480c5a29cb0d8973c"
 
@@ -2864,6 +2915,10 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+defined@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+
 del@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
@@ -2923,6 +2978,13 @@ detect-libc@^1.0.2:
 detect-newline@2.X:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+
+detective@^4.3.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-4.7.1.tgz#0eca7314338442febb6d65da54c10bb1c82b246e"
+  dependencies:
+    acorn "^5.2.1"
+    defined "^1.0.0"
 
 diff-match-patch@^1.0.0:
   version "1.0.1"
@@ -3169,6 +3231,13 @@ enhanced-resolve@^3.4.0:
     memory-fs "^0.4.0"
     object-assign "^4.0.1"
     tapable "^0.2.7"
+
+envify@^3.0.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/envify/-/envify-3.4.1.tgz#d7122329e8df1688ba771b12501917c9ce5cbce8"
+  dependencies:
+    jstransform "^11.0.3"
+    through "~2.3.4"
 
 errno@^0.1.2, errno@^0.1.3:
   version "0.1.7"
@@ -3459,11 +3528,15 @@ espree@^3.5.4:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
+esprima-fb@^15001.1.0-dev-harmony-fb:
+  version "15001.1.0-dev-harmony-fb"
+  resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz#30a947303c6b8d5e955bee2b99b1d233206a6901"
+
 esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
-esprima@^3.1.3:
+esprima@^3.1.3, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -3824,6 +3897,16 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fbjs@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.6.1.tgz#9636b7705f5ba9684d44b72f78321254afc860f7"
+  dependencies:
+    core-js "^1.0.0"
+    loose-envify "^1.0.0"
+    promise "^7.0.3"
+    ua-parser-js "^0.7.9"
+    whatwg-fetch "^0.9.0"
 
 fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.16"
@@ -4403,7 +4486,7 @@ glob@7.1.2, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glo
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.3:
+glob@^5.0.15, glob@^5.0.3:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   dependencies:
@@ -4965,7 +5048,7 @@ iconv-lite@0.2:
   version "0.2.11"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.2.11.tgz#1ce60a3a57864a292d1321ff4609ca4bb965adc8"
 
-iconv-lite@0.4, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
@@ -5684,6 +5767,16 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jstransform@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/jstransform/-/jstransform-11.0.3.tgz#09a78993e0ae4d4ef4487f6155a91f6190cb4223"
+  dependencies:
+    base62 "^1.1.0"
+    commoner "^0.10.1"
+    esprima-fb "^15001.1.0-dev-harmony-fb"
+    object-assign "^2.0.0"
+    source-map "^0.4.2"
+
 jsx-ast-utils@^2.0.0, jsx-ast-utils@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
@@ -5745,6 +5838,14 @@ latest-version@^1.0.0:
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-1.0.1.tgz#72cfc46e3e8d1be651e1ebb54ea9f6ea96f374bb"
   dependencies:
     package-json "^1.0.0"
+
+layer-manager@^1.0.4:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/layer-manager/-/layer-manager-1.0.17.tgz#fb73ea8b2bb46f117e9e71f491296e53cd654817"
+  dependencies:
+    bluebird "^3.5.1"
+    lodash "^4.17.10"
+    wri-json-api-serializer "^1.0.1"
 
 lazy-cache@^0.2.3:
   version "0.2.7"
@@ -6666,6 +6767,10 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
 
 node-gyp@^3.3.1:
   version "3.6.2"
@@ -7723,7 +7828,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-private@^0.1.6, private@^0.1.7, private@^0.1.8:
+private@^0.1.6, private@^0.1.7, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -7753,7 +7858,7 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
-promise@^7.0.1, promise@^7.1.1:
+promise@^7.0.1, promise@^7.0.3, promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   dependencies:
@@ -7779,6 +7884,13 @@ prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.3, prop-types@^15.5.4, pr
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
     fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -8023,7 +8135,7 @@ rc-slider@7.0.8:
     rc-util "^4.0.4"
     warning "^3.0.0"
 
-rc-slider@^8.4.0:
+rc-slider@^8.4.0, rc-slider@^8.6.1:
   version "8.6.1"
   resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-8.6.1.tgz#ee5e0380dbdf4b5de6955a265b0d4ff6196405d1"
   dependencies:
@@ -8157,6 +8269,10 @@ react-dom@16.3.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-dom@^0.14.7:
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.14.9.tgz#05064a3dcf0fb1880a3b2bfc9d58c55d8d9f6293"
+
 react-dropdown-tree-select@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/react-dropdown-tree-select/-/react-dropdown-tree-select-1.9.2.tgz#6446ab477706a51c90876530bc1e580188dc49f8"
@@ -8259,6 +8375,14 @@ react-input-range@1.3.0, react-input-range@^1.2.1:
   dependencies:
     autobind-decorator "^1.3.4"
     prop-types "^15.5.8"
+
+react-lib@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/react-lib/-/react-lib-0.1.3.tgz#da7fc2832a35887c0ba8175c3fcd5757dc5ec6b1"
+  dependencies:
+    core-js "^0.6.0"
+    react "^0.14.7"
+    react-dom "^0.14.7"
 
 react-medium-editor@^1.8.1:
   version "1.8.1"
@@ -8455,6 +8579,12 @@ react-vega@3.1.2:
   dependencies:
     prop-types "^15.5.8"
 
+react-vega@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/react-vega/-/react-vega-4.0.2.tgz#3f2713c3efcc8fbf30e094e5c1ea0035ccea41d6"
+  dependencies:
+    prop-types "^15.6.1"
+
 react-youtube@7.5.0:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/react-youtube/-/react-youtube-7.5.0.tgz#3175a9c4e078164cf103ce4bc780a9e4ca4f1f94"
@@ -8481,6 +8611,13 @@ react@16.3.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react@^0.14.7:
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.14.9.tgz#9110a6497c49d44ba1c0edd317aec29c2e0d91d1"
+  dependencies:
+    envify "^3.0.0"
+    fbjs "^0.6.1"
 
 "react@^15.6.2 || ^16.0":
   version "16.4.0"
@@ -8587,6 +8724,15 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
+
+recast@^0.11.17:
+  version "0.11.23"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
+  dependencies:
+    ast-types "0.9.6"
+    esprima "~3.1.0"
+    private "~0.1.5"
+    source-map "~0.5.0"
 
 recompose@^0.26.0:
   version "0.26.0"
@@ -9454,7 +9600,7 @@ source-map@^0.4.2, source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -10060,7 +10206,7 @@ through2@^0.6.0, through2@^0.6.1:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3, through@~2.3.1:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -10157,7 +10303,7 @@ toastr@^2.1.2:
   dependencies:
     jquery ">=1.12.0"
 
-topojson-client@3:
+topojson-client@3, topojson-client@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/topojson-client/-/topojson-client-3.0.0.tgz#1f99293a77ef42a448d032a81aa982b73f360d2f"
   dependencies:
@@ -10526,7 +10672,7 @@ vary@~1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
-vega-canvas@1, vega-canvas@^1.0.1:
+vega-canvas@1, vega-canvas@^1.0.1, vega-canvas@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vega-canvas/-/vega-canvas-1.1.0.tgz#99ce74d4510a46fc9ed1a8721014da725898ec9f"
 
@@ -10538,12 +10684,27 @@ vega-crossfilter@2:
     vega-dataflow "3"
     vega-util "1"
 
+vega-crossfilter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vega-crossfilter/-/vega-crossfilter-3.0.0.tgz#390f4c380a9c6018bf89700c38c08d16cd95607a"
+  dependencies:
+    d3-array "^1.2.1"
+    vega-dataflow "^4.0.0"
+    vega-util "^1.7.0"
+
 vega-dataflow@3, vega-dataflow@^3.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/vega-dataflow/-/vega-dataflow-3.1.0.tgz#1021d14f9d080403cb2a85801a6a70cd79d2f916"
   dependencies:
     vega-loader "2"
     vega-util "1"
+
+vega-dataflow@^4.0.0, vega-dataflow@^4.0.3, vega-dataflow@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/vega-dataflow/-/vega-dataflow-4.0.4.tgz#e2f4b4805618d01c0b833a93484d3c244675fba3"
+  dependencies:
+    vega-loader "^3.0.1"
+    vega-util "^1.7.0"
 
 vega-encode@2:
   version "2.0.8"
@@ -10556,11 +10717,22 @@ vega-encode@2:
     vega-scale "^2.1"
     vega-util "1"
 
+vega-encode@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/vega-encode/-/vega-encode-3.1.4.tgz#ecf1bdeb7a01bc07ed86fb0bfb6ae32d34f6279b"
+  dependencies:
+    d3-array "^1.2.1"
+    d3-format "^1.3.0"
+    d3-interpolate "^1.2.0"
+    vega-dataflow "^4.0.3"
+    vega-scale "^2.4.0"
+    vega-util "^1.7.0"
+
 vega-event-selector@2, vega-event-selector@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-2.0.0.tgz#6af8dc7345217017ceed74e9155b8d33bad05d42"
 
-vega-expression@2, vega-expression@^2.3:
+vega-expression@2, vega-expression@^2.3, vega-expression@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-2.3.1.tgz#d802a329190bdeb999ce6d8083af56b51f686e83"
   dependencies:
@@ -10574,6 +10746,14 @@ vega-force@2:
     vega-dataflow "3"
     vega-util "1"
 
+vega-force@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vega-force/-/vega-force-3.0.0.tgz#f5d10bb0a49e41c47f2d83441e407510948eb89a"
+  dependencies:
+    d3-force "^1.1.0"
+    vega-dataflow "^4.0.0"
+    vega-util "^1.7.0"
+
 vega-geo@^2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-2.2.2.tgz#d45dd6b843696618e9b6bd646ebcc711029975dc"
@@ -10585,6 +10765,17 @@ vega-geo@^2.2:
     vega-projection "1"
     vega-util "1"
 
+vega-geo@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vega-geo/-/vega-geo-3.1.0.tgz#2022f0dc612199585b10d2274967fee94d7505b4"
+  dependencies:
+    d3-array "^1.2.1"
+    d3-contour "^1.3.0"
+    d3-geo "^1.10.0"
+    vega-dataflow "^4.0.3"
+    vega-projection "^1.2.0"
+    vega-util "^1.7.0"
+
 vega-hierarchy@^2.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/vega-hierarchy/-/vega-hierarchy-2.1.2.tgz#36d7ecb279d3df055853d8ca052198cc94cbde24"
@@ -10593,6 +10784,42 @@ vega-hierarchy@^2.1:
     d3-hierarchy "1"
     vega-dataflow "^3.1"
     vega-util "1"
+
+vega-hierarchy@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vega-hierarchy/-/vega-hierarchy-3.0.3.tgz#0003ed59eacdba70256a00c9c39e1643424662ec"
+  dependencies:
+    d3-collection "^1.0.4"
+    d3-hierarchy "^1.1.6"
+    vega-dataflow "^4.0.4"
+    vega-util "^1.7.0"
+
+vega-lib@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/vega-lib/-/vega-lib-4.2.0.tgz#78adc086c7b0230da5b41c3fdfc0202b48e228fa"
+  dependencies:
+    vega-crossfilter "^3.0.0"
+    vega-dataflow "^4.0.4"
+    vega-encode "^3.1.4"
+    vega-event-selector "^2.0.0"
+    vega-expression "^2.3.1"
+    vega-force "^3.0.0"
+    vega-geo "^3.1.0"
+    vega-hierarchy "^3.0.3"
+    vega-loader "^3.0.1"
+    vega-parser "^3.7.2"
+    vega-projection "^1.2.0"
+    vega-runtime "^3.1.0"
+    vega-scale "^2.4.0"
+    vega-scenegraph "^3.2.2"
+    vega-statistics "^1.2.1"
+    vega-transforms "^2.2.0"
+    vega-typings "*"
+    vega-util "^1.7.0"
+    vega-view "^3.3.3"
+    vega-view-transforms "^2.0.2"
+    vega-voronoi "^3.0.0"
+    vega-wordcloud "^3.0.0"
 
 vega-lite@^2.1.1:
   version "2.5.1"
@@ -10616,6 +10843,16 @@ vega-loader@2, vega-loader@^2.1.0:
     topojson-client "3"
     vega-util "1"
 
+vega-loader@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/vega-loader/-/vega-loader-3.0.1.tgz#728426b54e74de7dbc91d418e05230bc7ee23a88"
+  dependencies:
+    d3-dsv "^1.0.8"
+    d3-time-format "^2.1.1"
+    node-fetch "^2.1.2"
+    topojson-client "^3.0.0"
+    vega-util "^1.7.0"
+
 vega-parser@2, vega-parser@^2.5:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-2.7.0.tgz#974a7c4cd877eafd07b425f842b1ce83cc18e3cf"
@@ -10633,7 +10870,24 @@ vega-parser@2, vega-parser@^2.5:
     vega-statistics "^1.2"
     vega-util "^1.7"
 
-vega-projection@1:
+vega-parser@^3.7.0, vega-parser@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-3.7.2.tgz#03b7ce1bcf4cb3edd2f81576937023a2ffac167d"
+  dependencies:
+    d3-array "^1.2.1"
+    d3-color "^1.2.0"
+    d3-format "^1.3.0"
+    d3-geo "^1.10.0"
+    d3-time-format "^2.1.1"
+    vega-dataflow "^4.0.4"
+    vega-event-selector "^2.0.0"
+    vega-expression "^2.3.1"
+    vega-scale "^2.4.0"
+    vega-scenegraph "^3.2.2"
+    vega-statistics "^1.2.1"
+    vega-util "^1.7.0"
+
+vega-projection@1, vega-projection@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/vega-projection/-/vega-projection-1.2.0.tgz#812c955251dab495fda83d9406ba72d9833a2014"
   dependencies:
@@ -10646,6 +10900,13 @@ vega-runtime@2:
     vega-dataflow "3"
     vega-util "1"
 
+vega-runtime@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vega-runtime/-/vega-runtime-3.1.0.tgz#c8bd3d65bef28cae0b1bbc8ddfbcd6b76e5e6013"
+  dependencies:
+    vega-dataflow "^4.0.4"
+    vega-util "^1.7.0"
+
 vega-scale@2, vega-scale@^2.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-2.2.0.tgz#676c0aa2e744ee378bc5dc3fc1251d249f468d40"
@@ -10653,6 +10914,17 @@ vega-scale@2, vega-scale@^2.1:
     d3-array "^1.2.1"
     d3-interpolate "^1.2.0"
     d3-scale "^2.0.0"
+    d3-scale-chromatic "^1.3.0"
+    d3-time "^1.0.8"
+    vega-util "^1.7.0"
+
+vega-scale@^2.1.1, vega-scale@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/vega-scale/-/vega-scale-2.4.0.tgz#184b11979e643463ed45dfae9142e42b5a35eecc"
+  dependencies:
+    d3-array "^1.2.1"
+    d3-interpolate "^1.2.0"
+    d3-scale "^2.1.0"
     d3-scale-chromatic "^1.3.0"
     d3-time "^1.0.8"
     vega-util "^1.7.0"
@@ -10667,7 +10939,17 @@ vega-scenegraph@2, vega-scenegraph@^2.3:
     vega-loader "^2.1.0"
     vega-util "^1.7.0"
 
-vega-statistics@^1.2:
+vega-scenegraph@^3.2.1, vega-scenegraph@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/vega-scenegraph/-/vega-scenegraph-3.2.2.tgz#6ed5f37f637c7e5eed702621eacc68b1c6ed4cdb"
+  dependencies:
+    d3-path "^1.0.5"
+    d3-shape "^1.2.0"
+    vega-canvas "^1.1.0"
+    vega-loader "^3.0.1"
+    vega-util "^1.7.0"
+
+vega-statistics@^1.2, vega-statistics@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/vega-statistics/-/vega-statistics-1.2.1.tgz#a35b3fc3d0039f8bb0a8ba1381d42a1df79ecb34"
   dependencies:
@@ -10692,6 +10974,15 @@ vega-transforms@^1.2:
     vega-statistics "^1.2"
     vega-util "1"
 
+vega-transforms@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/vega-transforms/-/vega-transforms-2.2.0.tgz#5f427632abf6d4226249435fadf0b8d7d74e79bc"
+  dependencies:
+    d3-array "^1.2.1"
+    vega-dataflow "^4.0.4"
+    vega-statistics "^1.2.1"
+    vega-util "^1.7.0"
+
 vega-typings@*, vega-typings@^0.3.4:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-0.3.6.tgz#7d37e9259a978b622d8fb79d7a60537491099618"
@@ -10710,6 +11001,14 @@ vega-view-transforms@^1.2:
     vega-scenegraph "2"
     vega-util "1"
 
+vega-view-transforms@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/vega-view-transforms/-/vega-view-transforms-2.0.2.tgz#5c2877bb9e7ebef296f740b60c5e1612d2666dcd"
+  dependencies:
+    vega-dataflow "^4.0.3"
+    vega-scenegraph "^3.2.1"
+    vega-util "^1.7.0"
+
 vega-view@^2.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-2.3.2.tgz#037040b8e64d9dbf7900e86bbc8e952f0b99a119"
@@ -10721,6 +11020,18 @@ vega-view@^2.2:
     vega-scenegraph "2"
     vega-util "1"
 
+vega-view@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-3.3.3.tgz#aa811775fe5f171620bc2f5357d3de1585e4ce12"
+  dependencies:
+    d3-array "^1.2.1"
+    d3-timer "^1.0.7"
+    vega-dataflow "^4.0.4"
+    vega-parser "^3.7.0"
+    vega-runtime "^3.1.0"
+    vega-scenegraph "^3.2.1"
+    vega-util "^1.7.0"
+
 vega-voronoi@2:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/vega-voronoi/-/vega-voronoi-2.0.0.tgz#6df399181dc070a2ef52234ebfe5d7cebd0f3802"
@@ -10728,6 +11039,14 @@ vega-voronoi@2:
     d3-voronoi "1"
     vega-dataflow "3"
     vega-util "1"
+
+vega-voronoi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vega-voronoi/-/vega-voronoi-3.0.0.tgz#e83d014c0d8d083592d5246122e3a9d4af0ce434"
+  dependencies:
+    d3-voronoi "^1.1.2"
+    vega-dataflow "^4.0.0"
+    vega-util "^1.7.0"
 
 vega-wordcloud@^2.1:
   version "2.1.0"
@@ -10738,6 +11057,16 @@ vega-wordcloud@^2.1:
     vega-scale "2"
     vega-statistics "^1.2"
     vega-util "1"
+
+vega-wordcloud@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vega-wordcloud/-/vega-wordcloud-3.0.0.tgz#3843d5233673a36a93f78c849d3c7568c1cdc2ce"
+  dependencies:
+    vega-canvas "^1.0.1"
+    vega-dataflow "^4.0.0"
+    vega-scale "^2.1.1"
+    vega-statistics "^1.2.1"
+    vega-util "^1.7.0"
 
 vega@3.1.0:
   version "3.1.0"
@@ -11092,6 +11421,10 @@ whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
+whatwg-fetch@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
+
 whet.extend@~0.9.9:
   version "0.9.9"
   resolved "https://registry.yarnpkg.com/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1"
@@ -11117,8 +11450,8 @@ wide-align@^1.1.0:
     string-width "^1.0.2 || 2"
 
 widget-editor@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-1.3.1.tgz#5756082cd418e8fcd4370c7ca51ab8cb87be824c"
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-1.3.6.tgz#dc6894d23505f8b58254e3329d568a84aa4efcbc"
   dependencies:
     autobind-decorator "^2.1.0"
     babel-runtime "^6.26.0"
@@ -11128,7 +11461,6 @@ widget-editor@^1.3.1:
     esri-leaflet "^2.1.1"
     lodash "^4.17.4"
     peer-deps-externals-webpack-plugin "^1.0.2"
-    prop-types "^15.6.0"
     rc-slider "^8.4.0"
     react-dnd "^2.5.4"
     react-dnd-html5-backend "^2.5.4"
@@ -11142,7 +11474,7 @@ widget-editor@^1.3.1:
     react-tether "^0.6.0"
     toastr "^2.1.2"
     vega-tooltip "^0.5.1"
-    wri-api-components "1.0.3"
+    wri-api-components "2.0.17"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -11181,19 +11513,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-wri-api-components@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/wri-api-components/-/wri-api-components-1.0.3.tgz#d3e3e04e1b427f1a6ee69645bf56578df163fd40"
-  dependencies:
-    prop-types "^15.6.1"
-    rc-tooltip "3.7.0"
-    react "15.6.2"
-    react-css-modules "^4.7.1"
-    react-dom "15.6.2"
-    react-input-range "1.3.0"
-    react-sortable-hoc "^0.6.8"
-    wri-json-api-serializer "^1.0.1"
-
 wri-api-components@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/wri-api-components/-/wri-api-components-1.0.6.tgz#55da1035b775e36af14ffd1603c133e34c89e9e8"
@@ -11205,6 +11524,21 @@ wri-api-components@1.0.6:
     react-dom "15.6.2"
     react-input-range "1.3.0"
     react-sortable-hoc "^0.6.8"
+    wri-json-api-serializer "^1.0.1"
+
+wri-api-components@2.0.17:
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/wri-api-components/-/wri-api-components-2.0.17.tgz#4033ccc382df6faf432cd52f8b0d5b91578dae03"
+  dependencies:
+    layer-manager "^1.0.4"
+    prop-types "^15.6.2"
+    rc-slider "^8.6.1"
+    rc-tooltip "3.7.0"
+    react-css-modules "^4.7.1"
+    react-lib "^0.1.3"
+    react-sortable-hoc "^0.6.8"
+    react-vega "^4.0.2"
+    vega-lib "^4.2.0"
     wri-json-api-serializer "^1.0.1"
 
 wri-json-api-serializer@1.0.1, wri-json-api-serializer@^1.0.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11449,7 +11449,7 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
-widget-editor@^1.3.1:
+widget-editor@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/widget-editor/-/widget-editor-1.3.6.tgz#dc6894d23505f8b58254e3329d568a84aa4efcbc"
   dependencies:


### PR DESCRIPTION
## Overview
This PR upgrades the widget editor version to `1.3.6`.
It also fixes how the Vega theme was being imported across a set of different components.