### PR TITLE
Layer info pop-up "more info" button leads to `resourcewatch.org/data/explore/[slug]`

### DIFF
--- a/components/modal/layer-info-modal/layer-info-modal-component.js
+++ b/components/modal/layer-info-modal/layer-info-modal-component.js
@@ -7,9 +7,6 @@ import { connect } from 'react-redux';
 
 import { fetchDataset } from 'services/dataset';
 
-// Styles
-import './styles.scss';
-
 function LayerInfoModal(props) {
   const { embed, layer } = props;
   const [slug, setSlug] = useState(' ');
@@ -26,7 +23,7 @@ function LayerInfoModal(props) {
       <div className="layer-info-content">
         <h2>{layer.name}</h2>
         <p>{layer.description}</p>
-        <div className="buttons">
+        <div className="c-button-container -j-end">
           {embed && (
             <a
               className="c-btn -primary"

--- a/components/modal/layer-info-modal/layer-info-modal-component.js
+++ b/components/modal/layer-info-modal/layer-info-modal-component.js
@@ -2,19 +2,16 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'routes';
 
-// Redux
-import { connect } from 'react-redux';
-
 import { fetchDataset } from 'services/dataset';
 
 function LayerInfoModal(props) {
-  const { embed, layer } = props;
+  const { layer } = props;
   const [slug, setSlug] = useState(' ');
 
   useEffect(() => {
     fetchDataset(layer.dataset)
-      .then((response) => {
-        setSlug(response.slug);
+      .then((dataset) => {
+        setSlug(dataset.slug);
       });
   }, []);
 
@@ -24,34 +21,15 @@ function LayerInfoModal(props) {
         <h2>{layer.name}</h2>
         <p>{layer.description}</p>
         <div className="c-button-container -j-end">
-          {embed && (
-            <a
-              className="c-btn -primary"
-              href={`${window.location.origin}/data/explore/${slug}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              More info
-            </a>
-          )}
-
-          {!embed && (
-            <Link route="explore_detail" params={{ id: slug }}>
-              <a className="c-btn -primary">More info</a>
-            </Link>
-          )}
+          <Link route="explore_detail" params={{ id: slug }}>
+            <a className="c-btn -primary">More info</a>
+          </Link>
         </div>
       </div>
     </div>
   );
 }
 
-LayerInfoModal.propTypes = {
-  layer: PropTypes.object.isRequired,
-  embed: PropTypes.bool.isRequired
-};
+LayerInfoModal.propTypes = { layer: PropTypes.object.isRequired };
 
-export default connect(
-  state => ({ embed: state.common.embed }),
-  null
-)(LayerInfoModal);
+export default LayerInfoModal;

--- a/components/modal/layer-info-modal/layer-info-modal-component.js
+++ b/components/modal/layer-info-modal/layer-info-modal-component.js
@@ -1,55 +1,57 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'routes';
 
 // Redux
 import { connect } from 'react-redux';
 
-class LayerInfoModal extends React.Component {
-  static propTypes = {
-    layer: PropTypes.object,
-    embed: PropTypes.bool
-  };
+import { fetchDataset } from 'services/dataset';
 
-  render() {
-    const { embed, layer } = this.props;
+function LayerInfoModal(props) {
+  const { embed, layer } = props;
+  const [slug, setSlug] = useState(' ');
 
-    return (
-      <div className="layer-info-modal">
-        <div className="layer-info-content">
-          <h2>{layer.name}</h2>
-          <p>{layer.description}</p>
-          <div className="buttons">
-            {embed &&
-              <a
-                className="c-btn -primary"
-                href={`${window.location.origin}/data/explore/${layer.dataset}`}
-                target="_blank"
-              >
-                More info
-              </a>
-            }
+  useEffect(() => {
+    fetchDataset(layer.dataset)
+      .then((response) => {
+        setSlug(response.slug);
+      });
+  }, []);
 
-            {!embed &&
-              <Link
-                route="explore_detail"
-                params={{ id: layer.dataset }}
-              >
-                <a className="c-btn -primary">
-                  More info
-                </a>
-              </Link>
-            }
-          </div>
+  return (
+    <div className="layer-info-modal">
+      <div className="layer-info-content">
+        <h2>{layer.name}</h2>
+        <p>{layer.description}</p>
+        <div className="buttons">
+          {embed && (
+            <a
+              className="c-btn -primary"
+              href={`${window.location.origin}/data/explore/${layer.dataset}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              More info
+            </a>
+          )}
+
+          {!embed && (
+            <Link route="explore_detail" params={{ id: slug }}>
+              <a className="c-btn -primary">More info</a>
+            </Link>
+          )}
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
+LayerInfoModal.propTypes = {
+  layer: PropTypes.object.isRequired,
+  embed: PropTypes.bool.isRequired
+};
+
 export default connect(
-  state => ({
-    embed: state.common.embed
-  }),
+  state => ({ embed: state.common.embed }),
   null
 )(LayerInfoModal);

--- a/components/modal/layer-info-modal/layer-info-modal-component.js
+++ b/components/modal/layer-info-modal/layer-info-modal-component.js
@@ -7,6 +7,9 @@ import { connect } from 'react-redux';
 
 import { fetchDataset } from 'services/dataset';
 
+// Styles
+import './styles.scss';
+
 function LayerInfoModal(props) {
   const { embed, layer } = props;
   const [slug, setSlug] = useState(' ');
@@ -19,7 +22,7 @@ function LayerInfoModal(props) {
   }, []);
 
   return (
-    <div className="layer-info-modal">
+    <div className="c-layer-info-modal">
       <div className="layer-info-content">
         <h2>{layer.name}</h2>
         <p>{layer.description}</p>
@@ -27,7 +30,7 @@ function LayerInfoModal(props) {
           {embed && (
             <a
               className="c-btn -primary"
-              href={`${window.location.origin}/data/explore/${layer.dataset}`}
+              href={`${window.location.origin}/data/explore/${slug}`}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/components/modal/layer-info-modal/styles.scss
+++ b/components/modal/layer-info-modal/styles.scss
@@ -1,7 +1,0 @@
-.c-layer-info-modal {
-
-  .buttons {
-    display: flex;
-    justify-content: flex-end;
-  }
-}

--- a/components/modal/layer-info-modal/styles.scss
+++ b/components/modal/layer-info-modal/styles.scss
@@ -1,4 +1,4 @@
-.layer-info-modal {
+.c-layer-info-modal {
 
   .buttons {
     display: flex;

--- a/css/index.scss
+++ b/css/index.scss
@@ -90,7 +90,6 @@
 @import "./components/modal/subscribe_to_dataset_modal";
 @import "./components/modal/area_subscription_modal";
 @import "./components/modal/subscriptions_modal";
-@import "./components/modal/layer_info_modal";
 @import "./components/modal/alerts_preview";
 
 

--- a/layout/explore/explore-map/explore-map-component.js
+++ b/layout/explore/explore-map/explore-map-component.js
@@ -221,6 +221,8 @@ class ExploreMapComponent extends React.Component {
       layerGroupsInteractionLatLng
     } = this.props;
 
+    const { loading, layer } = this.state;
+
     return (
       <div className="l-explore-map -relative">
         {/* Brand logo */}
@@ -235,8 +237,8 @@ class ExploreMapComponent extends React.Component {
           </div>
         )}
         {/* Spinner */}
-        {Object.keys(this.state.loading)
-          .map(k => this.state.loading[k])
+        {Object.keys(loading)
+          .map(k => loading[k])
           .some(l => !!l) && <Spinner isLoading />}
 
         {/* Map */}
@@ -410,13 +412,13 @@ class ExploreMapComponent extends React.Component {
           </Legend>
         </div>
 
-        {!!this.state.layer && (
+        {!!layer && (
           <Modal
-            isOpen={!!this.state.layer}
+            isOpen={!!layer}
             className="-medium"
             onRequestClose={() => this.onChangeInfo(null)}
           >
-            <LayerInfoModal layer={this.state.layer} />
+            <LayerInfoModal layer={layer} />
           </Modal>
         )}
       </div>


### PR DESCRIPTION
## Overview
This PR updates the "more info" button from the layer info pop-up to direct to `resourcewatch.org/data/explore/[slug]` instead of `resourcewatch.org/data/explore/[id]`

## Testing instructions
Add any dataset to the Explore page and open the layer info pop up. The "More info" button should link to the dataset detail page using the slug instead of the dataset id.

## [Pivotal task](https://www.pivotaltracker.com/story/show/167211371)