### PR TITLE
Leaflet styles updated to 1.3.4

### DIFF
--- a/layout/head/admin.js
+++ b/layout/head/admin.js
@@ -30,8 +30,8 @@ export default class HeadAdmin extends React.Component {
         {/* Leaflet styles are here to allow our chunk css (custom styles) override them */}
         <link
           rel="stylesheet"
-          href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"
-          integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ=="
+          href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css"
+          integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
           crossOrigin=""
         />
         <link

--- a/layout/head/app/component.js
+++ b/layout/head/app/component.js
@@ -100,8 +100,8 @@ class HeadApp extends PureComponent {
         {/* Leaflet styles are here to allow our chunk css (custom styles) override them */}
         <link
           rel="stylesheet"
-          href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"
-          integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ=="
+          href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css"
+          integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
           crossOrigin=""
         />
         <link


### PR DESCRIPTION
## Overview
This PR updates the version of Leaflet CSS used and fixes an issue consisting of the grab pointer not appearing on maps when using Firefox.

## Testing instructions
Go for instance here http://localhost:9000/data/explore?zoom=3&lat=31.57853542647338&lng=13.0078125&basemap=dark&labels=light&layers=%255B%257B%2522dataset%2522%253A%2522815eaa09-d626-495e-91e2-523cb07de475%2522%252C%2522opacity%2522%253A1%252C%2522layer%2522%253A%2522a0cf3282-976c-455c-9352-3cc559dc76c0%2522%257D%255D&page=1&sort=most-viewed&sortDirection=-1 and check that the grab pointer is appearing when using Firefox.

## [Pivotal task](https://www.pivotaltracker.com/story/show/167044228)