### PR TITLE
MyRW fix: redundant "Explore datasets" button removed from Datasets section

### DIFF
--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
@@ -50,7 +50,7 @@ class DatasetsListCard extends PureComponent {
     const isOwnerOrAdmin = (dataset.userId === user.id || user.role === 'ADMIN');
     const isInACollection = belongsToACollection(user, dataset);
 
-    const classNames = classnames({'-owner': isOwnerOrAdmin});
+    const classNames = classnames({ '-owner': isOwnerOrAdmin });
 
     const starIconName = classnames({
       'icon-star-full': isInACollection,
@@ -99,7 +99,7 @@ class DatasetsListCard extends PureComponent {
                 />
               }
               overlayClassName="c-rc-tooltip"
-              overlayStyle={{color: '#fff'}}
+              overlayStyle={{ color: '#fff' }}
               placement="bottomLeft"
               trigger="click"
             >

--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-component.js
@@ -18,7 +18,10 @@ class DatasetsList extends PureComponent {
     },
     datasets: [],
     filters: [],
-    loading: true
+    loading: true,
+    user: {},
+    currentTab: '',
+    getDatasetsByTab: () => null
   };
 
   static propTypes = {
@@ -47,7 +50,7 @@ class DatasetsList extends PureComponent {
 
     toastr.confirm(
       `Are you sure you want to delete the dataset: ${
-      metadata && metadata.attributes.info ? metadata.attributes.info.name : dataset.name
+        metadata && metadata.attributes.info ? metadata.attributes.info.name : dataset.name
       }?`,
       {
         onOk: () => {
@@ -89,17 +92,13 @@ class DatasetsList extends PureComponent {
           )}
         </div>
 
-        {!datasets.length &&
-          !loading &&
-          !filters.length && (
-            <div className="no-data-div">There are no datasets added in this collection yet</div>
-          )}
+        {!datasets.length && !loading && !filters.length && (
+          <div className="no-data-div">There are no datasets added in this collection yet</div>
+        )}
 
         <div className="c-button-container -j-center c-field-buttons">
           <Link route="explore">
-            <a className="c-button -secondary">
-              {'Explore Datasets'}
-            </a>
+            <a className="c-button -secondary">Explore Datasets</a>
           </Link>
         </div>
       </div>

--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-component.js
@@ -16,23 +16,18 @@ class DatasetsList extends PureComponent {
       index: '',
       detail: ''
     },
-    datasets: [],
-    filters: [],
-    loading: true,
-    user: {},
-    currentTab: '',
-    getDatasetsByTab: () => null
+    currentTab: ''
   };
 
   static propTypes = {
     routes: PropTypes.object,
-    datasets: PropTypes.array,
-    filters: PropTypes.array,
-    loading: PropTypes.bool,
-    user: PropTypes.object,
+    datasets: PropTypes.array.isRequired,
+    filters: PropTypes.array.isRequired,
+    loading: PropTypes.bool.isRequired,
+    user: PropTypes.object.isRequired,
     locale: PropTypes.string.isRequired,
     currentTab: PropTypes.string,
-    getDatasetsByTab: PropTypes.func
+    getDatasetsByTab: PropTypes.func.isRequired
   };
 
   constructor(props) {

--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/index.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/index.js
@@ -10,16 +10,15 @@ import DatasetList from './dataset-list-component';
 
 class DatasetListContainer extends PureComponent {
   static propTypes = {
-    pathname: PropTypes.string,
-    tab: PropTypes.string,
-    subtab: PropTypes.string,
-    orderDirection: PropTypes.string,
-    pagination: PropTypes.object,
-    getDatasetsByTab: PropTypes.func,
-    setFilters: PropTypes.func,
-    setPaginationPage: PropTypes.func,
-    setPaginationTotal: PropTypes.func,
-    resetDatasets: PropTypes.func
+    pathname: PropTypes.string.isRequired,
+    tab: PropTypes.string.isRequired,
+    subtab: PropTypes.string.isRequired,
+    orderDirection: PropTypes.string.isRequired,
+    pagination: PropTypes.object.isRequired,
+    getDatasetsByTab: PropTypes.func.isRequired,
+    setPaginationPage: PropTypes.func.isRequired,
+    setPaginationTotal: PropTypes.func.isRequired,
+    resetDatasets: PropTypes.func.isRequired
   }
 
   componentWillMount() {

--- a/layout/myrw/component.js
+++ b/layout/myrw/component.js
@@ -64,7 +64,7 @@ class LayoutMyRW extends PureComponent {
                 {(currentTab === 'areas') && (<AreasTab tag={currentTab} subtab={currentTab} />)}
                 {(currentTab === 'widgets') && (<WidgetsTab tab={currentTab} subtab={subtab} />)}
                 {(currentTab === 'collections') && (<CollectionsTab tab={currentTab} subtab={subtab} />)}
-                {(currentTab !== 'profile' && 'datasets') && (tab !== 'widgets') && (
+                {(currentTab !== 'profile') && (currentTab !== 'datasets') && (tab !== 'widgets') && (
                   <div className="c-button-container -j-center explore c-field-buttons">
                     <ul className="c-field-buttons">
                       <li />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/59514744-c36a5680-8ebd-11e9-8e10-ff9161e030b4.png)

## Overview
This PR removes a redundant "Explore datasets" button appearing in the Myrw --> Datasets section

## Testing instructions
Go to `http://localhost:9000/myrw/datasets/my_datasets`

## [Pivotal task](https://www.pivotaltracker.com/story/show/166694334)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
