### PR TITLE
Subscriptions: uses metadata name instead of name

### DIFF
--- a/components/modal/subscriptions-modal/actions.js
+++ b/components/modal/subscriptions-modal/actions.js
@@ -3,6 +3,7 @@ import { toastr } from 'react-redux-toastr';
 import { replace } from 'layer-manager';
 import axios from 'axios';
 import moment from 'moment';
+import WRISerializer from 'wri-json-api-serializer';
 
 // services
 import AreasService from 'services/AreasService';
@@ -139,9 +140,10 @@ export const getDatasets = createThunkAction('SUBSCRIPTIONS__GET-DATASETS', () =
 
     dispatch(setDatasetsLoading(true));
 
-    dasetService.getSubscribableDatasets()
+    dasetService.getSubscribableDatasets('metadata')
       .then((datasets = []) => {
-        dispatch(setDatasets(datasets));
+        const parsedDatasets = WRISerializer({ data: datasets });
+        dispatch(setDatasets(parsedDatasets));
         dispatch(setDatasetsLoading(false));
       })
       .catch((err) => {

--- a/components/modal/subscriptions-modal/dataset-manager/selectors.js
+++ b/components/modal/subscriptions-modal/dataset-manager/selectors.js
@@ -7,16 +7,16 @@ const getDatasets = state => state.subscriptions.datasets.list;
 export const getSuscribableDatasets = createSelector(
   [getDatasets],
   _datasets => sortBy(uniq(_datasets
-    .filter(dataset => Object.keys(dataset.subscribable || dataset.attributes.subscribable).length)
+    .filter(dataset => Object.keys(dataset.subscribable || dataset.subscribable).length)
     .map(dataset => ({
       id: dataset.id,
-      label: dataset.attributes.name,
-      value: dataset.attributes.name,
-      subscriptions: sortBy(Object.keys(dataset.subscribable || dataset.attributes.subscribable)
+      label: dataset.metadata && dataset.metadata.length ? dataset.metadata[0].name : dataset.name,
+      value: dataset.name,
+      subscriptions: sortBy(Object.keys(dataset.subscribable || dataset.subscribable)
         .map(key => ({
           label: key,
           value: key,
-          query: ((dataset.subscribable || dataset.attributes.subscribable)[key] || {}).dataQuery
+          query: ((dataset.subscribable || dataset.subscribable)[key] || {}).dataQuery
         })), 'label'),
       threshold: 1
     }))), 'label')


### PR DESCRIPTION
## Overview
Uses metadata name instead of official name for datasets in subscriptions modal.

## Testing instructions
Open a subscriptions modal and check datasets name.

## Pivotal task
https://www.pivotaltracker.com/story/show/163725196

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
