### PR TITLE
Prevent blog feed from loading "UNCATEGORIZED" blog posts

### DIFF
--- a/components/blog/feed/component.js
+++ b/components/blog/feed/component.js
@@ -11,9 +11,7 @@ class BlogFeed extends PureComponent {
     latestPosts: PropTypes.array.isRequired,
     spotlightPosts: PropTypes.array.isRequired,
     latestPostsError: PropTypes.string,
-    spotlightPostsError: PropTypes.string,
-    getLatestPosts: PropTypes.func.isRequired,
-    getSpotlightPosts: PropTypes.func.isRequired
+    spotlightPostsError: PropTypes.string
   };
 
   static defaultProps = {

--- a/components/blog/feed/index.js
+++ b/components/blog/feed/index.js
@@ -1,15 +1,8 @@
 import { connect } from 'react-redux';
 
-// actions
-import { getLatestPosts, getSpotlightPosts } from 'modules/blog/actions';
-
 // component
 import BlogFeed from './component';
 
 export default connect(
-  state => ({ ...state.blog }),
-  {
-    getLatestPosts,
-    getSpotlightPosts
-  }
+  state => ({ ...state.blog }), null
 )(BlogFeed);

--- a/constants/blog.js
+++ b/constants/blog.js
@@ -1,5 +1,10 @@
 // number of featured posts
 export const SPOTLIGHT_CATEGORY = 15;
+/*
+ * The category "uncategorized" always has the id 1 by default when
+ * installling WordPress. More info about this can be found here:
+ * https://wordpress.stackexchange.com/questions/187955/how-to-view-wordpress-default-category-ids
+*/
 export const UNCATEGORIZED_CATEGORY = 1;
 
 export const ERROR_MESSAGE_FETCH_POSTS = 'Ops, something went wrong getting latest posts. Please, try later.';

--- a/constants/blog.js
+++ b/constants/blog.js
@@ -1,9 +1,11 @@
 // number of featured posts
 export const SPOTLIGHT_CATEGORY = 15;
+export const UNCATEGORIZED_CATEGORY = 1;
 
 export const ERROR_MESSAGE_FETCH_POSTS = 'Ops, something went wrong getting latest posts. Please, try later.';
 
 export default {
   SPOTLIGHT_CATEGORY,
+  UNCATEGORIZED_CATEGORY,
   ERROR_MESSAGE_FETCH_POSTS
 };

--- a/modules/blog/actions.js
+++ b/modules/blog/actions.js
@@ -7,7 +7,7 @@ import { fetchPosts } from 'services/blog';
 import { postParser } from 'utils/blog';
 
 // constants
-import { SPOTLIGHT_CATEGORY, ERROR_MESSAGE_FETCH_POSTS } from 'constants/blog';
+import { SPOTLIGHT_CATEGORY, ERROR_MESSAGE_FETCH_POSTS, UNCATEGORIZED_CATEGORY } from 'constants/blog';
 
 export const setLatestPosts = createAction('BLOG/SET_LATEST_POSTS');
 export const setLatestPostsError = createAction('BLOG/SET_LATEST_POSTS_ERROR');
@@ -20,7 +20,7 @@ export const getLatestPosts = createThunkAction('BLOG/GET_LATEST_POSTS', () => (
   return fetchPosts({
     _embed: true,
     per_page: 3,
-    categories_exclude: SPOTLIGHT_CATEGORY
+    categories_exclude: [SPOTLIGHT_CATEGORY, UNCATEGORIZED_CATEGORY]
   })
     .then((posts) => { dispatch(setLatestPosts(postParser(posts))); })
     .catch(() => { dispatch(setLatestPostsError(ERROR_MESSAGE_FETCH_POSTS)); });


### PR DESCRIPTION
## Overview
This PR updates the request performed to the WP API so that `UNCATEGORIZED` posts are not returned.

## Testing instructions
Go to http://localhost:9000/ and check the blog posts shown there in the `Latest stories` section. There should be no posts categorized as `UNCATEGORIZED`.

## [Pivotal task](https://www.pivotaltracker.com/story/show/164267722)
