### PR TITLE
Explore detail: markdown related improvements

### DIFF
--- a/components/modal/layer-info-modal/layer-info-modal-component.js
+++ b/components/modal/layer-info-modal/layer-info-modal-component.js
@@ -5,6 +5,8 @@ import ReactMarkdown from 'react-markdown';
 
 import { fetchDataset } from 'services/dataset';
 
+import './styles.scss';
+
 function LayerInfoModal(props) {
   const { layer } = props;
   const [slug, setSlug] = useState(' ');

--- a/components/modal/layer-info-modal/layer-info-modal-component.js
+++ b/components/modal/layer-info-modal/layer-info-modal-component.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'routes';
+import ReactMarkdown from 'react-markdown';
 
 import { fetchDataset } from 'services/dataset';
 
@@ -19,7 +20,7 @@ function LayerInfoModal(props) {
     <div className="c-layer-info-modal">
       <div className="layer-info-content">
         <h2>{layer.name}</h2>
-        <p>{layer.description}</p>
+        <ReactMarkdown linkTarget="_blank" source={layer.description} />
         <div className="c-button-container -j-end">
           <Link route="explore_detail" params={{ id: slug }}>
             <a className="c-btn -primary">More info</a>

--- a/components/modal/layer-info-modal/styles.scss
+++ b/components/modal/layer-info-modal/styles.scss
@@ -1,0 +1,10 @@
+.c-layer-info-modal {
+  ul, ol {
+    list-style: disc outside none;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 30px;
+  }
+}

--- a/css/components/explore-detail/explore-detail-info.scss
+++ b/css/components/explore-detail/explore-detail-info.scss
@@ -8,4 +8,13 @@
       margin-top: 30px;
     }
   }
+
+  ul, ol {
+    list-style: disc outside none;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 30px;
+  }
 }

