### PR TITLE
BUGFIX: fix conditions as geojson is always true for areas

### DIFF
--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -117,17 +117,20 @@ class AreasForm extends React.Component {
     e.preventDefault();
     const drawedGeoJson = this.state.geojson ? await this.areasService.createGeostore(this.state.geojson) : null;
 
+    if (drawedGeoJson && 'id' in drawedGeoJson) {
+      this.setState({ geostore: drawedGeoJson.id });
+    }
+
     const { name, geostore } = this.state;
     const { user, mode, id, routes } = this.props;
     const { query } = routes;
     const { subscriptionDataset } = query || {};
-    const drawedGeoJsonId = drawedGeoJson ? drawedGeoJson.id : null;
 
-    if (geostore || drawedGeoJsonId) {
+    if (geostore) {
       this.setState({ loading: true });
 
       if (mode === 'new') {
-        this.userService.createNewArea(name, drawedGeoJsonId || geostore, user.token)
+        this.userService.createNewArea(name, geostore, user.token)
           .then(() => {
             Router.pushRoute('myrw', {
               tab: 'areas',
@@ -139,7 +142,7 @@ class AreasForm extends React.Component {
 
         logEvent('My RW', 'Create area', name);
       } else if (mode === 'edit') {
-        this.userService.updateArea(id, name, user.token, drawedGeoJsonId || geostore)
+        this.userService.updateArea(id, name, user.token, geostore)
           .then(() => {
             Router.pushRoute('myrw', { tab: 'areas' });
             toastr.success('Success', 'Area successfully updated!');

--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -121,12 +121,13 @@ class AreasForm extends React.Component {
     const { user, mode, id, routes } = this.props;
     const { query } = routes;
     const { subscriptionDataset } = query || {};
+    const drawedGeoJsonId = drawedGeoJson ? drawedGeoJson.id : null;
 
-    if (geostore || (drawedGeoJson && 'id' in drawedGeoJson)) {
+    if (geostore || drawedGeoJsonId) {
       this.setState({ loading: true });
 
       if (mode === 'new') {
-        this.userService.createNewArea(name, geostore || drawedGeoJson.id, user.token)
+        this.userService.createNewArea(name, drawedGeoJsonId || geostore, user.token)
           .then(() => {
             Router.pushRoute('myrw', {
               tab: 'areas',
@@ -138,8 +139,7 @@ class AreasForm extends React.Component {
 
         logEvent('My RW', 'Create area', name);
       } else if (mode === 'edit') {
-        this.userService.updateArea(id, name, user.token,
-          geostore || (drawedGeoJson && drawedGeoJson.id ? drawedGeoJson.id : null))
+        this.userService.updateArea(id, name, user.token, drawedGeoJsonId || geostore)
           .then(() => {
             Router.pushRoute('myrw', { tab: 'areas' });
             toastr.success('Success', 'Area successfully updated!');


### PR DESCRIPTION
### BUG
when trying to update  your area, your drawing does not get saved

### Desc
So when trying to update geojson drawing in your area, geostore is always `true` so the new drawing you make is always being ignored.

cleaned up the logic so we dont have to struggle with this again! 