### PR TITLE
Share by email functionality added to all share modals

### DIFF
--- a/components/modal/share-modal/share-modal-component.js
+++ b/components/modal/share-modal/share-modal-component.js
@@ -21,6 +21,7 @@ class ShareModalComponent extends PureComponent {
     analytics: PropTypes.shape({
       facebook: PropTypes.func.isRequired,
       twitter: PropTypes.func.isRequired,
+      email: PropTypes.func.isRequired,
       copy: PropTypes.func.isRequired
     }),
 
@@ -35,6 +36,7 @@ class ShareModalComponent extends PureComponent {
     analytics: {
       facebook: () => {},
       twitter: () => {},
+      email: () => {},
       copy: () => {}
     }
   };
@@ -124,6 +126,16 @@ class ShareModalComponent extends PureComponent {
                       />
 
                       <div className="share-buttons">
+                        <a
+                          className="c-btn -secondary -compressed -square"
+                          href={`mailto:?body=I+would+like+to+share+this+link+with+you+${url}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={() => this.props.analytics.email(type)}
+                        >
+                          <Icon name="icon-share-email" className="-small" />
+                        </a>
+
                         <a
                           className="c-btn -secondary -compressed -square"
                           href={`http://www.facebook.com/sharer/sharer.php?u=${url}`}

--- a/components/modal/share-modal/share-modal-component.js
+++ b/components/modal/share-modal/share-modal-component.js
@@ -129,8 +129,6 @@ class ShareModalComponent extends PureComponent {
                         <a
                           className="c-btn -secondary -compressed -square"
                           href={`mailto:?body=I+would+like+to+share+this+link+with+you+${url}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
                           onClick={() => this.props.analytics.email(type)}
                         >
                           <Icon name="icon-share-email" className="-small" />

--- a/components/ui/map/controls/ShareControl.js
+++ b/components/ui/map/controls/ShareControl.js
@@ -44,6 +44,7 @@ class ShareControl extends React.Component {
             analytics={{
               facebook: () => logEvent('Share', 'Share explore', 'Facebook'),
               twitter: () => logEvent('Share', 'Share explore', 'Twitter'),
+              email: () => logEvent('Share', 'Share explore', 'Email'),
               copy: type => logEvent('Share', 'Share explore', `Copy ${type}`)
             }}
           />

--- a/components/wysiwyg/widget-block/component.js
+++ b/components/wysiwyg/widget-block/component.js
@@ -186,6 +186,7 @@ class WidgetBlock extends PureComponent {
                       analytics={{
                         facebook: () => logEvent('Share (embed)', `Share widget: ${widget.name}`, 'Facebook'),
                         twitter: () => logEvent('Share (embed)', `Share widget: ${widget.name}`, 'Twitter'),
+                        email: () => logEvent('Share', `Share widget: ${widget.name}`, 'Email'),
                         copy: type => logEvent('Share (embed)', `Share widget: ${widget.name}`, `Copy ${type}`)
                       }}
                     />

--- a/layout/app/dashboard-detail/component.js
+++ b/layout/app/dashboard-detail/component.js
@@ -101,6 +101,7 @@ class DashboardsDetailPage extends PureComponent {
                             analytics={{
                               facebook: () => logEvent('Share', `Share dashboard: ${name}`, 'Facebook'),
                               twitter: () => logEvent('Share', `Share dashboard: ${name}`, 'Twitter'),
+                              email: () => logEvent('Share',  `Share dashboard: ${name}`, 'Email'),
                               copy: type => logEvent('Share', `Share dashboard: ${name}`, `Copy ${type}`)
                             }}
                           />

--- a/layout/app/topics-detail/topics-detail-header/component.js
+++ b/layout/app/topics-detail/topics-detail-header/component.js
@@ -50,6 +50,7 @@ class TopicDetailHeader extends PureComponent {
                     analytics={{
                       facebook: () => logEvent('Share', `Share topic: ${topic.name}`, 'Facebook'),
                       twitter: () => logEvent('Share', `Share topic: ${topic.name}`, 'Twitter'),
+                      email: () => logEvent('Share', `Share topic: ${topic.name}`, 'Email'),
                       copy: type => logEvent('Share', `Share topic: ${topic.name}`, `Copy ${type}`)
                     }}
                   />

--- a/layout/app/widget-detail/widget-detail-header/component.js
+++ b/layout/app/widget-detail/widget-detail-header/component.js
@@ -72,6 +72,7 @@ class WidgetDetailHeader extends PureComponent {
                     analytics={{
                       facebook: () => logEvent('Share', `Share widget: ${widget.name}`, 'Facebook'),
                       twitter: () => logEvent('Share', `Share widget: ${widget.name}`, 'Twitter'),
+                      email: () => logEvent('Share', `Share widget: ${widget.name}`, 'Email'),
                       copy: type => logEvent('Share', `Share widget: ${widget.name}`, `Copy ${type}`)
                     }}
                   />

--- a/layout/embed/dashboard/component.js
+++ b/layout/embed/dashboard/component.js
@@ -59,6 +59,7 @@ class LayoutEmbedDashboard extends PureComponent {
                             analytics={{
                               facebook: () => logEvent('Share (embed)', `Share dashboard: ${dashboard.name}`, 'Facebook'),
                               twitter: () => logEvent('Share (embed)', `Share dashboard: ${dashboard.name}`, 'Twitter'),
+                              email: () => logEvent('Share', `Share dashboard: ${dashboard.name}`, 'Email'),
                               copy: type => logEvent('Share (embed)', `Share dashboard: ${dashboard.name}`, `Copy ${type}`)
                             }}
                           />

--- a/layout/embed/widget/component.js
+++ b/layout/embed/widget/component.js
@@ -213,6 +213,7 @@ class LayoutEmbedWidget extends PureComponent {
                       analytics={{
                         facebook: () => logEvent('Share (embed)', `Share widget: ${widget.name}`, 'Facebook'),
                         twitter: () => logEvent('Share (embed)', `Share widget: ${widget.name}`, 'Twitter'),
+                        email: () => logEvent('Share', `Share widget: ${widget.name}`, 'Email'),
                         copy: type => logEvent('Share (embed)', `Share widget: ${widget.name}`, `Copy ${type}`)
                       }}
                     />

--- a/layout/explore-detail/explore-detail-header/explore-detail-header-component.js
+++ b/layout/explore-detail/explore-detail-header/explore-detail-header-component.js
@@ -93,6 +93,7 @@ class ExploreDetailHeader extends PureComponent {
                     analytics={{
                       facebook: () => logEvent('Share', `Share dataset: ${datasetName}`, 'Facebook'),
                       twitter: () => logEvent('Share', `Share dataset: ${datasetName}`, 'Twitter'),
+                      email: () => logEvent('Share', `Share dataset: ${datasetName}`, 'Email'),
                       copy: type => logEvent('Share', `Share dataset: ${datasetName}`, `Copy ${type}`)
                     }}
                   />

--- a/layout/explore-detail/explore-detail-info/explore-detail-info-component.js
+++ b/layout/explore-detail/explore-detail-info/explore-detail-info-component.js
@@ -62,6 +62,7 @@ class ExploreDetailInfo extends PureComponent {
                 analytics={{
                   facebook: () => logEvent('Share', `Share dataset: ${datasetName}`, 'Facebook'),
                   twitter: () => logEvent('Share', `Share dataset: ${datasetName}`, 'Twitter'),
+                  email: () => logEvent('Share', `Share dataset: ${datasetName}`, 'Email'),
                   copy: type => logEvent('Share', `Share dataset: ${datasetName}`, `Copy ${type}`)
                 }}
               />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/60891828-5d73b380-a25e-11e9-8fe1-18fdc5ecb163.png)

## Overview
This PR adds a new button to the share modal that allows users to share by email by means of a `mailto` link.
_NOTE: the mailto params might not be final as they stand now_ 

## Testing instructions
Go for instance to http://localhost:9000/data/explore , click on the share button and then click on the email option.

## [Pivotal task](https://www.pivotaltracker.com/story/show/166956378)