### PR TITLE
manage your suscrip in email pointing to staging/myrw/areas

### DIFF
--- a/static/mails/alerts.html
+++ b/static/mails/alerts.html
@@ -257,10 +257,19 @@
         <!-- Footer -->
         <table style="width:700px;" cellspacing="0" cellpadding="0">
           <tr>
-            <td class="spacer" bgcolor="#f2f2f2" style="font-size:0pt; line-height:0pt; text-align:center; height:40px;">&nbsp;</td>
+            <td class="spacer" bgcolor="#f2f2f2" style="font-size:0pt; line-height:0pt; text-align:center; height:25px;">&nbsp;</td>
           </tr>
           <tr>
-            <td class="h4" style="width: 100%; color:#555555; font-family: Arial; font-style: italic; font-size: 14px; line-height: 18px; text-align:left">
+            <td class="h4" style="color:#555555; font-family:Arial,sans-serif;font-size:14px; line-height:26px; text-align:left">
+              <a href="https://staging.resourcewatch.org/myrw/areas" style="color:blue;">
+                View or manage subscription</a>
+            </td>
+          </tr>
+          <tr>
+            <td class="spacer" bgcolor="#f2f2f2" style="font-size:0pt; line-height:0pt; text-align:center; height:10px;">&nbsp;</td>
+          </tr>
+          <tr>
+            <td class="h4" style="width: 100%; color:#555555; font-family: Arial; font-style: italic; font-size: 14px; line-height: 25px; text-align:left">
               This notification reports Brazilian Amazon Deforestation Alerts, GLAD Deforestation Alerts, Fires
               (VIIRS)
               for
@@ -290,9 +299,8 @@
               Terms of Service. You can<a href="https://resourcewatch.org/myrw" style="color:#2C75B0; text-decoration:none;">
                 unsubscribe
               </a> or
-              <a href="https://staging.resourcewatch.org/myrw/areas" style="color:#2C75B0; text-decoration:none;">manage
-                your
-                subscriptions</a>
+              <a href="https://staging.resourcewatch.org/myrw/areas" style="color:#2C75B0; text-decoration:none;">
+                manage your subscriptions</a>
               at <a href="https://resourcewatch.org/" style="color:#2C75B0; text-decoration:none;">My
                 Resource Watch</a>
             </td>

--- a/static/mails/alerts.html
+++ b/static/mails/alerts.html
@@ -290,7 +290,8 @@
               Terms of Service. You can<a href="https://resourcewatch.org/myrw" style="color:#2C75B0; text-decoration:none;">
                 unsubscribe
               </a> or
-              <a href="https://resourcewatch.org/myrw" style="color:#2C75B0; text-decoration:none;">manage your
+              <a href="https://staging.resourcewatch.org/myrw/areas" style="color:#2C75B0; text-decoration:none;">manage
+                your
                 subscriptions</a>
               at <a href="https://resourcewatch.org/" style="color:#2C75B0; text-decoration:none;">My
                 Resource Watch</a>


### PR DESCRIPTION
## Overview
Link to "manage your subscriptions" at the bottom of email changed. Currently it points to https://staging.resourcewatch.org/myrw/areas.

## Testing instructions
Open alerts.html file and click on "manage your subscriptions" at the bottom of the page (both logged in and logged out). It should redirect you to your areas of interest or log in page respectively.

## Pivotal task
https://www.pivotaltracker.com/story/show/159927273

---

## Checklist before submitting
[ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
[ ] Meaningful commits and code rebased on `develop`.
