### PR TITLE
Fixes fetching topics in /sign-in

### DIFF
--- a/constants/app.js
+++ b/constants/app.js
@@ -22,7 +22,7 @@ export const FULLSCREEN_PAGES = [
 ];
 
 export const PAGES_WITHOUT_TOPICS = [
-  '/sign-in',
+  '/admin',
   '/embed'
 ];
 

--- a/services/TopicsService.js
+++ b/services/TopicsService.js
@@ -124,7 +124,7 @@ export default class TopicsService {
  * @returns {Object[]} array of serialized topics.
  */
 export const fetchTopics = (params = {}) => {
-  logger.info('Fetching topics');
+  logger.info('fetches topics');
 
   return WRIAPI.get('/topic', {
     headers: {


### PR DESCRIPTION
https://vizzuality.slack.com/files/U062H7TJB/FJKN82SF9/image.png

## Overview
Fixes a bug where topics in the app header won't fetch if you land in the `/sign-in` page directly. Also, it happens if you come from another page and refresh being in `/sign-in` page.

Also, disables fetching topics in `/admin` pages as we don't need them.

## Testing instructions
Go to `/sign-in` page and refresh. Topics in the header app should have fetched.

## Pivotal task
https://www.pivotaltracker.com/story/show/165890985

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
