### PR TITLE
remove areaModal as its deperecated and returns 404

### DIFF
--- a/components/areas/AreasForm.js
+++ b/components/areas/AreasForm.js
@@ -62,19 +62,14 @@ class AreasForm extends React.Component {
     routes: PropTypes.object.isRequired
   };
 
-  static defaultProps = {
-    openUploadAreaModal: false
-  };
-
   constructor(props) {
     super(props);
 
     const { query } = props.routes;
-    const { openUploadAreaModal } = query || {};
     const { areas } = props.user;
 
     const area = areas.items.find(a => a.id === query.id);
-    let { name, geostore } = area ? area.attributes : {};
+    const { name, geostore } = area ? area.attributes : {};
 
     this.state = {
       areaOptions: [],
@@ -82,7 +77,6 @@ class AreasForm extends React.Component {
       loading: false,
       name: name || '',
       geostore: geostore || '',
-      openUploadAreaModal,
       geojson: null,
       geoCountrySelected: false
     };
@@ -101,15 +95,10 @@ class AreasForm extends React.Component {
   }
 
   componentDidMount() {
-    const { openUploadAreaModal } = this.state;
     const { query } = this.props.routes;
 
     if (query.id) {
       this.loadAreas();
-    }
-
-    if (openUploadAreaModal) {
-      this.openUploadAreaModal();
     }
   }
 

--- a/components/modal/SubscribeToDatasetModal.js
+++ b/components/modal/SubscribeToDatasetModal.js
@@ -71,8 +71,7 @@ class SubscribeToDatasetModal extends React.Component {
         id: 'new',
         subscriptionDataset: this.props.dataset.id,
         subscriptionType: this.state.selectedType,
-        subscriptionThreshold: this.state.selectedThreshold,
-        openUploadAreaModal: true
+        subscriptionThreshold: this.state.selectedThreshold
       });
     } else {
       this.setState({

--- a/components/modal/subscribe-to-dataset-modal/component.js
+++ b/components/modal/subscribe-to-dataset-modal/component.js
@@ -69,8 +69,7 @@ class SubscribeToDatasetModal extends React.Component {
         id: 'new',
         subscriptionDataset: this.props.dataset.id,
         subscriptionType: this.state.selectedType,
-        subscriptionThreshold: this.state.selectedThreshold,
-        openUploadAreaModal: true
+        subscriptionThreshold: this.state.selectedThreshold
       });
     } else {
       this.setState({


### PR DESCRIPTION
On planet pulse, we are trying to open the upload area modal that does not exist anymore by passing the parameter `openUploadAreaModal`. This, in the end, returns a `404`. Remove this parameter and just return the new area page. as the upload form now is embedded right there.