### PR TITLE
Table footer in admin restricted

### DIFF
--- a/components/ui/customtable/CustomTable.js
+++ b/components/ui/customtable/CustomTable.js
@@ -291,11 +291,13 @@ export default class CustomTable extends PureComponent {
 
         </table>
         {/* Table footer */}
-        <TableFooter
-          pagination={pagination}
-          onChangePage={this.onChangePage}
-          showTotalPages
-        />
+        {pagination.size > 0 && (
+          <TableFooter
+            pagination={pagination}
+            onChangePage={this.onChangePage}
+            showTotalPages
+          />
+          )}
       </div>
     );
   }

--- a/components/ui/customtable/footer/TableFooter.js
+++ b/components/ui/customtable/footer/TableFooter.js
@@ -26,16 +26,13 @@ class TableFooter extends PureComponent {
 
     return (
       <div className="table-footer">
-        {(pagination.size > 0) &&
-          <Paginator
-            options={pagination}
-            onChange={page => this.onChangePage(page)}
-          />
-        }
-        {(pagination.enabled && showTotalPages && pagination.pages && (pagination.size > 0)) &&
+        <Paginator
+          options={pagination}
+          onChange={page => this.onChangePage(page)}
+        />
+        {(pagination.enabled && showTotalPages && pagination.pages) &&
           <div>Page <span>{pagination.page}</span> of <span>{pagination.pages}</span></div>
         }
-
       </div>
     );
   }

--- a/components/ui/customtable/footer/TableFooter.js
+++ b/components/ui/customtable/footer/TableFooter.js
@@ -23,22 +23,21 @@ class TableFooter extends PureComponent {
 
   render() {
     const { pagination, showTotalPages } = this.props;
-    if (pagination.size > 0) {
-      return (
-        <div className="table-footer">
+
+    return (
+      <div className="table-footer">
+        {(pagination.size > 0) &&
           <Paginator
             options={pagination}
             onChange={page => this.onChangePage(page)}
           />
+        }
+        {(pagination.enabled && showTotalPages && pagination.pages && (pagination.size > 0)) &&
+          <div>Page <span>{pagination.page}</span> of <span>{pagination.pages}</span></div>
+        }
 
-          {(pagination.enabled && showTotalPages && pagination.pages) &&
-            <div>Page <span>{pagination.page}</span> of <span>{pagination.pages}</span></div>
-          }
-
-        </div>
-      );
-    }
-    return null;
+      </div>
+    );
   }
 }
 

--- a/components/ui/customtable/footer/TableFooter.js
+++ b/components/ui/customtable/footer/TableFooter.js
@@ -23,20 +23,22 @@ class TableFooter extends PureComponent {
 
   render() {
     const { pagination, showTotalPages } = this.props;
+    if (pagination.size > 0) {
+      return (
+        <div className="table-footer">
+          <Paginator
+            options={pagination}
+            onChange={page => this.onChangePage(page)}
+          />
 
-    return (
-      <div className="table-footer">
-        <Paginator
-          options={pagination}
-          onChange={page => this.onChangePage(page)}
-        />
+          {(pagination.enabled && showTotalPages && pagination.pages) &&
+            <div>Page <span>{pagination.page}</span> of <span>{pagination.pages}</span></div>
+          }
 
-        {(pagination.enabled && showTotalPages && pagination.pages) &&
-          <div>Page <span>{pagination.page}</span> of <span>{pagination.pages}</span></div>
-        }
-
-      </div>
-    );
+        </div>
+      );
+    }
+    return null;
   }
 }
 


### PR DESCRIPTION
## Overview
Condition added to table footer, it doesn´t appear if there are no results.

## Testing instructions
Go to any of the options in admin (http://localhost:9000/admin/pages) and search until you get no results, table footer must disappear.


---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