--- a/layout/app/dashboard-detail/component.js
+++ b/layout/app/dashboard-detail/component.js
@@ -120,7 +120,7 @@ class DashboardsDetailPage extends PureComponent {
             <div className="row">
               {description && (
                 <div className="column small-12">
-                  <ReactMarkdown source={description} />
+                  <ReactMarkdown linkTarget="_blank" source={description} />
                 </div>)}
               <div className="column small-12">
                 <DashboardDetail />

--- a/layout/explore-detail/explore-detail-component.js
+++ b/layout/explore-detail/explore-detail-component.js
@@ -71,7 +71,7 @@ class ExploreDetail extends PureComponent {
               <div className="row">
                 <div className="column small-12 large-7">
                   {metadata.description &&
-                    <ReactMarkdown source={metadata.description} />}
+                    <ReactMarkdown linkTarget="_blank" source={metadata.description} />}
                 </div>
 
                 <div className="column small-12 large-4 large-offset-1">

--- a/layout/explore-detail/explore-detail-info/explore-detail-info-component.js
+++ b/layout/explore-detail/explore-detail-info/explore-detail-info-component.js
@@ -73,19 +73,19 @@ class ExploreDetailInfo extends PureComponent {
         {metadata.info && metadata.info.cautions &&
           <div className="l-section-mod medium-7">
             <h3>Cautions</h3>
-            <ReactMarkdown source={metadata.info.cautions} />
+            <ReactMarkdown linkTarget="_blank" source={metadata.info.cautions} />
           </div>}
 
         {metadata.info && metadata.info.citation &&
           <div className="l-section-mod medium-7">
             <h3>Suggested citation</h3>
-            <ReactMarkdown source={metadata.info.citation} />
+            <ReactMarkdown linkTarget="_blank" source={metadata.info.citation} />
           </div>}
 
         {dataset && dataset.attributes && dataset.attributes.type &&
           <div className="l-section-mod">
             <h3>Data type</h3>
-            <p>{dataset.attributes.type}</p>
+            <ReactMarkdown linkTarget="_blank" source={dataset.attributes.type} />
           </div>}
 
         {metadata.info && metadata.info.sources ? (
@@ -106,28 +106,28 @@ class ExploreDetailInfo extends PureComponent {
           {metadata.info && metadata.info.geographic_coverage ? (
             <div className="column small-6 medium-4 large-3">
               <h3>Geographic coverage</h3>
-              <p>{metadata.info.geographic_coverage}</p>
+              <ReactMarkdown linkTarget="_blank" source={metadata.info.geographic_coverage} />
             </div>
           ) : null}
 
           {metadata.info && metadata.info.spatial_resolution ? (
             <div className="column small-6 medium-4 large-3">
               <h3>Spatial resolution</h3>
-              <p>{metadata.info.spatial_resolution}</p>
+              <ReactMarkdown linkTarget="_blank" source={metadata.info.spatial_resolution} />
             </div>
           ) : null}
 
           {metadata.info && metadata.info.date_of_content ? (
             <div className="column small-6 medium-4 large-3">
               <h3>Date of content</h3>
-              <p>{metadata.info.date_of_content}</p>
+              <ReactMarkdown linkTarget="_blank" source={metadata.info.date_of_content} />
             </div>
           ) : null}
 
           {metadata.info && metadata.info.frequency_of_updates ? (
             <div className="column small-6 medium-4 large-3">
               <h3>Frequency of updates</h3>
-              <p>{metadata.info.frequency_of_updates}</p>
+              <ReactMarkdown linkTarget="_blank" source={metadata.info.frequency_of_updates} />
             </div>
           ) : null}
         </div>
@@ -136,21 +136,21 @@ class ExploreDetailInfo extends PureComponent {
           {metadata.info && metadata.info.license ? (
             <div className="column small-6 medium-4 large-3">
               <h3>License</h3>
-              <p>
-                {!!metadata.info.license_link &&
+              {!!metadata.info.license_link &&
+                <p>
                   <a href={metadata.info.license_link} target="_blank" rel="noopener noreferrer">{metadata.info.license}</a>
-                }
-                {!metadata.info.license_link &&
-                  metadata.info.license
-                }
-              </p>
+                </p>
+              }
+              {!metadata.info.license_link &&
+                <ReactMarkdown linkTarget="_blank" source={metadata.info.license} />
+              }
             </div>
           ) : null}
 
           {metadata.info && metadata.info.summary_of_license ? (
             <div className="column small-6 medium-4 large-3">
               <h3>Summary of license</h3>
-              <p>{metadata.info.summary_of_license}</p>
+              <ReactMarkdown linkTarget="_blank" source={metadata.info.summary_of_license} />
             </div>
           ) : null}
 
@@ -166,7 +166,7 @@ class ExploreDetailInfo extends PureComponent {
           {metadata && metadata.language ? (
             <div className="column small-6 medium-4 large-3">
               <h3>Published language</h3>
-              <p>{metadata.language}</p>
+              <ReactMarkdown linkTarget="_blank" source={metadata.language} />
             </div>
           ) : null}
         </div>
@@ -174,7 +174,7 @@ class ExploreDetailInfo extends PureComponent {
         {metadata.info && metadata.info.language && metadata.info.language.toLowerCase() !== 'en' ? (
           <div className="l-section-mod">
             <h3>Translated title</h3>
-            <p>{metadata.info && metadata.info.translated_title}</p>
+            <ReactMarkdown linkTarget="_blank" source={metadata.info && metadata.info.translated_title} />
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
## Overview
This PR includes the following markdown-related improvements:
1. All links included in markdown supported fields are opened in a new tab now.
2. Bullet lists support
3. Extend markdown support to all fields currently surfaced in the Explore Detail page

## Testing instructions
You can check this dataset on staging: http://localhost:9000/data/explore/VIIRS-Active-Fire-Global-1490086842549 _See the cautions field for an example of how bullet lists are rendered now_

## Pivotal task
Related to this one https://www.pivotaltracker.com/story/show/167444891 but also to the need to extend the markdown support to more fields and having the ability to display bullet lists.
