### PR TITLE
MyRW fix: show pagination tool only when there is more than one page

### DIFF
--- a/components/app/myrw/widgets/tabs/list/component.js
+++ b/components/app/myrw/widgets/tabs/list/component.js
@@ -145,7 +145,7 @@ class MyRWWidgets extends PureComponent {
                         showActions
                         showRemove
                       />
-                      {!!size && pages > 1 && (
+                      {(pages > 1) && (
                         <Paginator
                           options={{
                             size,

--- a/components/app/myrw/widgets/tabs/list/component.js
+++ b/components/app/myrw/widgets/tabs/list/component.js
@@ -51,7 +51,7 @@ class MyRWWidgets extends PureComponent {
       handleWidgetRemoved,
       handleRefresh
     } = this.props;
-    const { page, size, limit } = pagination;
+    const { page, size, limit, pages } = pagination;
     const sortIcon = classnames({
       'icon-arrow-up': sort === 'asc',
       'icon-arrow-down': sort !== 'asc'
@@ -145,7 +145,7 @@ class MyRWWidgets extends PureComponent {
                         showActions
                         showRemove
                       />
-                      {!!size && (
+                      {!!size && pages > 1 && (
                         <Paginator
                           options={{
                             size,

--- a/components/collections-list/index.js
+++ b/components/collections-list/index.js
@@ -34,7 +34,7 @@ class CollectionsList extends PureComponent {
     setUserCollectionsFilter: PropTypes.func.isRequired
   };
 
-  state = { pagination: INITIAL_PAGINATION }
+  state = { pagination: INITIAL_PAGINATION };
 
   componentWillReceiveProps(nextProps) {
     const { filteredCollections } = this.props;
@@ -54,7 +54,7 @@ class CollectionsList extends PureComponent {
 
   onSearch = (value) => {
     this.props.setUserCollectionsFilter(value);
-  }
+  };
 
   onChangePage = (page) => {
     const { pagination } = this.state;
@@ -65,7 +65,7 @@ class CollectionsList extends PureComponent {
         page
       }
     });
-  }
+  };
 
   render() {
     const { routes, collections, filteredCollections, user } = this.props;

--- a/components/ui/customtable/footer/TableFooter.js
+++ b/components/ui/customtable/footer/TableFooter.js
@@ -23,16 +23,18 @@ class TableFooter extends PureComponent {
 
   render() {
     const { pagination, showTotalPages } = this.props;
-    if (pagination.size > 0) {
+    const { size, pages, page, enabled } = pagination;
+
+    if (size > 0 && pages > 1) {
       return (
         <div className="table-footer">
           <Paginator
             options={pagination}
-            onChange={page => this.onChangePage(page)}
+            onChange={pageValue => this.onChangePage(pageValue)}
           />
 
-          {(pagination.enabled && showTotalPages && pagination.pages) &&
-            <div>Page <span>{pagination.page}</span> of <span>{pagination.pages}</span></div>
+          {(enabled && showTotalPages && pages) &&
+            <div>Page <span>{page}</span> of <span>{pages}</span></div>
           }
 
         </div>

--- a/components/ui/customtable/footer/TableFooter.js
+++ b/components/ui/customtable/footer/TableFooter.js
@@ -30,12 +30,11 @@ class TableFooter extends PureComponent {
         <div className="table-footer">
           <Paginator
             options={pagination}
-            onChange={pageValue => this.onChangePage(pageValue)}
+            onChange={(pageValue) => { this.onChangePage(pageValue); }}
           />
 
-          {(enabled && showTotalPages && pages) &&
-            <div>Page <span>{page}</span> of <span>{pages}</span></div>
-          }
+          {(enabled && showTotalPages) &&
+            (<div>Page <span>{page}</span> of <span>{pages}</span></div>)}
 
         </div>
       );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/59515982-a4b98f00-8ec0-11e9-8a9a-89125ec1cd83.png)

## Overview
This PR updates the MyRW section so that the pagination toolbar is only displayed when there two or more pages of data. The fix has been applied to the "Visualizations" and "Collections" tabs.

## Testing instructions
Go to `http://localhost:9000/myrw/widgets/my_widgets` and  `http://localhost:9000/myrw/collections` and make sure that you have less than two pages of results.

## [Pivotal task](https://www.pivotaltracker.com/story/show/166694746)
