### PR TITLE
Improvements for MyRWDatasets and DatasetList components

### DIFF
--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-component.js
@@ -4,7 +4,7 @@ import { toastr } from 'react-redux-toastr';
 import { Link } from 'routes';
 
 // Services
-import DatasetsService from 'services/DatasetsService';
+import { deleteDataset } from 'services/dataset';
 
 // Components
 import Spinner from 'components/ui/Spinner';
@@ -30,18 +30,9 @@ class DatasetsList extends PureComponent {
     getDatasetsByTab: PropTypes.func.isRequired
   };
 
-  constructor(props) {
-    super(props);
-
-    // service shouldn't be here.
-    this.service = new DatasetsService({
-      authorization: props.user.token,
-      language: props.locale
-    });
-  }
-
   handleDatasetDelete = (dataset) => {
     const metadata = dataset.metadata[0];
+    const { user, currentTab } = this.props;
 
     toastr.confirm(
       `Are you sure you want to delete the dataset: ${
@@ -49,11 +40,10 @@ class DatasetsList extends PureComponent {
       }?`,
       {
         onOk: () => {
-          this.service
-            .deleteData(dataset.id)
+          deleteDataset(dataset.id, user.token)
             .then(() => {
               toastr.success('Success', 'Dataset removed successfully');
-              this.props.getDatasetsByTab(this.props.currentTab);
+              this.props.getDatasetsByTab(currentTab);
             })
             .catch(err => toastr.error('Error deleting the dataset', err));
         }

--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-component.js
@@ -25,27 +25,26 @@ class DatasetsList extends PureComponent {
     filters: PropTypes.array.isRequired,
     loading: PropTypes.bool.isRequired,
     user: PropTypes.object.isRequired,
-    locale: PropTypes.string.isRequired,
     subtab: PropTypes.string,
     getDatasetsByTab: PropTypes.func.isRequired
   };
 
   handleDatasetDelete = (dataset) => {
     const metadata = dataset.metadata[0];
-    const { user, subtab } = this.props;
+    const { user, subtab, getDatasetsByTab } = this.props;
 
     toastr.confirm(
       `Are you sure you want to delete the dataset: ${
-        metadata && metadata.attributes.info ? metadata.attributes.info.name : dataset.name
+        metadata && metadata.info ? metadata.info.name : dataset.name
       }?`,
       {
         onOk: () => {
           deleteDataset(dataset.id, user.token)
             .then(() => {
               toastr.success('Success', 'Dataset removed successfully');
-              this.props.getDatasetsByTab(subtab);
+              getDatasetsByTab(subtab);
             })
-            .catch(err => toastr.error('Error deleting the dataset', err));
+            .catch(({ message }) => toastr.error('Error deleting the dataset', message));
         }
       }
     );
@@ -55,7 +54,7 @@ class DatasetsList extends PureComponent {
     const { datasets, routes, user, filters, loading } = this.props;
 
     return (
-      <div className="c-datasets-list">
+      <div className="c-myrw-datasets-list">
         {loading && <Spinner className="-light" isLoading={loading} />}
 
         <div className="l-row row list -equal-height">

--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-component.js
@@ -16,7 +16,7 @@ class DatasetsList extends PureComponent {
       index: '',
       detail: ''
     },
-    currentTab: ''
+    subtab: ''
   };
 
   static propTypes = {
@@ -26,13 +26,13 @@ class DatasetsList extends PureComponent {
     loading: PropTypes.bool.isRequired,
     user: PropTypes.object.isRequired,
     locale: PropTypes.string.isRequired,
-    currentTab: PropTypes.string,
+    subtab: PropTypes.string,
     getDatasetsByTab: PropTypes.func.isRequired
   };
 
   handleDatasetDelete = (dataset) => {
     const metadata = dataset.metadata[0];
-    const { user, currentTab } = this.props;
+    const { user, subtab } = this.props;
 
     toastr.confirm(
       `Are you sure you want to delete the dataset: ${
@@ -43,7 +43,7 @@ class DatasetsList extends PureComponent {
           deleteDataset(dataset.id, user.token)
             .then(() => {
               toastr.success('Success', 'Dataset removed successfully');
-              this.props.getDatasetsByTab(currentTab);
+              this.props.getDatasetsByTab(subtab);
             })
             .catch(err => toastr.error('Error deleting the dataset', err));
         }

--- a/components/app/myrw/datasets/pages/my-rw-datasets/my-rw-datasets-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/my-rw-datasets-component.js
@@ -92,7 +92,7 @@ class MyRWDatasets extends PureComponent {
                 detail: 'myrw_detail'
               }}
             />
-            {!!total && <Paginator
+            {!!total && total >= 2 && <Paginator
               options={{
                 size: total,
                 page,

--- a/redactions/admin/datasets.js
+++ b/redactions/admin/datasets.js
@@ -145,19 +145,21 @@ export const getAllDatasets = createThunkAction(
   options => (dispatch, getState) => {
     dispatch({ type: GET_DATASETS_LOADING });
     const { user } = getState();
-
     return fetchDatasets(
       { ...options.filters, includes: options.includes },
       {
         Authorization: user.token,
         'Upgrade-Insecure-Requests': 1
-      }
+      },
+      true
     )
-      .then(({ data, meta }) => {
+      .then((result) => {
+        const { datasets, meta } = result;
         const { 'total-items': totalItems } = meta;
+
         dispatch({
           type: GET_DATASETS_SUCCESS,
-          payload: data.map(d => ({ ...{ id: d.id, type: d.type }, ...d.attributes }))
+          payload: datasets
         });
         dispatch(setPaginationTotal(totalItems));
       })


### PR DESCRIPTION
## Overview
This PR includes the following fixes and improvements:

- The component uses now the right service `services/dataset` instead of the old approach to handle datasets fetching and deletion as part of the MyRW --> datasets section
- WRISerializer is used now to convert the results from the requests to the appropriate JSON format
- Pagination toolbar is only shown when there are two or more pages of data
- Fix for a bug that prevented successfully loading the user datasets after one dataset had been removed 

## Testing instructions
Go to `http://localhost:9000/myrw/datasets/my_datasets`

## [Pivotal task](https://www.pivotaltracker.com/story/show/166727155)

