### PR TITLE
Prevent widgets from other apps to be loaded in MyRW

### DIFF
--- a/components/app/myrw/widgets/tabs/list/helpers.js
+++ b/components/app/myrw/widgets/tabs/list/helpers.js
@@ -12,7 +12,7 @@ export const getQueryParams = (state = {}, props) => {
   const isCollection = !['my_widgets', 'favourites'].includes(subtab);
 
   return ({
-    application: 'rw',
+    application: process.env.APPLICATIONS,
     'page[size]': limit,
     'page[number]': page,
     sort: sort === 'asc' ? 'updatedAt' : '-updatedAt',

--- a/components/app/myrw/widgets/tabs/list/helpers.js
+++ b/components/app/myrw/widgets/tabs/list/helpers.js
@@ -12,6 +12,7 @@ export const getQueryParams = (state = {}, props) => {
   const isCollection = !['my_widgets', 'favourites'].includes(subtab);
 
   return ({
+    application: 'rw',
     'page[size]': limit,
     'page[number]': page,
     sort: sort === 'asc' ? 'updatedAt' : '-updatedAt',


### PR DESCRIPTION
## Overview
This PR adds a missing parameter to the request that retrieves the widgets so that it filters out widgets from other apps.

## Testing instructions
Go to MyRW --> My visualizations and check if widgets from other apps are being loaded.

## Pivotal task
This PR is related to this comment: https://www.pivotaltracker.com/story/show/166645058/comments/204678608

