### PR TITLE
Explore Detail: Remove href from anchor in add to map Link

### DIFF
--- a/layout/explore-detail/explore-detail-buttons/explore-detail-buttons-component.js
+++ b/layout/explore-detail/explore-detail-buttons/explore-detail-buttons-component.js
@@ -97,7 +97,7 @@ class ExploreDetailButtons extends PureComponent {
                   }]))
                 }}
               >
-                <a href="/data/explore" className="c-button -primary">
+                <a className="c-button -primary">
                   Open in map
                 </a>
               </Link>


### PR DESCRIPTION
## Overview
A user reported that opening the Add to Map link in a new tab doesn't work (the layer doesn't show up). It looks like the Link route and anchor href differ causing inconsistent behavior.

## Test
Confirm add-to-map still works.