### PR TITLE
Removes default meta viewport

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -13,11 +13,8 @@ export default class MyDocument extends Document {
         <Head>
           <meta charSet="utf-8" />
           <meta httpEquiv="x-ua-compatible" content="ie=edge" />
-          <meta name="viewport" content="width=1024, initial-scale=1, shrink-to-fit=no" />
           <meta name="author" content="Vizzuality" />
-
           <link rel="icon" href="/static/favicon.ico" />
-
           <link
             rel="stylesheet"
             media="screen"


### PR DESCRIPTION
## Overview
Fixes an issue with meta tag values producing content overflow in mobile versions.

NextJS provides a default viewport meta (https://nextjs.org/blog/next-8-0-4#default-viewport-meta-tag) that satisfies our needs so we don't need to add it explicitly unless we need anything else.

## Testing instructions
Go to https://resourcewatch.org on mobile to see the issue, you should notice the content overflow at first sight.

Run this branch in your mobile, overflow should be gone and content fit in the viewport again. (I've tested on Safari and Firefox in iOS 12.2)


## Pivotal task
–

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
