### PR TITLE
map swipe fix: moves onReady callback to layer manager

### DIFF
--- a/layout/embed/map-swipe/component.js
+++ b/layout/embed/map-swipe/component.js
@@ -77,40 +77,38 @@ class EmbedMapSwipe extends React.Component {
                 >
                   {map => (
                     <React.Fragment>
-                      {/* Controls */}
-                      <MapControls
-                        customClass="c-map-controls -embed"
-                      >
+                      <MapControls customClass="c-map-controls -embed">
                         <ZoomControl map={map} />
                       </MapControls>
 
-                      {/* LayerManager */}
-                      <LayerManager map={map} plugin={PluginLeaflet}>
+                      <LayerManager
+                        map={map}
+                        plugin={PluginLeaflet}
+                        onReady={(layers) => {
+                          const setLayers = {
+                            0: 'setLeftLayers',
+                            1: 'setRightLayers'
+                          };
+
+                          layers.forEach((lm, index) => {
+                            const { mapLayer } = lm;
+                            if (mapLayer.group) {
+                              mapLayer.getLayers().forEach((ml, j) => {
+                                if (j === 0) {
+                                  this.sideBySide[setLayers[index]](ml);
+                                }
+                              });
+                            } else {
+                              this.sideBySide[setLayers[index]](mapLayer);
+                            }
+                          });
+                        }}
+                      >
                         {layerGroups && flatten((layerGroups).map(lg => lg.layers.filter(l => l.active === true))).map((l, i) => (
                           <Layer
                             {...l}
                             key={l.id}
                             zIndex={1000 - i}
-
-                            onReady={(layers) => {
-                              const setLayers = {
-                                0: 'setLeftLayers',
-                                1: 'setRightLayers'
-                              };
-
-                              layers.forEach((lm, index) => {
-                                const { mapLayer } = lm;
-                                if (mapLayer.group) {
-                                  mapLayer.getLayers().forEach((ml, j) => {
-                                    if (j === 0) {
-                                      this.sideBySide[setLayers[index]](ml);
-                                    }
-                                  });
-                                } else {
-                                  this.sideBySide[setLayers[index]](mapLayer);
-                                }
-                              });
-                            }}
                           />
                         ))}
                       </LayerManager>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "isomorphic-fetch": "2.2.1",
     "json-loader": "^0.5.7",
     "jsonapi-serializer": "3.5.3",
-    "layer-manager": "^1.14.5",
+    "layer-manager": "^1.15.0",
     "leaflet-utfgrid": "^0.3.0",
     "lodash": "4.17.4",
     "lusca": "1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6353,9 +6353,10 @@ layer-manager@^1.0.4, layer-manager@^1.10.0:
     supercluster "^4.1.1"
     wri-json-api-serializer "^1.0.1"
 
-layer-manager@^1.14.5:
-  version "1.14.5"
-  resolved "https://registry.yarnpkg.com/layer-manager/-/layer-manager-1.14.5.tgz#3b7b3a87fa9c773daa3dcfa1e0de059c9dfe9cf2"
+layer-manager@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/layer-manager/-/layer-manager-1.15.0.tgz#eae89ed449e458f86e9f8fbbb2b09c32184b12a5"
+  integrity sha512-INH6bVyMXqgc/WwND6QBLNMXdiVaad9IuMUY+RlmTqU4pTgwHLeq38wWMUfQEkiNYtlu98a5yLxG0C+CNidYIw==
   dependencies:
     axios "^0.18.0"
     lodash "^4.17.11"


### PR DESCRIPTION
## Overview
Fixes an issue where map-swipe wasn't showing the layer comparative

## Testing instructions
Test a couple of different layers like http://localhost:9000/embed/map-swipe?zoom=5&lat=20&lng=75&layers=aad32781-71f2-4ee2-99a8-0d06a7c7e27e,53353f6d-b11f-4ba7-b6cd-9fa441d761e4 and see how they change when the swipe is moved.

## Pivotal task
https://www.pivotaltracker.com/story/show/163767481

Blocked: https://github.com/Vizzuality/layer-manager/pull/48


**Edit**: blocked removed.

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
