### PR TITLE
Surface the Last update date in Explore detail only when this field has a value

### DIFF
--- a/layout/app/pulse/component.js
+++ b/layout/app/pulse/component.js
@@ -237,7 +237,7 @@ class LayoutPulse extends PureComponent {
         className="l-pulse"
       >
         <div
-          className="l-map -dark"
+          className="pulse-container -dark"
         >
           <Spinner
             isLoading={

--- a/layout/app/pulse/styles.scss
+++ b/layout/app/pulse/styles.scss
@@ -1,24 +1,41 @@
 @import 'css/settings';
 
 .l-pulse {
+
   background-color: black;
   background-repeat: no-repeat;
   background-position: left top;
   background-size: cover;
 
-  .cesium-infoBox {
-    z-index: 10;
+  .pulse-container {
+    position: absolute;
+    top: $header-main-height-mobile;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: calc(100% - #{$header-main-height-mobile});
+    overflow: hidden;
 
-    button {
-      cursor: pointer;
+    @media screen and (min-width: map-get($breakpoints, medium)) {
+      top: $header-main-height;
+      height: calc(100% - #{$header-main-height});
     }
-  }
 
-  .c-zoom-control {
-    z-index: 9;
+    .cesium-infoBox {
+      z-index: 10;
 
-    @media screen and (max-width: map-get($breakpoints, medium)) {
-      top: 30px;
+      button {
+        cursor: pointer;
+      }
+    }
+
+    .c-zoom-control {
+      z-index: 9;
+
+      @media screen and (max-width: map-get($breakpoints, medium)) {
+        top: 30px;
+      }
     }
   }
 }

--- a/layout/explore-detail/explore-detail-header/explore-detail-header-component.js
+++ b/layout/explore-detail/explore-detail-header/explore-detail-header-component.js
@@ -77,7 +77,9 @@ class ExploreDetailHeader extends PureComponent {
         <div className="page-header-info">
           <ul>
             <li>Source: {(metadata.source) || '-'}</li>
-            <li>Last update: {dataset.dateLastUpdated || '-'}</li>
+            {dataset.dateLastUpdated &&
+              <li>Last update: {dataset.dateLastUpdated}</li>
+            }
             <li>
               <button className="c-btn -tertiary -alt -clean" onClick={() => this.handleToggleShareModal(true)}>
                 <Icon name="icon-share" className="-small" />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/61374633-23796180-a89d-11e9-8af7-c092236eedfd.png)

## Overview
This PR hides the `Last Update Date` field from the Explore detail page when this field has no value.
It also includes a fix for a regression in Planet Pulse that affected the styles of the page.

## Testing instructions
Go to http://localhost:9000/data/explore/GINI-Index (there should be no last update value field in this case)
and http://localhost:9000/data/explore/VIIRS-Active-Fire-Global-1490086842549 (the last update date should surface in this case)
_To check the fix for the Planet Pulse styles simply go to_ http://localhost:9000/data/pulse 

## [Pivotal task](https://www.pivotaltracker.com/story/show/167342509)

