### PR TITLE
Small fixes in BO

### DIFF
--- a/components/admin/data/datasets/pages/show/component.js
+++ b/components/admin/data/datasets/pages/show/component.js
@@ -74,7 +74,7 @@ class DatasetsShow extends PureComponent {
               }
 
               {(currentSubtab === 'widgets') && (<WidgetsIndex dataset={id} />)}
-              {(currentSubtab === 'layers') && (<LayersIndex />)}
+              {(currentSubtab === 'layers') && (<LayersIndex dataset={id} />)}
             </div>
 
           </div>

--- a/components/admin/data/datasets/pages/show/component.js
+++ b/components/admin/data/datasets/pages/show/component.js
@@ -73,7 +73,7 @@ class DatasetsShow extends PureComponent {
                 </div>
               }
 
-              {(currentSubtab === 'widgets') && (<WidgetsIndex />)}
+              {(currentSubtab === 'widgets') && (<WidgetsIndex dataset={id} />)}
               {(currentSubtab === 'layers') && (<LayersIndex />)}
             </div>
 

--- a/components/admin/data/layers/table/component.js
+++ b/components/admin/data/layers/table/component.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
 
 // services
@@ -19,6 +20,10 @@ import GoToDatasetAction from './actions/go-to-dataset';
 import { INITIAL_PAGINATION } from './constants';
 
 class LayersTable extends PureComponent {
+  static propTypes = { dataset: PropTypes.string }
+
+  static defaultProps = { dataset: null }
+
   state = {
     pagination: INITIAL_PAGINATION,
     loading: true,
@@ -27,13 +32,15 @@ class LayersTable extends PureComponent {
   }
 
   componentDidMount() {
+    const { dataset } = this.props;
     const { pagination } = this.state;
 
     fetchLayers({
       includes: 'user',
       'page[number]': pagination.page,
       'page[size]': pagination.limit,
-      application: process.env.APPLICATIONS
+      application: process.env.APPLICATIONS,
+      ...dataset && { dataset }
     }, true)
       .then(({ layers, meta }) => {
         const {
@@ -60,6 +67,7 @@ class LayersTable extends PureComponent {
    * @param {string} { value } Search keywords
    */
   onSearch = debounce((value) => {
+    const { dataset } = this.props;
     const { pagination, filters } = this.state;
 
     if (value.length > 0 && value.length < 3) return;
@@ -76,14 +84,16 @@ class LayersTable extends PureComponent {
         ...!value.length && {
           'page[number]': INITIAL_PAGINATION.page,
           'page[size]': INITIAL_PAGINATION.limit,
-          application: process.env.APPLICATIONS
+          application: process.env.APPLICATIONS,
+          ...dataset && { dataset }
         },
         ...value.length > 2 && {
           'page[number]': INITIAL_PAGINATION.page,
           'page[size]': INITIAL_PAGINATION.limit,
           application: process.env.APPLICATIONS,
           sort: 'name',
-          name: value
+          name: value,
+          ...dataset && { dataset }
         }
       };
 
@@ -112,6 +122,7 @@ class LayersTable extends PureComponent {
   }, 250)
 
   onChangePage = (nextPage) => {
+    const { dataset } = this.props;
     const { pagination, filters } = this.state;
 
     this.setState({
@@ -128,7 +139,8 @@ class LayersTable extends PureComponent {
         'page[number]': page,
         'page[size]': pagination.limit,
         application: process.env.APPLICATIONS,
-        ...filters
+        ...filters,
+        ...dataset && { dataset }
       })
         .then((layers) => {
           this.setState({
@@ -141,6 +153,7 @@ class LayersTable extends PureComponent {
   }
 
   onRemoveLayer = () => {
+    const { dataset } = this.props;
     const { pagination, filters } = this.state;
 
     this.setState({ loading: true });
@@ -150,7 +163,8 @@ class LayersTable extends PureComponent {
       'page[number]': pagination.page,
       'page[size]': pagination.limit,
       application: process.env.APPLICATIONS,
-      ...filters
+      ...filters,
+      ...dataset && { dataset }
     }, true)
       .then(({ layers, meta }) => {
         const {

--- a/components/admin/data/widgets/form/constants.js
+++ b/components/admin/data/widgets/form/constants.js
@@ -26,16 +26,15 @@ export const STATE_DEFAULT = {
 };
 
 export const FORM_ELEMENTS = {
-  elements: {
-  },
+  elements: {},
   validate() {
-    const elements = this.elements;
+    const { elements } = this;
     Object.keys(elements).forEach((k) => {
       elements[k].validate();
     });
   },
   isValid() {
-    const elements = this.elements;
+    const { elements } = this;
     const valid = Object.keys(elements)
       .map(k => elements[k].isValid())
       .filter(v => v !== null)

--- a/components/admin/data/widgets/form/index.js
+++ b/components/admin/data/widgets/form/index.js
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+
+// component
+import WidgetForm from './component';
+
+export default connect(
+  state => ({
+    widgetEditor: state.widgetEditor,
+    locale: state.common.locale
+  }),
+  null
+)(WidgetForm);

--- a/components/admin/data/widgets/pages/list/component.js
+++ b/components/admin/data/widgets/pages/list/component.js
@@ -5,14 +5,16 @@ import PropTypes from 'prop-types';
 import WidgetsTable from 'components/admin/data/widgets/table';
 
 class WidgetsIndex extends PureComponent {
-  static propTypes = { user: PropTypes.object.isRequired }
+  static propTypes = { dataset: PropTypes.string }
+
+  static defaultProps = { dataset: null }
 
   render() {
-    const { user: { token } } = this.props;
+    const { dataset } = this.props;
 
     return (
       <div className="c-widgets-index">
-        <WidgetsTable authorization={token} />
+        <WidgetsTable dataset={dataset} />
       </div>
     );
   }

--- a/components/admin/data/widgets/pages/new/component.js
+++ b/components/admin/data/widgets/pages/new/component.js
@@ -3,37 +3,30 @@ import PropTypes from 'prop-types';
 import { Router } from 'routes';
 
 // components
-import WidgetsForm from 'components/admin/data/widgets/form/WidgetsForm';
+import WidgetForm from 'components/admin/data/widgets/form';
 
 class WidgetsNew extends PureComponent {
-  static propTypes = {
-    dataset: PropTypes.string,
-    user: PropTypes.object.isRequired
-  }
+  static propTypes = { user: PropTypes.object.isRequired }
 
-  static defaultProps = { dataset: null }
-
-  handleSubmit = () => {
-    const { dataset } = this.props;
-
-    if (dataset) {
-      Router.pushRoute('admin_data_detail', { tab: 'datasets', subtab: 'widgets', id: dataset });
+  handleSubmit = (widget) => {
+    if (widget) {
+      Router.pushRoute('admin_data_detail', {
+        tab: 'datasets',
+        subtab: 'widgets',
+        id: widget.dataset
+      });
     } else {
       Router.pushRoute('admin_data', { tab: 'widgets' });
     }
   }
 
   render() {
-    const {
-      user: { token },
-      dataset
-    } = this.props;
+    const { user: { token } } = this.props;
 
     return (
       <div className="c-widgets-new">
-        <WidgetsForm
+        <WidgetForm
           authorization={token}
-          dataset={dataset}
           onSubmit={this.handleSubmit}
         />
       </div>

--- a/components/admin/data/widgets/pages/new/index.js
+++ b/components/admin/data/widgets/pages/new/index.js
@@ -4,9 +4,6 @@ import { connect } from 'react-redux';
 import WidgetsNew from './component';
 
 export default connect(
-  state => ({
-    user: state.user,
-    dataset: state.routes.query.id
-  }),
+  state => ({ user: state.user }),
   null
 )(WidgetsNew);

--- a/components/admin/data/widgets/pages/show/component.js
+++ b/components/admin/data/widgets/pages/show/component.js
@@ -4,23 +4,33 @@ import { Router } from 'routes';
 import PropTypes from 'prop-types';
 
 // components
-import WidgetsForm from 'components/admin/data/widgets/form/WidgetsForm';
 import Aside from 'components/ui/Aside';
+import WidgetForm from 'components/admin/data/widgets/form';
 import MetadataForm from 'components/widgets/metadata/form/MetadataForm';
 
 class WidgetsShow extends PureComponent {
   static propTypes = {
     tabs: PropTypes.array.isRequired,
     query: PropTypes.object.isRequired,
-    dataset: PropTypes.string.isRequired,
     user: PropTypes.object.isRequired
+  }
+
+  handleSubmit = (widget) => {
+    if (widget) {
+      Router.pushRoute('admin_data_detail', {
+        tab: 'datasets',
+        subtab: 'widgets',
+        id: widget.dataset
+      });
+    } else {
+      Router.pushRoute('admin_data', { tab: 'widgets' });
+    }
   }
 
   render() {
     const {
       query: { id, subtab },
       tabs,
-      dataset,
       user: { token }
     } = this.props;
     const currentSubTab = subtab || 'edit';
@@ -46,17 +56,11 @@ class WidgetsShow extends PureComponent {
 
             <div className="columns small-12 medium-9">
               {(subtab === 'edit') &&
-              (<WidgetsForm
+              (<WidgetForm
                 id={id}
                 authorization={token}
                 showEditor
-                onSubmit={() => {
-                  if (dataset) {
-                    Router.pushRoute('admin_data_detail', { tab: 'datasets', subtab: 'widgets', id: dataset });
-                  } else {
-                    Router.pushRoute('admin_data', { tab: 'widgets' });
-                  }
-                }}
+                onSubmit={this.handleSubmit}
               />)}
 
               {(subtab === 'metadata') &&

--- a/components/admin/data/widgets/pages/show/index.js
+++ b/components/admin/data/widgets/pages/show/index.js
@@ -10,8 +10,7 @@ export default connect(
   state => ({
     user: state.user,
     query: state.routes.query,
-    tabs: parseTabs(state),
-    dataset: state.routes.query.id
+    tabs: parseTabs(state)
   }),
   null
 )(WidgetsShow);

--- a/components/admin/data/widgets/table/component.js
+++ b/components/admin/data/widgets/table/component.js
@@ -1,10 +1,6 @@
-import React from 'react';
-
-// utils
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
-
-// constants
-import { INITIAL_PAGINATION } from 'components/datasets/table/constants';
 
 // services
 import { fetchWidgets } from 'services/widget';
@@ -19,7 +15,14 @@ import OwnerTD from './td/owner';
 import EditAction from './actions/edit';
 import DeleteAction from './actions/delete';
 
-class WidgetsTable extends React.Component {
+// constants
+import { INITIAL_PAGINATION } from './constants';
+
+class WidgetsTable extends PureComponent {
+  static propTypes = { dataset: PropTypes.string }
+
+  static defaultProps = { dataset: null }
+
   state = {
     pagination: INITIAL_PAGINATION,
     loading: true,
@@ -28,13 +31,15 @@ class WidgetsTable extends React.Component {
   }
 
   componentDidMount() {
+    const { dataset } = this.props;
     const { pagination } = this.state;
 
     fetchWidgets({
       includes: 'user',
       'page[number]': pagination.page,
       'page[size]': pagination.limit,
-      application: process.env.APPLICATIONS
+      application: process.env.APPLICATIONS,
+      ...dataset && { dataset }
     }, true)
       .then(({ widgets, meta }) => {
         const {
@@ -61,6 +66,7 @@ class WidgetsTable extends React.Component {
    * @param {string} { value } Search keywords
    */
   onSearch = debounce((value) => {
+    const { dataset } = this.props;
     const { pagination, filters } = this.state;
 
     if (value.length > 0 && value.length < 3) return;
@@ -77,14 +83,17 @@ class WidgetsTable extends React.Component {
         ...!value.length && {
           'page[number]': INITIAL_PAGINATION.page,
           'page[size]': INITIAL_PAGINATION.limit,
-          application: process.env.APPLICATIONS
+          application: process.env.APPLICATIONS,
+          ...dataset && { dataset }
+
         },
         ...value.length > 2 && {
           'page[number]': INITIAL_PAGINATION.page,
           'page[size]': INITIAL_PAGINATION.limit,
           application: process.env.APPLICATIONS,
           sort: 'name',
-          name: value
+          name: value,
+          ...dataset && { dataset }
         }
       };
       fetchWidgets(params, true)
@@ -112,6 +121,7 @@ class WidgetsTable extends React.Component {
   }, 250)
 
   onChangePage = (nextPage) => {
+    const { dataset } = this.props;
     const { pagination, filters } = this.state;
 
     this.setState({
@@ -128,7 +138,8 @@ class WidgetsTable extends React.Component {
         'page[number]': page,
         'page[size]': pagination.limit,
         application: process.env.APPLICATIONS,
-        ...filters
+        ...filters,
+        ...dataset && { dataset }
       })
         .then((widgets) => {
           this.setState({
@@ -211,7 +222,7 @@ class WidgetsTable extends React.Component {
               show: true,
               list: [
                 { name: 'Edit', route: 'admin_data_detail', params: { tab: 'widgets', subtab: 'edit', id: '{{id}}' }, show: true, component: EditAction },
-                { name: 'Remove', route: 'admin_data_detail', params: { tab: 'widgets', subtab: 'remove', id: '{{id}}' }, component: DeleteAction, componentProps: { authorization: this.props.authorization } }
+                { name: 'Remove', route: 'admin_data_detail', params: { tab: 'widgets', subtab: 'remove', id: '{{id}}' }, component: DeleteAction }
               ]
             }}
             sort={{

--- a/components/admin/data/widgets/table/component.js
+++ b/components/admin/data/widgets/table/component.js
@@ -152,6 +152,7 @@ class WidgetsTable extends PureComponent {
   }
 
   onRemoveWidget = () => {
+    const { dataset } = this.props;
     const { pagination, filters } = this.state;
 
     this.setState({ loading: true });
@@ -160,7 +161,8 @@ class WidgetsTable extends PureComponent {
       'page[number]': pagination.page,
       'page[size]': pagination.limit,
       application: process.env.APPLICATIONS,
-      ...filters
+      ...filters,
+      ...dataset && { dataset }
     }, true)
       .then(({ widgets, meta }) => {
         const {

--- a/components/admin/data/widgets/table/constants.js
+++ b/components/admin/data/widgets/table/constants.js
@@ -1,0 +1,14 @@
+export const INITIAL_PAGINATION = {
+  // displays pagination
+  enabled: true,
+  // number of items per page
+  limit: 20,
+  // current page
+  page: 1,
+  // total of pages
+  pages: null,
+  // total of items to display
+  size: null
+};
+
+export default { INITIAL_PAGINATION };

--- a/layout/admin/data-detail/component.js
+++ b/layout/admin/data-detail/component.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { singular } from 'pluralize';
 import { toastr } from 'react-redux-toastr';
+import isEqual from 'react-fast-compare';
 
 // components
 import Layout from 'layout/layout/layout-admin';
@@ -29,6 +30,14 @@ class LayoutAdminDataDetail extends PureComponent {
     if (id === 'new') return;
 
     this.getData();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { query } = this.props;
+    const { query: prevQuery } = prevProps;
+    const queryChanged = !isEqual(query, prevQuery);
+
+    if (queryChanged && query.id) this.getData();
   }
 
   getName() {
@@ -79,14 +88,14 @@ class LayoutAdminDataDetail extends PureComponent {
               <div className="column small-12">
                 <div className="page-header-content">
                   {dataset && tab !== 'datasets' &&
-                    <Breadcrumbs
+                    (<Breadcrumbs
                       items={[{ name: capitalizeFirstLetter(tab), route: 'admin_data_detail', params: { tab: 'datasets', subtab: tab, id: dataset } }]}
-                    />
+                    />)
                   }
                   {!dataset &&
-                    <Breadcrumbs
+                    (<Breadcrumbs
                       items={[{ name: capitalizeFirstLetter(tab), route: 'admin_data', params: { tab } }]}
-                    />
+                    />)
                   }
                   <h1>{this.getName()}</h1>
                 </div>

--- a/layout/admin/data-detail/component.js
+++ b/layout/admin/data-detail/component.js
@@ -37,7 +37,7 @@ class LayoutAdminDataDetail extends PureComponent {
     const { query: prevQuery } = prevProps;
     const queryChanged = !isEqual(query, prevQuery);
 
-    if (queryChanged && query.id) this.getData();
+    if (queryChanged && query.id && query.id !== 'new') this.getData();
   }
 
   getName() {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-dom": "16.4.2",
     "react-dropdown-tree-select": "1.9.2",
     "react-dropzone": "4.2.9",
+    "react-fast-compare": "^2.0.4",
     "react-ga": "^2.3.5",
     "react-geosuggest": "^2.7.0",
     "react-google-recaptcha": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9184,6 +9184,11 @@ react-error-overlay@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
+react-fast-compare@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
 react-flatpickr@^3.6.4:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/react-flatpickr/-/react-flatpickr-3.6.4.tgz#41a8406d00d787b629839ae1f5a01ed3bb6e84ac"


### PR DESCRIPTION
## Overview
This PR includes 3 fixes regarding the BO:
- Fixes an issue where the ID of the dataset was wrong after updating a widget and triggered an error. Also, titles in the header updates correctly depending on where you are.
![image](https://user-images.githubusercontent.com/999124/57850104-63f52a00-77dd-11e9-9206-14acd4284683.png)

- Fixes filtering of widgets in dataset view.
![image](https://user-images.githubusercontent.com/999124/57850068-52ac1d80-77dd-11e9-8a94-cb4c8017b336.png)

- Fixes filtering of layers in dataset view.
![image](https://user-images.githubusercontent.com/999124/57850061-4922b580-77dd-11e9-98cb-b884049932b9.png)


## Testing instructions
- ID issue:
Go to any widget, update it. After that you will be redirected to the dataset detail page, click on `edit dataset`: it should load the info of the dataset, before it triggered an error. You can test the flow with https://staging.resourcewatch.org/admin/data/widgets/de877a28-8997-46c2-8e1f-ce6fcf125e5f/edit
- Fixes filtering of widgets in dataset view:
http://localhost:9000/admin/data/datasets/20cc5eca-8c63-4c41-8e8e-134dcf1e6d76/widgets should load only widgets associated to the dataset. (staging env)
- Fixes filtering of layers in dataset view:
http://localhost:9000/admin/data/datasets/20cc5eca-8c63-4c41-8e8e-134dcf1e6d76/layers
should load only layers associated to the dataset. (staging env)

## Pivotal task
https://www.pivotaltracker.com/story/show/166012357 (for filtering of widgets and layers)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
