### PR TITLE
swaping underlined for boxed elements in nav bar

### DIFF
--- a/css/layouts/_header.scss
+++ b/css/layouts/_header.scss
@@ -74,7 +74,9 @@
         margin-left: $margin-size-extra-small;
         color: $alt-font-color;
 
-        > a, > span, > button {
+        > a,
+        > span,
+        > button {
           position: relative;
           display: flex;
           align-items: center;
@@ -85,7 +87,7 @@
           cursor: pointer;
 
           &.-bordered {
-            border: 1px solid rgba($alt-border-color, .5);
+            border: 1px solid rgba($alt-border-color, 0.5);
             border-radius: 4px;
           }
 
@@ -99,7 +101,9 @@
         &.-active > a {
           color: $active-font-color;
           fill: $active-font-color;
-          text-decoration: underline;
+          text-decoration: none;
+          border: 1px $active-font-color solid;
+          border-radius: 5px;
         }
       }
     }


### PR DESCRIPTION
## Overview
New style for active elements in nav bar. Swaped underlined element when active by a line border box

## Testing instructions
Go to nav bar and click in any of the elements

## Pivotal task
https://www.pivotaltracker.com/n/projects/1374154/stories/161778130

---

## Checklist before submitting
[ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
[ ] Meaningful commits and code rebased on `develop`.
