### PR TITLE
Replace error object with error message on state tree update after 40…

### DIFF
--- a/modules/dashboards/actions.js
+++ b/modules/dashboards/actions.js
@@ -22,7 +22,7 @@ export const getPublishedDashboards = createThunkAction('DASHBOARDS__GET-PUBLISH
         dispatch(setLoading({ key: 'published', value: false }));
       })
       .catch((err) => {
-        dispatch(setError({ key: 'published', value: err }));
+        dispatch(setError({ key: 'published', value: err.message }));
         dispatch(setLoading({ key: 'published', value: false }));
       });
   });
@@ -39,7 +39,7 @@ export const getDashboard = createThunkAction('DASHBOARDS__GET-DASHBOARD',
         dispatch(setLoading({ key: 'detail', value: false }));
       })
       .catch((err) => {
-        dispatch(setError({ key: 'detail', value: err }));
+        dispatch(setError({ key: 'detail', value: err.message }));
         dispatch(setLoading({ key: 'detail', value: false }));
       });
   });

--- a/modules/partners/actions.js
+++ b/modules/partners/actions.js
@@ -30,7 +30,7 @@ export const getPublishedPartners = createThunkAction('PARTNERS/GET-PUBLISHED-PA
         dispatch(setLoading({ key: 'published', value: false }));
       })
       .catch((err) => {
-        dispatch(setError({ key: 'published', value: err }));
+        dispatch(setError({ key: 'published', value: err.message }));
         dispatch(setLoading({ key: 'published', value: false }));
       });
   });
@@ -46,7 +46,7 @@ export const getAllPartners = createThunkAction('PARTNERS/GET-ALL-PARTNERS',
         dispatch(setLoading({ key: 'all', value: false }));
       })
       .catch((err) => {
-        dispatch(setError({ key: 'all', value: err }));
+        dispatch(setError({ key: 'all', value: err.message }));
         dispatch(setLoading({ key: 'all', value: false }));
       });
   });
@@ -63,7 +63,7 @@ export const getPartner = createThunkAction('PARTNERS/GET-PARTNER',
         dispatch(setLoading({ key: 'detail', value: false }));
       })
       .catch((err) => {
-        dispatch(setError({ key: 'detail', value: err }));
+        dispatch(setError({ key: 'detail', value: err.message }));
         dispatch(setLoading({ key: 'detail', value: false }));
       });
   });
@@ -76,7 +76,7 @@ export const getDatasetsByPartner = createThunkAction('PARTNERS/GET-PARTNER',
 
     return DatasetService.getDatasets(datasetIds, locale, includes)
       .then((response) => { dispatch(setPartner({ key: 'datasetsByPartner', value: WRISerializer({ data: response, locale }) })); })
-      .catch((err) => { dispatch(setError({ key: 'datasetsByPartner', value: err })); });
+      .catch((err) => { dispatch(setError({ key: 'datasetsByPartner', value: err.message })); });
   });
 
 

--- a/modules/topics/actions.js
+++ b/modules/topics/actions.js
@@ -25,7 +25,7 @@ export const getAllTopics = createThunkAction('TOPICS/GET-ALL-TOPICS',
         dispatch(setLoading({ key: 'all', value: false }));
       })
       .catch((err) => {
-        dispatch(setError({ key: 'all', value: err }));
+        dispatch(setError({ key: 'all', value: err.message }));
         dispatch(setLoading({ key: 'all', value: false }));
       });
   });
@@ -48,7 +48,7 @@ export const getPublishedTopics = createThunkAction('TOPICS/GET-PUBLISHED-TOPICS
         dispatch(setLoading({ key: 'published', value: false }));
       })
       .catch((err) => {
-        dispatch(setError({ key: 'published', value: err }));
+        dispatch(setError({ key: 'published', value: err.message }));
         dispatch(setLoading({ key: 'published', value: false }));
       });
   });
@@ -65,7 +65,7 @@ export const getTopic = createThunkAction('TOPICS/GET-TOPIC',
         dispatch(setLoading({ key: 'detail', value: false }));
       })
       .catch((err) => {
-        dispatch(setError({ key: 'detail', value: err }));
+        dispatch(setError({ key: 'detail', value: err.message }));
         dispatch(setLoading({ key: 'detail', value: false }));
       });
   });
@@ -82,7 +82,7 @@ export const onUpdateTopic = createThunkAction('TOPICS/UPDATE-TOPIC',
         dispatch(setLoading({ key: 'detail', value: false }));
       })
       .catch((err) => {
-        dispatch(setError({ key: 'detail', value: err }));
+        dispatch(setError({ key: 'detail', value: err.message }));
         dispatch(setLoading({ key: 'detail', value: false }));
       });
   });

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "check-layers": "NODE_ENV=test babel-node ./tasks/check-layers.js",
     "test": "yarn lint",
     "lint": "eslint .",
-    "dev": "node index.js",
+    "dev": "node $NODE_DEBUG_OPTION index.js",
     "build": "better-npm-run build",
     "start": "better-npm-run start"
   },

--- a/services/TopicsService.js
+++ b/services/TopicsService.js
@@ -135,6 +135,11 @@ export const fetchTopics = (params = {}) =>
       const { status, statusText, data } = response;
       if (status >= 400) throw new Error(statusText);
       return WRISerializer(data);
+    })
+    .catch((response) => {
+      const { status, statusText, data } = response;
+      if (status >= 400) throw new Error(statusText);
+      return WRISerializer(data);
     });
 
 /**

--- a/services/TopicsService.js
+++ b/services/TopicsService.js
@@ -133,12 +133,7 @@ export const fetchTopics = (params = {}) =>
   })
     .then((response) => {
       const { status, statusText, data } = response;
-      if (status >= 400) throw new Error(statusText);
-      return WRISerializer(data);
-    })
-    .catch((response) => {
-      const { status, statusText, data } = response;
-      if (status >= 400) throw new Error(statusText);
+      if (status >= 200) throw new Error(statusText);
       return WRISerializer(data);
     });
 
@@ -152,7 +147,7 @@ export const fetchTopic = id =>
   WRIAPI.get(`/topic/${id}`)
     .then((response) => {
       const { status, statusText, data } = response;
-      if (status >= 400) throw new Error(statusText);
+      if (status >= 200) throw new Error(statusText);
       return WRISerializer(data);
     });
 


### PR DESCRIPTION
…4 error

## Overview
If a fetch request fails to load anything into the state, the applications does not throw an error. It instead pushes the whole Error object into the state tree, which is then parsed by whatever magic libraries you have, which attempt to serialize it into a JSON object. Because those error objects have circular dependencies, that serialization fails: https://console.cloud.google.com/errors/CKKO8r6Xi8u5fQ?time=P1D&project=resource-watch&authuser=1

This change replaces the injection of the whole error object into the state tree with just the error message - that way avoiding that error. As I don't know the implications of this on the rest of the application, I don't know if this should be the final form of the solution, or if it needs more luv, but it should at least be a place to start.

Since these errors seem to result from failed calls to external HTTP resources, and those calls are made on the server, it would also be great if you could log those failed calls to stderr, so we could keep an eye on them going forward. Again, you use magic libs, so I have no clue how to do this, but feel free to ping me for help

## Testing instructions
Start the project with a CT_URL pointing to something that does not exist, load the homepage, "Circular reference" errors everywhere on the server console.

## Pivotal task
Provide the link to the task(s), if any.

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
