### PR TITLE
Re-enable the pre-populating of the dataset name when creating widget and layers

### DIFF
--- a/components/admin/data/layers/form/steps/Step1.js
+++ b/components/admin/data/layers/form/steps/Step1.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -19,7 +19,24 @@ import Code from 'components/form/Code';
 import InteractionsComponent from '../interactions/interactions-component';
 import LayerPreviewComponent from '../layer-preview';
 
-class Step1 extends React.Component {
+class Step1 extends PureComponent {
+  static propTypes = {
+    id: PropTypes.string,
+    user: PropTypes.object.isRequired,
+    form: PropTypes.object.isRequired,
+    layerPreview: PropTypes.object.isRequired,
+    datasets: PropTypes.array,
+    onChange: PropTypes.func.isRequired,
+    onChangeDataset: PropTypes.func.isRequired,
+    verifyLayerConfig: PropTypes.func.isRequired,
+    query: PropTypes.object.isRequired
+  }
+
+  static defaultProps = {
+    id: null,
+    datasets: []
+  }
+
   constructor(props) {
     super(props);
 
@@ -237,28 +254,10 @@ class Step1 extends React.Component {
         >
           {Checkbox}
         </Field>
-
-
       </fieldset>
     );
   }
 }
-
-Step1.defaultPropTypes = {
-  datasets: []
-};
-
-Step1.propTypes = {
-  id: PropTypes.string,
-  user: PropTypes.object,
-  datasets: PropTypes.array,
-  form: PropTypes.object,
-  layerPreview: PropTypes.object,
-  onChange: PropTypes.func,
-  onChangeDataset: PropTypes.func,
-  verifyLayerConfig: PropTypes.func,
-  query: PropTypes.object.isRequired
-};
 
 const mapStateToProps = state => ({
   user: state.user,

--- a/components/admin/data/layers/form/steps/Step1.js
+++ b/components/admin/data/layers/form/steps/Step1.js
@@ -53,7 +53,8 @@ class Step1 extends React.Component {
     const {
       user,
       layerPreview,
-      verifyLayerConfig
+      verifyLayerConfig,
+      query
     } = this.props;
 
     const { form, id } = this.state;
@@ -71,7 +72,8 @@ class Step1 extends React.Component {
               label: 'Dataset',
               type: 'text',
               required: true,
-              default: form.dataset
+              default: form.dataset || query.dataset,
+              value: form.dataset || query.dataset
             }}
           >
             {Select}
@@ -254,9 +256,13 @@ Step1.propTypes = {
   layerPreview: PropTypes.object,
   onChange: PropTypes.func,
   onChangeDataset: PropTypes.func,
-  verifyLayerConfig: PropTypes.func
+  verifyLayerConfig: PropTypes.func,
+  query: PropTypes.object.isRequired
 };
 
-const mapStateToProps = state => ({ user: state.user });
+const mapStateToProps = state => ({
+  user: state.user,
+  query: state.routes.query
+});
 
 export default connect(mapStateToProps, null)(Step1);

--- a/components/admin/data/layers/pages/new/component.js
+++ b/components/admin/data/layers/pages/new/component.js
@@ -27,6 +27,7 @@ class LayersNew extends PureComponent {
       user: { token },
       dataset
     } = this.props;
+
     return (
       <div className="c-layers-new">
         <LayersForm

--- a/components/admin/data/layers/pages/new/index.js
+++ b/components/admin/data/layers/pages/new/index.js
@@ -6,7 +6,7 @@ import LayersNew from './component';
 export default connect(
   state => ({
     user: state.user,
-    dataset: state.routes.query.id
+    dataset: state.routes.query.dataset
   }),
   null
 )(LayersNew);

--- a/components/admin/data/layers/table/component.js
+++ b/components/admin/data/layers/table/component.js
@@ -207,6 +207,7 @@ class LayersTable extends PureComponent {
       layers,
       error
     } = this.state;
+    const { dataset } = this.props;
 
     return (
       <div className="c-layer-table">
@@ -226,7 +227,8 @@ class LayersTable extends PureComponent {
             route: 'admin_data_detail',
             params: {
               tab: 'layers',
-              id: 'new'
+              id: 'new',
+              dataset
             }
           }}
           onSearch={this.onSearch}

--- a/components/admin/data/widgets/form/steps/Step1.js
+++ b/components/admin/data/widgets/form/steps/Step1.js
@@ -34,7 +34,8 @@ class Step1 extends Component {
     onChange: PropTypes.func,
     onModeChange: PropTypes.func,
     showEditor: PropTypes.bool,
-    onGetWidgetConfig: PropTypes.func
+    onGetWidgetConfig: PropTypes.func,
+    query: PropTypes.object.isRequired
   };
 
   static defaultProps = { showEditor: true }
@@ -45,7 +46,7 @@ class Step1 extends Component {
     this.state = {
       id: props.id,
       form: props.form,
-      loadingVegaChart: false,
+      loadingVegaChart: false
     };
 
     // ------------------- BINDINGS ---------------------------
@@ -94,7 +95,7 @@ class Step1 extends Component {
 
   render() {
     const { id, loadingVegaChart } = this.state;
-    const { user, showEditor } = this.props;
+    const { user, showEditor, query } = this.props;
 
     // Reset FORM_ELEMENTS
     FORM_ELEMENTS.elements = {};
@@ -118,8 +119,8 @@ class Step1 extends Component {
             properties={{
               name: 'dataset',
               label: 'Dataset',
-              default: this.state.form.dataset,
-              value: this.state.form.dataset,
+              default: query.dataset,
+              value: this.state.form.dataset || query.dataset,
               disabled: !!id,
               required: true,
               instanceId: 'selectDataset'
@@ -359,6 +360,9 @@ class Step1 extends Component {
   }
 }
 
-const mapStateToProps = state => ({ user: state.user });
+const mapStateToProps = state => ({
+  user: state.user,
+  query: state.routes.query
+});
 
 export default connect(mapStateToProps, null)(Step1);

--- a/components/admin/data/widgets/table/component.js
+++ b/components/admin/data/widgets/table/component.js
@@ -206,6 +206,7 @@ class WidgetsTable extends PureComponent {
       widgets,
       error
     } = this.state;
+    const { dataset } = this.props;
 
     return (
       <div className="c-widgets-table">
@@ -222,7 +223,8 @@ class WidgetsTable extends PureComponent {
             route: 'admin_data_detail',
             params: {
               tab: 'widgets',
-              id: 'new'
+              id: 'new',
+              dataset
             }
           }}
           onSearch={this.onSearch}


### PR DESCRIPTION
## Overview
This PR selects by default the corresponding dataset in the dropdown selector both in the new widget and new layer forms.

## Testing instructions
Go to any dataset page from the back office and click on "New widget" and "New layer" in the respective "widgets" and "layers" tabs.

## [Pivotal task](https://www.pivotaltracker.com/story/show/166845169)