### PR TITLE
Fixes issue setting map center in widget-block

### DIFF
--- a/components/wysiwyg/widget-block/styles.scss
+++ b/components/wysiwyg/widget-block/styles.scss
@@ -1,4 +1,6 @@
-.c-widget-block-card {
+@import 'css/settings';
+
+.c-widget-block {
   width: 100%;
   height: 100%;
   display: flex;

--- a/components/wysiwyg/widget-block/widget-block-component.js
+++ b/components/wysiwyg/widget-block/widget-block-component.js
@@ -56,17 +56,16 @@ class WidgetBlock extends PureComponent {
 
   state = { shareWidget: null }
 
-  getMapOptions(widget) {
-    const { widgetConfig } = widget;
-    if (!widgetConfig) return {};
+  getMapOptions(widget = {}) {
+    if (!widget.widgetConfig) return {};
+    const { widgetConfig: { lat, lng, zoom } } = widget;
 
-
-    if (widgetConfig.lat && widgetConfig.lng && widgetConfig.zoom) {
+    if (lat && lng && zoom) {
       return {
-        zoom: widgetConfig.zoom,
-        latLng: {
-          lat: widgetConfig.lat,
-          lng: widgetConfig.lng
+        zoom,
+        center: {
+          lat,
+          lng
         }
       };
     }
@@ -74,7 +73,7 @@ class WidgetBlock extends PureComponent {
     return {};
   }
 
-  getMapBounds(widget) {
+  getMapBounds(widget = {}) {
     const { widgetConfig } = widget;
     if (!widgetConfig) return {};
 
@@ -83,7 +82,7 @@ class WidgetBlock extends PureComponent {
     return {};
   }
 
-  getMapBasemap(widget) {
+  getMapBasemap(widget = {}) {
     const { widgetConfig } = widget;
     if (!widgetConfig) return {};
 
@@ -95,7 +94,7 @@ class WidgetBlock extends PureComponent {
     };
   }
 
-  getMapLabel(widget) {
+  getMapLabel(widget = {}) {
     const { widgetConfig } = widget;
     if (!widgetConfig) return {};
 

--- a/components/wysiwyg/widget-block/widget-block-component.js
+++ b/components/wysiwyg/widget-block/widget-block-component.js
@@ -36,6 +36,9 @@ import { belongsToACollection } from 'components/collections-panel/collections-p
 // utils
 import { logEvent } from 'utils/analytics';
 
+// styles
+import './styles.scss';
+
 const defaultTheme = getVegaTheme();
 
 class WidgetBlock extends PureComponent {
@@ -143,10 +146,7 @@ class WidgetBlock extends PureComponent {
     const widgetIsEmbed = widget && widget.widgetConfig && widget.widgetConfig.type === 'embed';
     const widgetEmbedUrl = widgetIsEmbed && widget.widgetConfig.url;
     const caption = metadataInfo && metadataInfo.caption;
-    const classNames = classnames({
-      'c-widget-block-card': true,
-      [`-${widgetType}`]: true
-    });
+    const componentClass = classnames('c-widget-block', { [`-${widgetType}`]: !!widgetType });
     const isInACollection = belongsToACollection(user, widget);
     const starIconName = classnames({
       'icon-star-full': isInACollection,
@@ -158,7 +158,7 @@ class WidgetBlock extends PureComponent {
     });
 
     return (
-      <div className={classNames}>
+      <div className={componentClass}>
         <header>
           <div className="header-container">
             <Title className="-default">{widget ? widget.name : '–'}</Title>

--- a/css/index.scss
+++ b/css/index.scss
@@ -246,7 +246,6 @@
 @import "./components/explore-detail/explore-detail-info";
 
 // DASHBOARDS
-@import './components/dashboards/dashboard-card';
 @import './components/dashboards/list';
 @import './components/dashboards/template-selector';
 


### PR DESCRIPTION
## Overview
Fixes an issue where the centre of the map in the `widgetBlock` component wasn't set properly.
Also, moved styles of the component to component level.

## Testing instructions
On production env, go to http://localhost:9000/data/dashboards/elise-test-mapathon
You will see this widget (with the wrong centre): 
![image](https://user-images.githubusercontent.com/999124/59208185-e092e280-8ba8-11e9-9e6d-5b16865426ca.png)


The expected result is: 
![image](https://user-images.githubusercontent.com/999124/59208104-bd683300-8ba8-11e9-88ee-b3d6e942d56c.png)

As a reference: http://localhost:9000/embed/map/b93140d4-eef9-47d6-8aab-51ae66772987 is applying properly to the centre of the map.



## Pivotal task
https://www.pivotaltracker.com/story/show/165538206

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
