### PR TITLE
Fixes dahsboard listing

### DIFF
--- a/components/dashboards/list/DashboardsList.js
+++ b/components/dashboards/list/DashboardsList.js
@@ -56,7 +56,7 @@ class DashboardsList extends React.Component {
     const { getDashboardsFilters } = this.props;
 
     this.props.setFilters([]);
-    this.props.getDashboards({ filters: getDashboardsFilters });
+    this.props.getDashboards(getDashboardsFilters);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -85,7 +85,7 @@ class DashboardsList extends React.Component {
             const { getDashboardsFilters } = this.props;
 
             this.props.setFilters([]);
-            this.props.getDashboards({ filters: getDashboardsFilters });
+            this.props.getDashboards(getDashboardsFilters);
             toastr.success('Success', `The dashboard "${dashboard.id}" - "${dashboard.name}" has been removed correctly`);
           })
           .catch((err) => {

--- a/components/dashboards/table/DashboardsTable.js
+++ b/components/dashboards/table/DashboardsTable.js
@@ -54,7 +54,7 @@ class DashboardsTable extends React.Component {
 
   componentDidMount() {
     this.props.setFilters([]);
-    this.props.getDashboards({ env: 'production,preproduction' });
+    this.props.getDashboards();
   }
 
   /**

--- a/components/dashboards/thumbnail-list/dashboard-thumbnail-list-actions.js
+++ b/components/dashboards/thumbnail-list/dashboard-thumbnail-list-actions.js
@@ -19,7 +19,7 @@ export const fetchDashboards = createThunkAction('DASHBOARD_THUMBNAIL_LIST_FETCH
 
   const qParams = queryString.stringify({
     sort: 'name',
-    ...payload.filters
+    ...payload
   });
 
   return fetch(new Request(`${process.env.WRI_API_URL}/dashboard?${qParams}`))

--- a/pages/app/Dashboards.js
+++ b/pages/app/Dashboards.js
@@ -20,9 +20,7 @@ class Dashboards extends Page {
     context.store.dispatch(setAdd(false));
     context.store.dispatch(setSelected(null));
 
-    await context.store.dispatch(fetchDashboards({
-      filters: { 'filter[published]': 'true' }
-    }));
+    await context.store.dispatch(fetchDashboards({ 'filter[published]': 'true' }));
 
     return { ...props };
   }

--- a/services/dashboard.js
+++ b/services/dashboard.js
@@ -20,7 +20,7 @@ export const fetchDashboards = (params = {}) =>
     },
     params: {
       env: process.env.API_ENV,
-      ...Object.keys(params).reduce((x, y) => ({ ...x, ...params[y] }), {})
+      ...params
     }
   })
     .then((response) => {


### PR DESCRIPTION
## Overview
Fixes dashboard listing in `http://localhost:9000/admin/dashboards`

## Testing instructions
Go to `http://localhost:9000/admin/dashboards`, you should see all dashboards listed without any filter.

- [x] Check `/admin/dashboards` is listing all dashboards without filter.
- [x] Check `/data/dashboards` is listing all published dashboards.
- [x] Check `/myrw/dashboards` is listing all user's dashboards.

---
## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
