### PR TITLE
Fix back office navigation on save

### DIFF
--- a/components/admin/data/layers/form/LayersForm.js
+++ b/components/admin/data/layers/form/LayersForm.js
@@ -105,26 +105,28 @@ class LayersForm extends React.Component {
   onSubmit(event) {
     if (event) event.preventDefault();
 
+    const { step, form } = this.state;
+
     // Validate the form
-    FORM_ELEMENTS.validate(this.state.step);
+    FORM_ELEMENTS.validate(step);
 
     // Set a timeout due to the setState function of react
     setTimeout(() => {
       // Validate all the inputs on the current step
-      const valid = FORM_ELEMENTS.isValid(this.state.step);
+      const valid = FORM_ELEMENTS.isValid(step);
       const { interactions } = this.props;
 
-      let interactionConfig = this.state.form.interactionConfig;
+      let interactionConfig = form.interactionConfig;
       // Grab all the interactions from the redux store
-      if (this.state.form.provider === 'cartodb') {
+      if (form.provider === 'cartodb') {
         interactionConfig = Object.assign(
           {},
-          this.state.form.interactionConfig,
+          form.interactionConfig,
           { output: interactions.added }
         );
       }
 
-      const form = Object.assign({}, this.state.form, { interactionConfig });
+      const newForm = Object.assign({}, form, { interactionConfig });
 
       // Verify that layers are valid, otherwise render error
       const { adminLayerPreview } = this.props;
@@ -142,10 +144,10 @@ class LayersForm extends React.Component {
           this.layerManager.verifyCartoLayer(Object.assign(
             {},
             cartoLayer[0],
-            { layerConfig: form.layerConfig }
+            { layerConfig: newForm.layerConfig }
           ), (cartoLayerValid) => {
             if (cartoLayerValid) {
-              this.saveLayer(form);
+              this.saveLayer(newForm);
             } else {
               toastr.error('Error', 'Layer config contains errors');
               this.setState({ submitting: false });
@@ -154,7 +156,7 @@ class LayersForm extends React.Component {
           return;
         }
 
-        this.saveLayer(form);
+        this.saveLayer(newForm);
       } else {
         toastr.error('Error', 'Fill all the required fields or correct the invalid values');
       }
@@ -246,6 +248,7 @@ class LayersForm extends React.Component {
 
   saveLayer(form) {
     const { id, dataset } = this.state;
+    const { onSubmit } = this.props;
     this.layerService.saveData({
       dataset,
       id: id || '',
@@ -253,7 +256,7 @@ class LayersForm extends React.Component {
       body: form
     }).then((data) => {
       toastr.success('Success', `The layer "${data.id}" - "${data.name}" has been uploaded correctly`);
-      if (this.props.onSubmit) this.props.onSubmit();
+      if (onSubmit) onSubmit(data.id);
       this.setState({ submitting: false, form: data });
     }).catch((errors) => {
       this.setState({ submitting: false });

--- a/components/admin/data/layers/pages/new/component.js
+++ b/components/admin/data/layers/pages/new/component.js
@@ -13,13 +13,8 @@ class LayersNew extends PureComponent {
 
   static defaultProps = { dataset: null }
 
-  handleSubmit = () => {
-    const { dataset } = this.props;
-    if (dataset) {
-      Router.pushRoute('admin_data_detail', { tab: 'datasets', subtab: 'layers', id: dataset });
-    } else {
-      Router.pushRoute('admin_data', { tab: 'layers' });
-    }
+  handleSubmit = (layerID) => {
+    Router.pushRoute('admin_data_detail', { tab: 'layers', id: layerID });
   }
 
   render() {

--- a/components/admin/data/layers/pages/new/component.js
+++ b/components/admin/data/layers/pages/new/component.js
@@ -14,7 +14,11 @@ class LayersNew extends PureComponent {
   static defaultProps = { dataset: null }
 
   handleSubmit = (layerID) => {
-    Router.pushRoute('admin_data_detail', { tab: 'layers', id: layerID });
+    if (layerID) {
+      Router.pushRoute('admin_data_detail', { tab: 'layers', id: layerID, subtab: 'edit' });
+    } else {
+      Router.pushRoute('admin_data', { tab: 'layers' });
+    }
   }
 
   render() {

--- a/components/admin/data/widgets/form/component.js
+++ b/components/admin/data/widgets/form/component.js
@@ -19,7 +19,6 @@ import { getDataURL, getChartInfo } from 'utils/widgets/WidgetHelper';
 // constants
 import { STATE_DEFAULT, FORM_ELEMENTS } from './constants';
 
-
 class WidgetForm extends PureComponent {
   static propTypes = {
     authorization: PropTypes.string.isRequired,
@@ -79,13 +78,14 @@ class WidgetForm extends PureComponent {
         const current = response[1];
 
         // Set advanced mode if paramsConfig doesn't exist or if it's empty
-        const mode = (
+        const mode =
           current &&
           (!current.widgetConfig.paramsConfig || isEmpty(current.widgetConfig.paramsConfig))
-        ) ? 'advanced' : 'editor';
+            ? 'advanced'
+            : 'editor';
         this.setState({
           // CURRENT DASHBOARD
-          form: (id) ? this.setFormFromParams(current) : this.state.form,
+          form: id ? this.setFormFromParams(current) : this.state.form,
           loading: false,
           mode,
           // OPTIONS
@@ -99,7 +99,9 @@ class WidgetForm extends PureComponent {
         });
       })
       .catch((err) => {
-        this.setState({ loading: false }, () => { toastr.error('Something went wrong', err.message); });
+        this.setState({ loading: false }, () => {
+          toastr.error('Something went wrong', err.message);
+        });
       });
   }
 
@@ -108,7 +110,7 @@ class WidgetForm extends PureComponent {
    * - onSubmit
    * - onChange
    * - handleModeChange
-  */
+   */
   onSubmit(event) {
     const { submitting, stepLength, step, form, mode } = this.state;
     const { widgetEditor } = this.props;
@@ -119,9 +121,9 @@ class WidgetForm extends PureComponent {
 
     // Set a timeout due to the setState function of react
     setTimeout(async () => {
-      const widgetConfig = (this.onGetWidgetConfig) ? await this.getWidgetConfig() : {};
+      const widgetConfig = this.onGetWidgetConfig ? await this.getWidgetConfig() : {};
       // Validate all the inputs on the current step
-      const validWidgetConfig = (mode === 'editor') ? this.validateWidgetConfig() : true;
+      const validWidgetConfig = mode === 'editor' ? this.validateWidgetConfig() : true;
       const valid = FORM_ELEMENTS.isValid(step) && validWidgetConfig;
       if (valid) {
         // if we are in the last step we will submit the form
@@ -130,12 +132,12 @@ class WidgetForm extends PureComponent {
 
           // Start the submission
           this.setState({ submitting: true });
-          const formObj = (mode === 'editor') ? { ...form, widgetConfig } : form;
+          const formObj = mode === 'editor' ? { ...form, widgetConfig } : form;
 
           const obj = {
             dataset: form.dataset,
             id: id || '',
-            type: (id) ? 'PATCH' : 'POST',
+            type: id ? 'PATCH' : 'POST',
             body: formObj
           };
 
@@ -146,20 +148,16 @@ class WidgetForm extends PureComponent {
           // The widget has to be "frozen" first
           if (formObj.freeze) {
             const datasetObj = this.state.datasets.find(d => d.value === form.dataset);
-            const tempBand = formObj.widgetConfig.paramsConfig ?
-              formObj.widgetConfig.paramsConfig.band : null;
+            const tempBand = formObj.widgetConfig.paramsConfig
+              ? formObj.widgetConfig.paramsConfig.band
+              : null;
             getDataURL(
               datasetObj.value,
               datasetObj.type,
               datasetObj.tableName,
               tempBand,
               datasetObj.provider,
-              getChartInfo(
-                datasetObj.value,
-                datasetObj.type,
-                datasetObj.provider,
-                widgetEditor
-              ),
+              getChartInfo(datasetObj.value, datasetObj.type, datasetObj.provider, widgetEditor),
               false,
               datasetObj.slug
             ).then((dataURL) => {
@@ -213,8 +211,11 @@ class WidgetForm extends PureComponent {
     Object.keys(params).forEach((f) => {
       switch (f) {
         default: {
-          if ((typeof params[f] !== 'undefined' || params[f] !== null) ||
-              (typeof this.state.form[f] !== 'undefined' || this.state.form[f] !== null)) {
+          if (
+            typeof params[f] !== 'undefined' ||
+            params[f] !== null ||
+            (typeof this.state.form[f] !== 'undefined' || this.state.form[f] !== null)
+          ) {
             newForm[f] = params[f] || this.state.form[f];
           }
         }
@@ -233,11 +234,12 @@ class WidgetForm extends PureComponent {
   saveWidget(obj) {
     const { onSubmit } = this.props;
     // Save data
-    this.service.saveData(obj)
+    this.service
+      .saveData(obj)
       .then((widget) => {
         const { id, name } = widget;
         toastr.success('Success', `The widget "${id}" - "${name}" has been uploaded correctly`);
-
+        this.setState({ submitting: false });
         if (onSubmit) onSubmit(widget);
       })
       .catch((errors) => {
@@ -273,9 +275,15 @@ class WidgetForm extends PureComponent {
 
     switch (visualizationType) {
       case 'chart':
-        return toastr.error('Error', 'Value, Category and Chart type are mandatory fields for a widget visualization.');
+        return toastr.error(
+          'Error',
+          'Value, Category and Chart type are mandatory fields for a widget visualization.'
+        );
       case 'table':
-        return toastr.error('Error', 'Value, Category and Chart type are mandatory fields for a widget visualization.');
+        return toastr.error(
+          'Error',
+          'Value, Category and Chart type are mandatory fields for a widget visualization.'
+        );
       case 'map':
         return toastr.error('Error', 'Layer is mandatory field for a widget visualization.');
       case 'embed':
@@ -288,9 +296,10 @@ class WidgetForm extends PureComponent {
   handleModeChange(value) {
     // We have to set the defaultEditableWidget to false if the mode has been changed
     // to 'advanced'
-    const newForm = (value === 'advanced') ?
-      Object.assign({}, this.state.form, { defaultEditableWidget: false })
-      : this.state.form;
+    const newForm =
+      value === 'advanced'
+        ? Object.assign({}, this.state.form, { defaultEditableWidget: false })
+        : this.state.form;
 
     this.setState({
       form: newForm,
@@ -299,36 +308,48 @@ class WidgetForm extends PureComponent {
   }
 
   render() {
+    const {
+      submitting,
+      stepLength,
+      step,
+      loading,
+      id,
+      form,
+      partners,
+      datasets,
+      mode
+    } = this.state;
     return (
       <form className="c-form c-widgets-form" onSubmit={this.onSubmit} noValidate>
-        <Spinner isLoading={this.state.loading} className="-light" />
+        <Spinner isLoading={loading} className="-light" />
 
-        {(this.state.step === 1 && !this.state.loading) &&
+        {step === 1 && !loading && (
           <Step1
-            id={this.state.id}
-            form={this.state.form}
-            partners={this.state.partners}
-            datasets={this.state.datasets}
-            mode={this.state.mode}
+            id={id}
+            form={form}
+            partners={partners}
+            datasets={datasets}
+            mode={mode}
             onChange={value => this.onChange(value)}
             onModeChange={this.handleModeChange}
             showEditor={this.props.showEditor}
-            onGetWidgetConfig={(func) => { this.onGetWidgetConfig = func; }}
+            onGetWidgetConfig={(func) => {
+              this.onGetWidgetConfig = func;
+            }}
           />
-        }
+        )}
 
-        {!this.state.loading &&
+        {!loading && (
           <Navigation
-            step={this.state.step}
-            stepLength={this.state.stepLength}
-            submitting={this.state.submitting}
+            step={step}
+            stepLength={stepLength}
+            submitting={submitting}
             onStepChange={this.onStepChange}
           />
-        }
+        )}
       </form>
     );
   }
 }
-
 
 export default WidgetForm;

--- a/components/admin/data/widgets/pages/new/component.js
+++ b/components/admin/data/widgets/pages/new/component.js
@@ -11,9 +11,9 @@ class WidgetsNew extends PureComponent {
   handleSubmit = (widget) => {
     if (widget) {
       Router.pushRoute('admin_data_detail', {
-        tab: 'datasets',
-        subtab: 'widgets',
-        id: widget.dataset
+        tab: 'widgets',
+        subtab: 'edit',
+        id: widget.id
       });
     } else {
       Router.pushRoute('admin_data', { tab: 'widgets' });

--- a/components/admin/data/widgets/pages/show/component.js
+++ b/components/admin/data/widgets/pages/show/component.js
@@ -18,9 +18,9 @@ class WidgetsShow extends PureComponent {
   handleSubmit = (widget) => {
     if (widget) {
       Router.pushRoute('admin_data_detail', {
-        tab: 'datasets',
-        subtab: 'widgets',
-        id: widget.dataset
+        tab: 'widgets',
+        id: widget.id,
+        subtab: 'edit'
       });
     } else {
       Router.pushRoute('admin_data', { tab: 'widgets' });

--- a/components/admin/data/widgets/pages/show/component.js
+++ b/components/admin/data/widgets/pages/show/component.js
@@ -15,17 +15,7 @@ class WidgetsShow extends PureComponent {
     user: PropTypes.object.isRequired
   }
 
-  handleSubmit = (widget) => {
-    if (widget) {
-      Router.pushRoute('admin_data_detail', {
-        tab: 'widgets',
-        id: widget.id,
-        subtab: 'edit'
-      });
-    } else {
-      Router.pushRoute('admin_data', { tab: 'widgets' });
-    }
-  }
+  handleSubmit = () => { window.scrollTo(0, 0); }
 
   render() {
     const {


### PR DESCRIPTION
## Overview
This PR fixes the navigation behavior when clicking “save” button after creating/editing both layers and widgets. Now the app stays on same page rather than navigating back to the list of layers or widgets.

## Testing instructions
Go to `http://localhost:9000/admin/data/layers/` and `http://localhost:9000/admin/data/widgets/` and create + edit layers and widgets.

## [Pivotal task](https://www.pivotaltracker.com/story/show/166845219)