### PR TITLE
Back office fix: clicking on widgets/layers breadcrumbs leads to the corresponding dataset page

### DIFF
--- a/components/admin/data/layers/table/component.js
+++ b/components/admin/data/layers/table/component.js
@@ -209,9 +209,6 @@ class LayersTable extends PureComponent {
     } = this.state;
 
     const { dataset } = this.props;
-    console.log('dataset', dataset
-    );
-
 
     return (
       <div className="c-layer-table">

--- a/components/admin/data/layers/table/component.js
+++ b/components/admin/data/layers/table/component.js
@@ -208,6 +208,11 @@ class LayersTable extends PureComponent {
       error
     } = this.state;
 
+    const { dataset } = this.props;
+    console.log('dataset', dataset
+    );
+
+
     return (
       <div className="c-layer-table">
         <Spinner
@@ -243,7 +248,7 @@ class LayersTable extends PureComponent {
             actions={{
               show: true,
               list: [
-                { name: 'Edit', route: 'admin_data_detail', params: { tab: 'layers', subtab: 'edit', id: '{{id}}' }, show: true, component: EditAction },
+                { name: 'Edit', route: 'admin_data_detail', params: { tab: 'layers', subtab: 'edit', id: '{{id}}', dataset }, show: true, component: EditAction },
                 { name: 'Remove', route: 'admin_data_detail', params: { tab: 'layers', subtab: 'remove', id: '{{id}}' }, component: DeleteAction },
                 { name: 'Go to dataset', route: 'admin_data_detail', params: { tab: 'datasets', subtab: 'edit', id: '{{id}}' }, component: GoToDatasetAction }
               ]

--- a/components/admin/data/layers/table/td/name/component.js
+++ b/components/admin/data/layers/table/td/name/component.js
@@ -10,7 +10,7 @@ class NameTD extends PureComponent {
 
   render() {
     const {
-      row: { id },
+      row: { id, dataset },
       value
     } = this.props;
 
@@ -21,7 +21,8 @@ class NameTD extends PureComponent {
           params={{
             tab: 'layers',
             subtab: 'edit',
-            id
+            id,
+            dataset
           }}
         >
           <a>{value}</a>

--- a/components/admin/data/widgets/table/component.js
+++ b/components/admin/data/widgets/table/component.js
@@ -207,6 +207,8 @@ class WidgetsTable extends PureComponent {
       error
     } = this.state;
 
+    const { dataset } = this.props;
+
     return (
       <div className="c-widgets-table">
         <Spinner className="-light" isLoading={loading} />
@@ -238,7 +240,7 @@ class WidgetsTable extends PureComponent {
             actions={{
               show: true,
               list: [
-                { name: 'Edit', route: 'admin_data_detail', params: { tab: 'widgets', subtab: 'edit', id: '{{id}}' }, show: true, component: EditAction },
+                { name: 'Edit', route: 'admin_data_detail', params: { tab: 'widgets', subtab: 'edit', id: '{{id}}', dataset }, show: true, component: EditAction },
                 { name: 'Remove', route: 'admin_data_detail', params: { tab: 'widgets', subtab: 'remove', id: '{{id}}' }, component: DeleteAction }
               ]
             }}

--- a/components/admin/data/widgets/table/td/title/component.js
+++ b/components/admin/data/widgets/table/td/title/component.js
@@ -10,7 +10,7 @@ class TitleTD extends PureComponent {
 
   render() {
     const {
-      row: { id },
+      row: { id, dataset },
       value
     } = this.props;
 
@@ -21,7 +21,8 @@ class TitleTD extends PureComponent {
           params={{
             tab: 'widgets',
             subtab: 'edit',
-            id
+            id,
+            dataset
           }}
         >
           <a>{value}</a>


### PR DESCRIPTION
## Overview
This PR fixes the breadcrumbs behavior in the Dataset widgets and layers sections so that they lead to the corresponding dataset page instead of the general table including all datasets.

## Testing instructions
Go to any widget/layer page in the back office and click on the "Widgets"/"Layers" breadcrumb.

## [Pivotal task](https://www.pivotaltracker.com/story/show/166845191)

