### PR TITLE
Removes unnecessary rc-tooltip styles

### DIFF
--- a/css/index.scss
+++ b/css/index.scss
@@ -38,7 +38,6 @@
 // Components
 // UI
 @import '../node_modules/react-redux-toastr/src/styles/index';
-@import '../node_modules/rc-slider/assets/index';
 @import "./components/ui/aside";
 @import "./components/ui/avatar";
 @import "./components/ui/breadcrumbs";
@@ -297,9 +296,6 @@
 // ------ SPLASH -------
 @import "./components/splash/layout/splash_header";
 
-// RC-TOOLTIP
-@import '../node_modules/rc-tooltip/assets/bootstrap_white';
-@import "./components/ui/rc-tooltip";
 
 // Foundation:
 // We are using this library only for grid system

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "webpackbar": "^2.6.3",
     "whatwg-fetch": "2.0.2",
     "widget-editor": "^1.3.6",
-    "wri-api-components": "^2.2.7-alpha.2",
+    "wri-api-components": "^2.2.7-alpha.3",
     "wri-json-api-serializer": "1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "webpackbar": "^2.6.3",
     "whatwg-fetch": "2.0.2",
     "widget-editor": "^1.3.6",
-    "wri-api-components": "^2.2.4",
+    "wri-api-components": "^2.2.7-alpha.2",
     "wri-json-api-serializer": "1.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2269,6 +2269,10 @@ bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
+bluebird@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -7022,6 +7026,15 @@ layer-manager@^1.1.5:
   dependencies:
     bluebird "^3.5.1"
     lodash "^4.17.10"
+    wri-json-api-serializer "^1.0.1"
+
+layer-manager@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/layer-manager/-/layer-manager-1.10.0.tgz#53b566c0c23eb63076ec09ca9af08723e2683316"
+  dependencies:
+    bluebird "^3.5.2"
+    lodash "^4.17.10"
+    prop-types "^15.6.2"
     wri-json-api-serializer "^1.0.1"
 
 lazy-cache@^0.2.3:
@@ -13419,12 +13432,12 @@ wri-api-components@2.0.17:
     vega-lib "^4.2.0"
     wri-json-api-serializer "^1.0.1"
 
-wri-api-components@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/wri-api-components/-/wri-api-components-2.2.4.tgz#7b38117ba09a62ee3beaa7ab4dd54d27e9042018"
+wri-api-components@^2.2.7-alpha.2:
+  version "2.2.7-alpha.2"
+  resolved "https://registry.yarnpkg.com/wri-api-components/-/wri-api-components-2.2.7-alpha.2.tgz#09d65598cf5466452c284ee36e602fb32f77082c"
   dependencies:
     classnames "^2.2.6"
-    layer-manager "^1.1.5"
+    layer-manager "^1.10.0"
     lodash "^4.17.10"
     prop-types "^15.6.2"
     rc-slider "^8.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9753,6 +9753,18 @@ rc-slider@^8.4.0, rc-slider@^8.6.1:
     shallowequal "^1.0.1"
     warning "^3.0.0"
 
+rc-slider@^8.6.3:
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-8.6.3.tgz#1ca0e0bd2863252741de75e7bf8c9f2cfcffccb7"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "^2.2.5"
+    prop-types "^15.5.4"
+    rc-tooltip "^3.7.0"
+    rc-util "^4.0.4"
+    shallowequal "^1.0.1"
+    warning "^3.0.0"
+
 rc-tooltip@3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-3.7.0.tgz#3afbf109865f7cdcfe43752f3f3f501f7be37aaa"
@@ -13432,15 +13444,15 @@ wri-api-components@2.0.17:
     vega-lib "^4.2.0"
     wri-json-api-serializer "^1.0.1"
 
-wri-api-components@^2.2.7-alpha.2:
-  version "2.2.7-alpha.2"
-  resolved "https://registry.yarnpkg.com/wri-api-components/-/wri-api-components-2.2.7-alpha.2.tgz#09d65598cf5466452c284ee36e602fb32f77082c"
+wri-api-components@^2.2.7-alpha.3:
+  version "2.2.7-alpha.3"
+  resolved "https://registry.yarnpkg.com/wri-api-components/-/wri-api-components-2.2.7-alpha.3.tgz#14b530ef687493c8d1511621406d32c35e48561f"
   dependencies:
     classnames "^2.2.6"
     layer-manager "^1.10.0"
     lodash "^4.17.10"
     prop-types "^15.6.2"
-    rc-slider "^8.6.1"
+    rc-slider "^8.6.3"
     rc-tooltip "3.7.0"
     react-sortable-hoc "^0.6.8"
     react-vega "^4.0.2"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/999124/46201371-45a4f180-c314-11e8-946f-742384c9ae7a.png)

Part of https://github.com/resource-watch/wri-api-components/pull/33.

Removes `rc-tooltip` styles as we are already importing them from `wri-api-components`.

Also, removes duplicated `../node_modules/rc-slider/assets/index` import.

Updates `wri-api-components` to its latest version.

## Pivotal task
https://www.pivotaltracker.com/story/show/160817619
