### PR TITLE
Fixes wrong fetch in admin data/detail

### DIFF
--- a/layout/admin/data-detail/component.js
+++ b/layout/admin/data-detail/component.js
@@ -11,22 +11,23 @@ import WidgetsTab from 'components/admin/data/widgets';
 import LayersTab from 'components/admin/data/layers';
 
 // services
-import DatasetsService from 'services/DatasetsService';
-import WidgetsService from 'services/WidgetsService';
+import { fetchDataset } from 'services/dataset';
 import { fetchLayer } from 'services/LayersService';
+import { fetchWidget } from 'services/widget';
 
 // utils
 import { capitalizeFirstLetter } from 'utils/utils';
 
 class LayoutAdminDataDetail extends PureComponent {
-  static propTypes = {
-    query: PropTypes.object.isRequired,
-    locale: PropTypes.string.isRequired
-  }
+  static propTypes = { query: PropTypes.object.isRequired }
 
   state= { data: null }
 
   componentWillMount() {
+    const { query: { id } } = this.props;
+
+    if (id === 'new') return;
+
     this.getData();
   }
 
@@ -41,31 +42,24 @@ class LayoutAdminDataDetail extends PureComponent {
   }
 
   getData() {
-    const {
-      query: { tab, id },
-      locale
-    } = this.props;
+    const { query: { tab, id } } = this.props;
 
-    if (id === 'new') return;
-
-    this.service = null;
-
-    switch (tab) {
-      case 'datasets':
-        this.service = new DatasetsService({ language: locale });
-        break;
-      case 'widgets':
-        this.service = new WidgetsService();
-        break;
-      default:
-        this.service = new DatasetsService({ language: locale });
+    if (tab === 'datasets') {
+      fetchDataset(id)
+        .then((dataset) => { this.setState({ data: dataset }); })
+        .catch((err) => { toastr.error('Error', err.message); });
     }
 
-    if (this.service) {
-      // Fetch the dataset / layer / widget depending on the tab
+    if (tab === 'widgets') {
+      fetchWidget(id)
+        .then((widget) => { this.setState({ data: widget }); })
+        .catch((err) => { toastr.error('Error', err.message); });
+    }
+
+    if (tab === 'layers') {
       fetchLayer(id)
-        .then((data) => { this.setState({ data }); })
-        .catch((err) => { toastr.error('Error', err); });
+        .then((layer) => { this.setState({ data: layer }); })
+        .catch((err) => { toastr.error('Error', err.message); });
     }
   }
 

--- a/layout/app/pulse/layer-pill/actions.js
+++ b/layout/app/pulse/layer-pill/actions.js
@@ -39,7 +39,7 @@ export const toggleContextualLayer = createThunkAction('layer-pill/toggleContext
           );
           dispatch(setContextLayersLoading(false));
         })
-        .catch(error => dispatch(setContextLayersError(error)));
+        .catch(error => dispatch(setContextLayersError(error.message)));
     }
 
     const index = newActiveLayers.indexOf(id);

--- a/services/LayersService.js
+++ b/services/LayersService.js
@@ -192,7 +192,7 @@ export const fetchLayer = (id, params = {}) => {
   }).catch(({ response }) => {
     const { status, statusText } = response;
     logger.error('Error fetching layer:', `${status}: ${statusText}`);
-    return WRISerializer({});
+    throw new Error('Error fetching layer:', `${status}: ${statusText}`);
   });
 };
 

--- a/services/dataset.js
+++ b/services/dataset.js
@@ -1,5 +1,6 @@
 import { WRIAPI } from 'utils/axios';
 import WRISerializer from 'wri-json-api-serializer';
+import { logger } from 'utils/logs';
 
 // API docs: https://resource-watch.github.io/doc-api/index-rw.html#dataset
 
@@ -9,9 +10,10 @@ import WRISerializer from 'wri-json-api-serializer';
  * @param {Object[]} params - params sent to the API.
  * @returns {Object[]} array of serialized datasets.
  */
