### PR TITLE
Fixes profile route

### DIFF
--- a/layout/footer/footer-default-state.js
+++ b/layout/footer/footer-default-state.js
@@ -111,9 +111,9 @@ export default {
       route: 'myrw',
       label: 'My Resource Watch',
       children: [
-        { label: 'Profile', route: 'myrw/profile' },
+        { label: 'Profile', route: '/myrw/profile' },
         { label: 'Admin', href: '/admin', admin: true },
-        { label: 'Logout', id: 'logout' } // It should make an ajax call
+        { label: 'Logout', id: 'logout' }
       ]
     }
   ]

--- a/layout/footer/footer-default-state.js
+++ b/layout/footer/footer-default-state.js
@@ -98,12 +98,7 @@ export default {
     {
       user: false,
       id: 'myrw',
-      label: 'Log in',
-      children: [
-        { label: 'Facebook', href: '/auth/facebook' },
-        { label: 'Google', href: '/auth/google' },
-        { label: 'Twitter', href: '/auth/twitter' }
-      ]
+      label: 'Log in'
     },
     {
       user: true,
@@ -111,8 +106,8 @@ export default {
       route: 'myrw',
       label: 'My Resource Watch',
       children: [
-        { label: 'Profile', route: '/myrw/profile' },
-        { label: 'Admin', href: '/admin', admin: true },
+        { label: 'Profile', route: 'myrw', params: { tab: 'profile' } },
+        { label: 'Admin', route: 'admin_home', admin: true },
         { label: 'Logout', id: 'logout' }
       ]
     }

--- a/layout/header-admin/header-admin-user/header-admin-user-component.js
+++ b/layout/header-admin/header-admin-user/header-admin-user-component.js
@@ -1,28 +1,27 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import debounce from 'lodash/debounce';
-
-// Utils
-import { get } from 'utils/request';
-
 import { Link } from 'routes';
 import { toastr } from 'react-redux-toastr';
+import debounce from 'lodash/debounce';
 
-// Components
+// components
 import TetherComponent from 'react-tether';
 import Icon from 'components/ui/Icon';
 
-class HeaderUser extends React.Component {
-  /**
-   * UI EVENTS
-   * - logout
-  */
-  logout(e) {
-    if (e) {
-      e.preventDefault();
-    }
+// utils
+import { get } from 'utils/request';
 
-    // Get to logout
+class HeaderUser extends PureComponent {
+  static propTypes = {
+    user: PropTypes.object.isRequired,
+    header: PropTypes.object.isRequired,
+    setDropdownOpened: PropTypes.func.isRequired
+  }
+
+  logout(e) {
+    if (e) e.preventDefault();
+
+    // TO-DO: move this to an action
     get({
       url: `${process.env.CONTROL_TOWER_URL}/auth/logout`,
       withCredentials: true,
@@ -49,13 +48,9 @@ class HeaderUser extends React.Component {
         <div className="c-avatar" style={{ backgroundImage: photo }}>
           <TetherComponent
             attachment="top center"
-            constraints={[{
-              to: 'window'
-            }]}
+            constraints={[{ to: 'window' }]}
             targetOffset="0 0"
-            classes={{
-              element: 'c-header-dropdown'
-            }}
+            classes={{ element: 'c-header-dropdown' }}
           >
             {/* First child: This is what the item will be tethered to */}
             <Link route="myrw">
@@ -78,13 +73,15 @@ class HeaderUser extends React.Component {
                 onMouseLeave={() => this.toggleDropdown(false)}
               >
                 <li className="header-dropdown-list-item">
-                  <Link to="myrw/profile">
+                  <Link route="myrw" params={{ tab: 'profile' }}>
                     <a>Profile</a>
                   </Link>
                 </li>
                 {user.role === 'ADMIN' &&
                   <li className="header-dropdown-list-item">
-                    <a href="/admin">Admin</a>
+                    <Link route="admin_home">
+                      <a>Admin</a>
+                    </Link>
                   </li>
                 }
                 <li className="header-dropdown-list-item">
@@ -101,13 +98,9 @@ class HeaderUser extends React.Component {
       return (
         <TetherComponent
           attachment="top center"
-          constraints={[{
-            to: 'window'
-          }]}
+          constraints={[{ to: 'window' }]}
           targetOffset="0 0"
-          classes={{
-            element: 'c-header-dropdown'
-          }}
+          classes={{ element: 'c-header-dropdown' }}
         >
           {/* First child: This is what the item will be tethered to */}
           <span
@@ -148,12 +141,5 @@ class HeaderUser extends React.Component {
     return null;
   }
 }
-
-HeaderUser.propTypes = {
-  user: PropTypes.object,
-  header: PropTypes.object,
-  setDropdownOpened: PropTypes.func
-};
-
 
 export default HeaderUser;

--- a/layout/header/header-default-state.js
+++ b/layout/header/header-default-state.js
@@ -33,7 +33,6 @@ export default {
       children: [
         { label: 'Cities', route: 'topics_detail', params: { id: 'cities' } },
         { label: 'Climate', route: 'topics_detail', params: { id: 'climate' } },
-
         { label: 'Energy', route: 'topics_detail', params: { id: 'energy' } },
         { label: 'Food', route: 'topics_detail', params: { id: 'food' } },
         { label: 'Forests', route: 'topics_detail', params: { id: 'forests' } },
@@ -99,12 +98,7 @@ export default {
     {
       user: false,
       id: 'myrw',
-      label: 'Log in',
-      children: [
-        { label: 'Facebook', href: '/auth/facebook' },
-        { label: 'Google', href: '/auth/google' },
-        { label: 'Twitter', href: '/auth/twitter' }
-      ]
+      label: 'Log in'
     },
     {
       user: true,
@@ -112,9 +106,9 @@ export default {
       route: 'myrw',
       label: 'My Resource Watch',
       children: [
-        { label: 'Profile', route: 'myrw/profile' },
-        { label: 'Admin', href: '/admin', admin: true },
-        { label: 'Logout', id: 'logout' } // It should make an ajax call
+        { label: 'Profile', route: 'myrw', params: { tab: 'profile' } },
+        { label: 'Admin', route: 'admin_home', admin: true },
+        { label: 'Logout', id: 'logout' }
       ]
     }
   ]

--- a/layout/header/header-user/component.js
+++ b/layout/header/header-user/component.js
@@ -18,6 +18,7 @@ class HeaderUser extends PureComponent {
   logout(e) {
     if (e) e.preventDefault();
 
+    // TO-DO: move this to an action
     fetch(`${process.env.CONTROL_TOWER_URL}/auth/logout`, { credentials: 'include' })
       .then(() => {
         window.location.href = `/logout?callbackUrl=${window.location.href}`;
@@ -114,13 +115,15 @@ class HeaderUser extends PureComponent {
                 </ul>
                 <ul className="header-dropdown-list user-list">
                   <li className="header-dropdown-list-item">
-                    <Link to="myrw/profile">
+                    <Link route="myrw" params={{ tab: 'profile' }}>
                       <a>Profile</a>
                     </Link>
                   </li>
                   {user.role === 'ADMIN' &&
                     <li className="header-dropdown-list-item">
-                      <a href="/admin">Admin</a>
+                      <Link route="admin_home">
+                        <a>Admin</a>
+                      </Link>
                     </li>
                   }
                   <li className="header-dropdown-list-item">

--- a/layout/header/index.js
+++ b/layout/header/index.js
@@ -5,10 +5,7 @@ import initialState from './header-default-state';
 
 import HeaderComponent from './header-component';
 
-// Mandatory
-export {
-  actions, reducers, initialState
-};
+export { actions, reducers, initialState };
 
 export default connect(
   state => ({

--- a/routes.js
+++ b/routes.js
@@ -51,7 +51,7 @@ routes.add('explore_detail', '/data/explore/:id', 'app/explore-detail');
 
 routes.add('pulse', '/data/pulse', 'app/pulse');
 
-routes.add('dashboards', '/data/dashboards/', 'app/Dashboards');
+routes.add('dashboards', '/data/dashboards', 'app/Dashboards');
 routes.add('dashboards_detail', '/data/dashboards/:slug', 'app/dashboards-detail');
 
 routes.add('widget_detail', '/data/widget/:id', 'app/widget-detail');


### PR DESCRIPTION
## Overview
Fixes a bug when the user was switching sections in the backoffice, the `profile` link started to add the current path to its own path turning out the url something like `/myrw/myrw/myrw/profile`, making it unreachable.

Also, transforms some relative URLs to next routes format.

Also I added some eslinting.

## Testing instructions
Navigate between different sections in the backoffice.

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
