### PR TITLE
Adds origin param to reset password

### DIFF
--- a/layout/forgot-password/component.js
+++ b/layout/forgot-password/component.js
@@ -29,12 +29,7 @@ class ForgotPassword extends PureComponent {
         .then(() => {
           toastr.success('Reset password requested', 'Please, check your inbox and follow instructions to reset your password.');
         })
-        .catch((err) => {
-          err.json()
-            .then(({ errors } = {}) => {
-              (errors || []).forEach(_error => toastr.error('Something went wrong', `${_error.status}:${_error.detail}`));
-            });
-        });
+        .catch(({ message }) => { toastr.error('Something went wrong', `${message}`); });
     }, 0);
   }
 

--- a/services/user.js
+++ b/services/user.js
@@ -66,7 +66,7 @@ export default class UserService {
   // NOTE:this is NOT implemented in the API to be done from the app.
   // right now the only way it's through the email link pointing to Control Tower.
   resetPassword(tokenEmail, { password, repeatPassword }) {
-    return fetch(`${this.opts.apiURL}/auth/reset-password/${tokenEmail}`, {
+    return fetch(`${this.opts.apiURL}/auth/reset-password/${tokenEmail}?origin=${process.env.APPLICATIONS}`, {
       method: 'POST',
       body: JSON.stringify({ password, repeatPassword }),
       headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
## Overview
Adds `origin=rw` as query param in `reset-password` endpoint.

## Testing instructions
Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc.

## Pivotal task
Provide the link to the task(s), if any.

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