+export const fetchDatasets = (params = {}) => {
+  logger('fetches datasets');
 
-export const fetchDatasets = (params = {}) =>
-  WRIAPI.get('/dataset', {
+  return WRIAPI.get('/dataset', {
     headers: {
       ...WRIAPI.defaults.headers,
       // TO-DO: forces the API to not cache, this should be removed at some point
@@ -24,8 +26,62 @@ export const fetchDatasets = (params = {}) =>
   })
     .then((response) => {
       const { status, statusText, data } = response;
-      if (status >= 400) throw new Error(statusText);
+      if (status >= 300) {
+        logger.error('Error fetching datasets:', `${status}: ${statusText}`);
+        throw new Error(statusText);
+      }
       return WRISerializer(data);
-    });
+    })
+    .catch(({ response }) => {
+      const { status, statusText } = response;
 
-export default { fetchDatasets };
+      logger.error(`Error fetching datasets: ${status}: ${statusText}`);
+      throw new Error(`Error fetching datasets: ${status}: ${statusText}`);
+    });
+};
+
+
+/**
+ * fetches data for a specific dataset.
+ *
+ * @param {String} id - dataset id.
+ * @param {Object[]} params - params sent to the API.
+ * @returns {Object} serialized specified dataset.
+ */
+export const fetchDataset = (id, params = {}) => {
+  if (!id) throw Error('dataset id is mandatory to perform this fetching.');
+  logger.info(`Fetches dataset: ${id}`);
+
+  return WRIAPI.get(`/dataset/${id}`, {
+    headers: {
+      ...WRIAPI.defaults.headers,
+      // TO-DO: forces the API to not cache, this should be removed at some point
+      'Upgrade-Insecure-Requests': 1
+    },
+    params
+  })
+    .then((response) => {
+      const { status, statusText, data } = response;
+
+      if (status >= 300) {
+        if (status === 404) {
+          logger.debug(`Dataset '${id}' not found, ${status}: ${statusText}`);
+        } else {
+          logger.error(`Error fetching dataset: ${id}: ${status}: ${statusText}`);
+        }
+        throw new Error(statusText);
+      }
+      return WRISerializer(data);
+    })
+    .catch(({ response }) => {
+      const { status, statusText } = response;
+
+      logger.error(`Error fetching dataset ${id}: ${status}: ${statusText}`);
+      throw new Error(`Error fetching dataset ${id}: ${status}: ${statusText}`);
+    });
+};
+
+export default {
+  fetchDatasets,
+  fetchDataset
+};

--- a/services/widget.js
+++ b/services/widget.js
@@ -38,8 +38,9 @@ export const fetchWidget = (id, params = {}) => {
     })
     .catch(({ response }) => {
       const { status, statusText } = response;
+
       logger.error(`Error fetching widget ${id}: ${status}: ${statusText}`);
-      return WRISerializer({});
+      throw new Error(`Error fetching widget ${id}: ${status}: ${statusText}`);
     });
 };
 


### PR DESCRIPTION
## Overview
Fixes a regression where the layout always fetched a layer even when it was about datasets or widgets,  not showing the name of the resource in the header.

Also, adds `fetchWidget` method to new dataset service following the new format.
Finally, some improvement in error handling in fetches.

## Testing instructions
Go to http://localhost:9000/admin/data/datasets/e7b9efb2-3836-45ae-8b6a-f8391c7bcd2f/edit (in production environment). The header should display the name of the current dataset. Same for widgets and layers if you go to their tabs.

## Pivotal task
https://www.pivotaltracker.com/story/show/165406297/comments/201731174

@mluena if the PR is approved, please, tell Pablo P. or Tiago G. to deploy to `staging` and dollow the next deploys until `production` if everything works properly. This bug is already on `production` so it would be nice having it deployed and fixed ASAP. Let the client know in Pivotal (or tell Pablo) once the fix is on production and working.

Thanks!

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
