### PR TITLE
Fix issue when clicking on Remove layer in the back office

### DIFF
--- a/components/admin/data/layers/table/actions/delete/component.js
+++ b/components/admin/data/layers/table/actions/delete/component.js
@@ -12,7 +12,7 @@ class DeleteAction extends PureComponent {
     onRowDelete: PropTypes.func.isRequired
   };
 
-  static defaultProps = { data: {} };
+  static defaultProps = { data: {} }
 
   handleOnClickDelete = () => {
     const {
@@ -31,20 +31,22 @@ class DeleteAction extends PureComponent {
           .catch((err) => {
             toastr.error(
               'Error',
-              `The layer "${id}" - "${name}" was not deleted. Try again. ${err}`
+              `The layer "${id}" - "${name}" was not deleted. Try again. ${err.message}`
             );
           });
       }
     });
-  };
+  }
 
   render() {
     return (
-      <span>
-        <button className="c-btn" onClick={this.handleOnClickDelete}>
-          Remove
-        </button>
-      </span>
+      <button
+        type="button"
+        className="c-btn"
+        onClick={this.handleOnClickDelete}
+      >
+        Remove
+      </button>
     );
   }
 }

--- a/components/admin/data/layers/table/actions/delete/component.js
+++ b/components/admin/data/layers/table/actions/delete/component.js
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'routes';
 import { toastr } from 'react-redux-toastr';
 
 // services
@@ -13,7 +12,7 @@ class DeleteAction extends PureComponent {
     onRowDelete: PropTypes.func.isRequired
   };
 
-  static defaultProps = { data: {} }
+  static defaultProps = { data: {} };
 
   handleOnClickDelete = () => {
     const {
@@ -29,31 +28,22 @@ class DeleteAction extends PureComponent {
             onRowDelete(id);
             toastr.success('Success', `The layer "${id}" - "${name}" has been removed correctly`);
           })
-          .catch((err) => { toastr.error('Error', `The layer "${id}" - "${name}" was not deleted. Try again. ${err}`); });
+          .catch((err) => {
+            toastr.error(
+              'Error',
+              `The layer "${id}" - "${name}" was not deleted. Try again. ${err}`
+            );
+          });
       }
     });
-  }
+  };
 
   render() {
-    const { data: { id } } = this.props;
-
     return (
       <span>
-        <Link
-          route="admin_data_detail"
-          params={{
-            tab: 'layers',
-            id,
-            subtab: 'remove'
-          }}
-        >
-          <button
-            className="c-btn"
-            onClick={this.handleOnClickDelete}
-          >
-            Remove
-          </button>
-        </Link>
+        <button className="c-btn" onClick={this.handleOnClickDelete}>
+          Remove
+        </button>
       </span>
     );
   }


### PR DESCRIPTION
## Overview
This PR fixes the current erroneous behavior that happens when clicking on any layer row "Remove" link.

## Testing instructions
Go to `http://localhost:9000/admin/data/layers` and click on the "Remove" link. It shouldn't redirect you to the layer detail page now.

## [Pivotal task](https://www.pivotaltracker.com/story/show/166873360)