### PR TITLE
Improve explore search filter hits sorting

### DIFF
--- a/components/datasets/search/search-component.js
+++ b/components/datasets/search/search-component.js
@@ -193,7 +193,6 @@ class SearchComponent extends React.Component {
       }
       return index1 > index2;
     }) : [];
-    console.log('filteredList', filteredList);
     const newGroupFilteredList = omit(groupBy(filteredList, (l) => {
       const group = l.labels && l.labels[1];
       return group || 'undefined';

--- a/components/datasets/search/search-component.js
+++ b/components/datasets/search/search-component.js
@@ -181,7 +181,11 @@ class SearchComponent extends React.Component {
   onChangeSearch = (e) => {
     const { value } = e.currentTarget;
 
-    const filteredList = (value.length > 2) ? sortBy(this.fuse.search(value), 'label') : [];
+    const filteredList = (value.length > 2) ? this.fuse.search(value).sort((a, b) => {
+      const index1 = a.label.indexOf(value);
+      const index2 = b.label.indexOf(value);
+      return index1 > index2;
+    }) : [];
     const newGroupFilteredList = omit(groupBy(filteredList, (l) => {
       const group = l.labels && l.labels[1];
       return group || 'undefined';

--- a/components/datasets/search/search-component.js
+++ b/components/datasets/search/search-component.js
@@ -182,10 +182,18 @@ class SearchComponent extends React.Component {
     const { value } = e.currentTarget;
 
     const filteredList = (value.length > 2) ? this.fuse.search(value).sort((a, b) => {
-      const index1 = a.label.indexOf(value);
-      const index2 = b.label.indexOf(value);
+      const index1 = a.label.toLowerCase().indexOf(value.toLowerCase());
+      const index2 = b.label.toLowerCase().indexOf(value.toLowerCase());
+      const exactMatch1 = a.label.toLowerCase() === value.toLowerCase();
+      const exactMatch2 = b.label.toLowerCase() === value.toLowerCase();
+      if (exactMatch1) {
+        return -1;
+      } else if (exactMatch2) {
+        return 1;
+      }
       return index1 > index2;
     }) : [];
+    console.log('filteredList', filteredList);
     const newGroupFilteredList = omit(groupBy(filteredList, (l) => {
       const group = l.labels && l.labels[1];
       return group || 'undefined';

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "extract-text-webpack-plugin": "3.0.0",
     "file-loader": "0.11.1",
     "foundation-sites": "6.3.1",
-    "fuse.js": "3.2.0",
+    "fuse.js": "^3.2.1",
     "glob": "7.1.1",
     "image-webpack-loader": "3.3.1",
     "immutable": "3.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4277,9 +4277,9 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
-fuse.js@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.2.0.tgz#f0448e8069855bf2a3e683cdc1d320e7e2a07ef4"
+fuse.js@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.2.1.tgz#6320cb94ce56ec9755c89ade775bcdbb0358d425"
 
 gauge@~2.7.3:
   version "2.7.4"


### PR DESCRIPTION
## Overview
This PR improves the sorting of the concept filters found as hits for the string entered by the user in the Explore search.
 
![image](https://user-images.githubusercontent.com/545342/44261734-df0ebd00-a218-11e8-94f5-ab32b36b0fd4.png)
