### PR TITLE
finallyShim added

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "pluralize": "5.0.0",
     "postcss-easy-import": "2.0.0",
     "postcss-loader": "^3.0.0",
+    "promise.prototype.finally": "^3.1.0",
     "prop-types": "^15.6.0",
     "query-string": "5.0.1",
     "rc-pagination": "1.8.8",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,9 @@ import { Provider } from 'react-redux';
 import withRedux from 'next-redux-wrapper';
 import { initStore } from 'store';
 
+// es6 shim for .finally() in promises
+import finallyShim from 'promise.prototype.finally';
+
 // actions
 import { setRouter } from 'redactions/routes';
 import {
@@ -23,6 +26,9 @@ import {
 
 // app styles
 import 'css/index.scss';
+
+
+finallyShim.shim();
 
 class RWApp extends App {
   static async getInitialProps({ Component, router, ctx }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4042,7 +4042,19 @@ es-abstract@^1.10.0, es-abstract@^1.5.1, es-abstract@^1.6.1, es-abstract@^1.7.0:
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
-es-to-primitive@^1.1.1:
+es-abstract@^1.9.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
+  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-keys "^1.0.12"
+
+es-to-primitive@^1.1.1, es-to-primitive@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
   dependencies:
@@ -8530,6 +8542,15 @@ promise-each@^2.2.0:
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
+
+promise.prototype.finally@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz#66f161b1643636e50e7cf201dc1b84a857f3864e"
+  integrity sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.9.0"
+    function-bind "^1.1.1"
 
 promise@^7.0.1, promise@^7.0.3, promise@^7.1.1:
   version "7.3.1"


### PR DESCRIPTION
## Overview
MyRW: Widget preview didn´t load in Firefox. finallyShim added to provide compatibility shims so that legacy JavaScript engines behave as closely as possible to ECMAScript 6.

## Testing instructions
Go to /data/widget/ef6ea89e-0a8c-466d-8197-e294985f3e43 (in Firefox)

## Pivotal task
https://www.pivotaltracker.com/story/show/164958831.

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
