### PR TITLE
Adds missing dependencies to Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2019-03-18
+### Fixed
+- Fixed error compilation with `node-gyp` and `canvas` in Dockerfile 
+adding `pango-dev`, `jpeg-dev` dependencies.
 ## [2.0.0] - 2019-03-13
 ### Changed
 - Updates app pages according to Next 7.0.

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ ENV PARDOT_NEWSLETTER_URL https://go.pardot.com/l/120942/2018-01-25/3nzl13
 
 RUN apk update && apk add --no-cache \
     build-base gcc bash git \
-    cairo-dev
+    cairo-dev pango-dev jpeg-dev
+
 
 # Add app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Overview
Docker failed to install app dependencies when it tried to run `canvas` with `node-gyp`. Apparently, a couple of dependencies were missing. I've added them.

## Testing instructions
Enable Docker app and run `docker-compose -f docker-compose.yml up --build`

## Pivotal task
 –

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
