### PR TITLE
Timeline appearance improved when there are many time steps

### DIFF
--- a/components/ui/map/map-thumbnail/helper.js
+++ b/components/ui/map/map-thumbnail/helper.js
@@ -105,7 +105,13 @@ export const getImageForLeaflet = ({ layerSpec }) => {
     return null;
   }
 
-  const tile = layerConfig.url.replace('{z}', '0').replace('{x}', '0').replace('{y}', '0');
+  if (!layerConfig.url && !layerConfig.body && !layerConfig.body.url) {
+    return null;
+  }
+
+  const url = layerConfig.url || layerConfig.body.url;
+
+  const tile = url.replace('{z}', '0').replace('{x}', '0').replace('{y}', '0');
 
   return tile;
 };

--- a/components/ui/map/map-thumbnail/helper.js
+++ b/components/ui/map/map-thumbnail/helper.js
@@ -105,7 +105,7 @@ export const getImageForLeaflet = ({ layerSpec }) => {
     return null;
   }
 
-  if (!layerConfig.url && !layerConfig.body && !layerConfig.body.url) {
+  if (!layerConfig.url || (layerConfig.body && !layerConfig.body.url)) {
     return null;
   }
 

--- a/layout/explore/explore-map/constants.js
+++ b/layout/explore/explore-map/constants.js
@@ -44,4 +44,6 @@ export const LEGEND_TIMELINE_PROPERTIES = {
   }
 };
 
+export const TIMELINE_THRESHOLD = 5;
+
 export default { LEGEND_TIMELINE_PROPERTIES };

--- a/layout/explore/explore-map/explore-map-component.js
+++ b/layout/explore/explore-map/explore-map-component.js
@@ -42,7 +42,7 @@ import LayerInfoModal from 'components/modal/layer-info-modal';
 import CANVAS_DECODERS from 'utils/layers/canvas-decoders';
 
 // constants
-import { LEGEND_TIMELINE_PROPERTIES } from './constants';
+import { LEGEND_TIMELINE_PROPERTIES, TIMELINE_THRESHOLD } from './constants';
 
 // styles
 import './styles.scss';
@@ -406,6 +406,7 @@ class ExploreMapComponent extends React.Component {
                   onChangeLayer={this.onChangeLayerTimeLine}
                   customClass="rw-legend-timeline"
                   {...LEGEND_TIMELINE_PROPERTIES}
+                  { ...lg.layers.length > TIMELINE_THRESHOLD && { dotStyle: { opacity: 0 } }}
                 />
               </LegendListItem>
             ))}


### PR DESCRIPTION
## Overview
This PR modifies the style of the timeline when there are more than 5 steps to be displayed _(according to the request made for that specific threshold in the PT task)_

_An issue with layers having the url in the body property has also been fixed as part of this PR_

Before: 
![image](https://user-images.githubusercontent.com/545342/61784021-33e38c00-ae09-11e9-9600-63ee74424e40.png)

After:
![image](https://user-images.githubusercontent.com/545342/61784035-3ba33080-ae09-11e9-9fe1-a41eae328b9a.png)

## Testing instructions
Check the *"National Population"* dataset on Explore http://localhost:9000/data/explore?zoom=3&lat=0&lng=0&basemap=dark&labels=light&layers=%255B%257B%2522dataset%2522%253A%25222a8ca4f7-7285-4aed-9ef5-ba1f9c4b653d%2522%252C%2522opacity%2522%253A1%252C%2522layer%2522%253A%25221b47db11-8f4e-4e4b-a368-b918f099bffe%2522%257D%255D&page=1&sort=relevance&sortDirection=-1&search=national%20population

## [Pivotal task](https://www.pivotaltracker.com/story/show/167423678)
