### PR TITLE
Ensures backward compatibility with most-visited deprecated filter

### DIFF
--- a/pages/app/explore/index.js
+++ b/pages/app/explore/index.js
@@ -57,7 +57,8 @@ class ExplorePage extends Page {
     // Query
     if (page) store.dispatch(actions.setDatasetsPage(+page));
     if (search) store.dispatch(actions.setFiltersSearch(search));
-    if (sort) store.dispatch(actions.setSortSelected(sort));
+    // adds this extra-condition to enable backward compatibility with deprecated `most-visited` sorting filter
+    if (sort && sort !== 'most-visited') store.dispatch(actions.setSortSelected(sort));
     if (sortDirection) store.dispatch(actions.setSortDirection(+sortDirection));
     if (topics) store.dispatch(actions.setFiltersSelected({ key: 'topics', list: JSON.parse(decodeURIComponent(topics)) }));
     if (data_types) store.dispatch(actions.setFiltersSelected({ key: 'data_types', list: JSON.parse(decodeURIComponent(data_types)) }));


### PR DESCRIPTION
## Overview
Ensures backward compatibility with most-visited deprecated sorting filter

## Testing instructions
Go to `http://localhost:9000/data/explore?zoom=5&lat=36.049098959065645&lng=-95.09765625000001&basemap=light&labels=light&layers=[{%22dataset%22:%22c9eadefd-4a06-4f3b-a2eb-3e3f45624c24%22,%22opacity%22:1,%22layer%22:%2282e75226-a316-4462-9d56-f89f596d0d7d%22},{%22dataset%22:%2263a7a997-695d-4629-b6e9-9b169f5c69bf%22,%22opacity%22:1,%22layer%22:%2277ba0a3b-3940-4525-90ad-f1c729bc8673%22},{%22dataset%22:%22a86d906d-9862-4783-9e30-cdb68cd808b8%22,%22opacity%22:1,%22layer%22:%22f0bb4a22-ac63-4cd0-8bea-1ced880add03%22}]&page=1&sort=most-visited&sortDirection=-1`. Everything should be OK.

## Pivotal task
https://www.pivotaltracker.com/story/show/164441901

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
