### PR TITLE
Fix "Suggest a story" link from button in homepage banner

### DIFF
--- a/layout/app/home/component.js
+++ b/layout/app/home/component.js
@@ -187,7 +187,7 @@ class LayoutHome extends PureComponent {
 
               <Link
                 route="get_involved_detail"
-                params={{ id: 'submit-an-insight', source: 'home' }}
+                params={{ id: 'suggest-a-story', source: 'home' }}
               >
                 <a className="c-btn -b -alt">Suggest a story</a>
               </Link>


### PR DESCRIPTION
## Overview
This PR fixes the link from the "Suggest a story" button in the homepage get involved banner.

## Testing instructions
Go to `localhost:9000` and click on the "Suggest a story" button from the Get Involved banner

## [Pivotal task](https://www.pivotaltracker.com/story/show/166975033)