### PR TITLE
Allow dot notation for raster interaction

### DIFF
--- a/components/ui/map/popup/LayerPopup.js
+++ b/components/ui/map/popup/LayerPopup.js
@@ -117,6 +117,7 @@ class LayerPopup extends React.Component {
     }
     // Get interactionConfig
     const { interactionConfig } = layer;
+    const { output } = interactionConfig;
 
     // Get data from props or state
     const interaction = layersInteraction[layer.id] || {};
@@ -140,17 +141,27 @@ class LayerPopup extends React.Component {
           {(interaction.data || interactionState.data) &&
             <table className="popup-table">
               <tbody>
-                {interactionConfig.output.map(outputItem => (
-                  <tr
-                    className="dc"
-                    key={outputItem.property || outputItem.column}
-                  >
-                    <td className="dt">
-                      {outputItem.property || outputItem.column}:
-                    </td>
-                    <td className="dd">{this.formatValue(outputItem, (interaction.data || interactionState.data)[outputItem.column])}</td>
-                  </tr>
-                ))}
+                {output.map((outputItem) => {
+                  const { column } = outputItem;
+                  let value = (interaction.data || interactionState.data)[column];
+                  if (column.indexOf('.') >= 0) {
+                    value = (interaction.data || interactionState.data);
+                    const propArray = column.split('.');
+                    propArray.forEach(elem => (value = value[elem])); // eslint-disable-line no-return-assign, max-len
+                  }
+                    return (
+                      <tr
+                        className="dc"
+                        key={outputItem.property || outputItem.column}
+                      >
+                        <td className="dt">
+                          {outputItem.property || outputItem.column}:
+                        </td>
+                        <td className="dd">{this.formatValue(outputItem, value)}</td>
+                      </tr>
+                    );
+                  }
+              )}
               </tbody>
             </table>
           }

--- a/components/ui/map/popup/LayerPopup.js
+++ b/components/ui/map/popup/LayerPopup.js
@@ -143,12 +143,9 @@ class LayerPopup extends React.Component {
               <tbody>
                 {output.map((outputItem) => {
                   const { column } = outputItem;
-                  let value = (interaction.data || interactionState.data)[column];
-                  if (column.indexOf('.') >= 0) {
-                    value = (interaction.data || interactionState.data);
-                    const propArray = column.split('.');
-                    propArray.forEach(elem => (value = value[elem])); // eslint-disable-line no-return-assign, max-len
-                  }
+                  const columnArray = column.split('.');
+                  const value = columnArray.reduce((acc, c) => acc[c],
+                    interaction.data || interactionState.data);
                     return (
                       <tr
                         className="dc"


### PR DESCRIPTION
## Overview
Allow raster interactivity to be specified with dot notation. For instance:
```
"output": [
{
"column": "x.b1.mean",
"property": "Energy",
"type": "numeric",
"format": "0.00"
}
]
```

## Testing instructions
http://localhost:9000/data/explore?zoom=2&lat=-5.615985819155327&lng=0.17578125&basemap=dark&labels=light&layers=%255B%257B%2522dataset%2522%253A%2522cefd2836-3cc1-43dc-a9d1-bfecf79a6252%2522%252C%2522opacity%2522%253A1%252C%2522layer%2522%253A%25220668f151-1116-4a27-bb16-761cf259d3aa%2522%257D%255D&page=1&sort=relevance&sortDirection=-1&search=vegetation