### PR TITLE
fix fetch layer import

### DIFF
--- a/layout/app/pulse/layer-pill/actions.js
+++ b/layout/app/pulse/layer-pill/actions.js
@@ -4,7 +4,7 @@ import { createAction, createThunkAction } from 'redux-tools';
 import LayerGlobeManager from 'utils/layers/LayerGlobeManager';
 
 // Services
-import fetchLayer from 'services/LayersService';
+import { fetchLayer } from 'services/LayersService';
 
 export const setContextLayers = createAction('layer-pill/setContextLayers');
 export const setContextActiveLayers = createAction('layer-pill/setContextActiveLayers');


### PR DESCRIPTION
## Overview
fetchLayer import fixed in layout/app/pulse/layer-pill/actions.js.

## Testing instructions
http://localhost:9000/data/pulse (ex hazards -> fires -> population)

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
