### PR TITLE
Fix user collections not being loaded in Explore

### DIFF
--- a/constants/app.js
+++ b/constants/app.js
@@ -28,7 +28,8 @@ export const PAGES_WITHOUT_TOPICS = [
 
 export const PAGES_WITH_USER_COLLECTIONS = [
   '/myrw-detail/',
-  '/myrw/'
+  '/myrw/',
+  '/data/explore'
 ];
 
 export const CESIUM_ROUTES = [


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/59848408-5b0bf100-9365-11e9-9111-5f96bfab19ed.png)

## Overview
This PR fixes the issue that prevented user collections to appear in Explore in some cases.

## Testing instructions
Go to `http://localhost:9000/data/explore/` or any dataset detail page after logging in the app and verify that your user collections are being displayed in the collections tooltip.

## [Pivotal task](https://www.pivotaltracker.com/story/show/166673970)