### PR TITLE
Avoids fetching topics in embed pages

### DIFF
--- a/constants/app.js
+++ b/constants/app.js
@@ -22,7 +22,13 @@ export const FULLSCREEN_PAGES = [
 ];
 
 export const PAGES_WITHOUT_TOPICS = [
-  '/sign-in'
+  '/sign-in',
+  '/embed'
+];
+
+export const PAGES_WITH_USER_COLLECTIONS = [
+  '/myrw-detail/',
+  '/myrw/'
 ];
 
 export const CESIUM_ROUTES = [
@@ -35,5 +41,6 @@ export default {
   USERREPORT_BLACKLIST,
   FULLSCREEN_PAGES,
   PAGES_WITHOUT_TOPICS,
+  PAGES_WITH_USER_COLLECTIONS,
   CESIUM_ROUTES
 };

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -18,9 +18,13 @@ import { setMobileDetect, mobileParser } from 'react-responsive-redux';
 import { getPublishedTopics } from 'modules/topics/actions';
 import { getPublishedPartners } from 'modules/partners/actions';
 
+// utils
+import { containsString } from 'utils/string';
+
 // constants
 import {
   PAGES_WITHOUT_TOPICS,
+  PAGES_WITH_USER_COLLECTIONS,
   FULLSCREEN_PAGES
 } from 'constants/app';
 
@@ -46,14 +50,18 @@ class RWApp extends App {
     if (user) {
       store.dispatch(setUser(user));
       await store.dispatch(getUserFavourites());
-      if (['/myrw-detail/', '/myrw/'].some(el => pathname.includes(el))) await store.dispatch(getUserCollections());
+
+      // fetches user's collections
+      if (containsString(pathname, PAGES_WITH_USER_COLLECTIONS)) {
+        await store.dispatch(getUserCollections());
+      }
     }
 
-    // fetchs published topics to populate topics menu in the app header
-    if (!PAGES_WITHOUT_TOPICS.includes(pathname)) await store.dispatch(getPublishedTopics());
+    // fetches published topics to populate topics menu in the app header
+    if (!containsString(pathname, PAGES_WITHOUT_TOPICS)) await store.dispatch(getPublishedTopics());
 
-    // fetchs partners for footer
-    if (!FULLSCREEN_PAGES.includes(pathname)) await store.dispatch(getPublishedPartners());
+    // fetches partners for footer
+    if (!containsString(pathname, FULLSCREEN_PAGES)) await store.dispatch(getPublishedPartners());
 
     // mobile detection
     if (isServer) {


### PR DESCRIPTION
## Overview
Avoids fetching topics in `/embed/..` pages as we don't need them.

## Testing instructions
Go to some `/embed` page, you shouldn't see the fetch.

## Pivotal task
–

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
