### PR TITLE
Fix for favorite widgets not loading in MyRW

### DIFF
--- a/components/app/myrw/widgets/tabs/list/helpers.js
+++ b/components/app/myrw/widgets/tabs/list/helpers.js
@@ -4,10 +4,7 @@ export const getQueryParams = (state = {}, props) => {
     pagination,
     search
   } = state;
-  const {
-    user: { id },
-    subtab
-  } = props;
+  const { subtab } = props;
   const { page, limit } = pagination;
   const isCollection = !['my_widgets', 'favourites'].includes(subtab);
 
@@ -15,7 +12,6 @@ export const getQueryParams = (state = {}, props) => {
     'page[size]': limit,
     'page[number]': page,
     sort: sort === 'asc' ? 'updatedAt' : '-updatedAt',
-    userId: id,
     ...search && search.length && { name: search },
     ...subtab === 'favourites' && { favourite: true },
     ...isCollection && { collection: subtab }

--- a/components/app/myrw/widgets/tabs/list/helpers.js
+++ b/components/app/myrw/widgets/tabs/list/helpers.js
@@ -4,7 +4,10 @@ export const getQueryParams = (state = {}, props) => {
     pagination,
     search
   } = state;
-  const { subtab } = props;
+  const {
+    user: { id },
+    subtab
+  } = props;
   const { page, limit } = pagination;
   const isCollection = !['my_widgets', 'favourites'].includes(subtab);
 
@@ -14,6 +17,7 @@ export const getQueryParams = (state = {}, props) => {
     sort: sort === 'asc' ? 'updatedAt' : '-updatedAt',
     ...search && search.length && { name: search },
     ...subtab === 'favourites' && { favourite: true },
+    ...(subtab !== 'favourites' && !isCollection) && { userId: id },
     ...isCollection && { collection: subtab }
   });
 };


### PR DESCRIPTION
## Overview
This PR fixes the bug in MyRW that was preventing favorite widgets to be displayed in the favorites section.

## Testing instructions
Go to `http://localhost:9000/myrw/widgets/favourites` and verify that your favorite widgets are loaded and displayed accordingly.

## [Pivotal task](https://www.pivotaltracker.com/story/show/166697167)