### PR TITLE
Fixes strange behaviour in explore detail buttons

### DIFF
--- a/layout/explore-detail/explore-detail-buttons/explore-detail-buttons-component.js
+++ b/layout/explore-detail/explore-detail-buttons/explore-detail-buttons-component.js
@@ -1,17 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-
-// Utils
-import isEmpty from 'lodash/isEmpty';
-import { getLabel } from 'utils/datasets/dataset-helpers';
-import { logEvent } from 'utils/analytics';
-
-// Responsive
-import MediaQuery from 'react-responsive';
-import { breakpoints } from 'utils/responsive';
-
-// Next
 import { Link } from 'routes';
+import MediaQuery from 'react-responsive';
 
 // components
 import Icon from 'components/ui/Icon';
@@ -19,11 +9,17 @@ import LoginRequired from 'components/ui/login-required';
 import Modal from 'components/modal/modal-component';
 import DatasetSubscriptionsModal from 'components/modal/subscriptions-modal/dataset';
 
+// utils
+import isEmpty from 'lodash/isEmpty';
+import { breakpoints } from 'utils/responsive';
+import { getLabel } from 'utils/datasets/dataset-helpers';
+import { logEvent } from 'utils/analytics';
 
 class ExploreDetailButtons extends PureComponent {
   static propTypes = {
     dataset: PropTypes.object.isRequired,
-    partner: PropTypes.object
+    partner: PropTypes.object,
+    responsive: PropTypes.object.isRequired
   }
 
   static defaultProps = { partner: {} }
@@ -75,7 +71,8 @@ class ExploreDetailButtons extends PureComponent {
   }
 
   render() {
-    const { dataset, partner } = this.props;
+    const { dataset, partner, responsive: { fakeWidth } } = this.props;
+    const { showSubscribeModal } = this.state;
     const metadata = this.getDatasetMetadata();
 
     return (
@@ -95,6 +92,7 @@ class ExploreDetailButtons extends PureComponent {
         {!!dataset.layer.length &&
           <MediaQuery
             minDeviceWidth={breakpoints.medium - 1}
+            values={{ deviceWidth: fakeWidth }}
           >
             <div>
               <Link
@@ -108,7 +106,7 @@ class ExploreDetailButtons extends PureComponent {
                   }]))
                 }}
               >
-                <a href="/data/explore" className="c-button -primary">
+                <a className="c-button -primary">
                   Open in map
                 </a>
               </Link>
@@ -159,7 +157,6 @@ class ExploreDetailButtons extends PureComponent {
               <Icon name="icon-external" className="-smaller" />
             </a>
           </div>
-
         }
 
         {metadata.info && metadata.info.learn_more_link &&
@@ -180,7 +177,7 @@ class ExploreDetailButtons extends PureComponent {
         }
 
         <Modal
-          isOpen={this.state.showSubscribeModal}
+          isOpen={showSubscribeModal}
           onRequestClose={() => this.handleToggleSubscribeModal(false)}
         >
           <DatasetSubscriptionsModal

--- a/layout/explore-detail/explore-detail-buttons/index.js
+++ b/layout/explore-detail/explore-detail-buttons/index.js
@@ -6,7 +6,8 @@ export default connect(
   state => ({
     user: state.user,
     dataset: state.exploreDetail.data,
-    partner: state.exploreDetail.partner.data
+    partner: state.exploreDetail.partner.data,
+    responsive: state.responsive
   }),
   null
 )(ExploreDetailActionsComponent);


### PR DESCRIPTION
## Overview
Fixes a strange behaviour of the buttons depending on where you come from. More details: https://www.pivotaltracker.com/story/show/163713817.

## Testing instructions
Go to explore/detail/dataset and check `Open map`, `Downlaod`, etc.. buttons.

## Pivotal task
https://www.pivotaltracker.com/story/show/163713817

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
