### PR TITLE
Fix for issue: Backoffice widget creator only appears when dataset manually selected

### DIFF
--- a/components/admin/data/widgets/form/steps/Step1.js
+++ b/components/admin/data/widgets/form/steps/Step1.js
@@ -40,30 +40,26 @@ class Step1 extends Component {
 
   static defaultProps = { showEditor: true }
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      id: props.id,
-      form: props.form,
-      loadingVegaChart: false
-    };
-
-    // ------------------- BINDINGS ---------------------------
-    this.triggerChangeMode = this.triggerChangeMode.bind(this);
-    this.triggerToggleLoadingVegaChart = this.triggerToggleLoadingVegaChart.bind(this);
-    this.refreshWidgetPreview = this.refreshWidgetPreview.bind(this);
-  }
+  state = {
+    id: this.props.id,
+    form: this.props.form,
+    loadingVegaChart: false
+  };
 
   componentWillReceiveProps(nextProps) {
-    this.setState({ form: nextProps.form });
+    this.setState({
+      form: {
+        ...nextProps.form,
+        dataset: nextProps.form.dataset || nextProps.query.dataset
+      }
+    });
   }
 
   /**
    * HELPERS
    * - triggerChangeMode
   */
-  triggerChangeMode(mode) {
+  triggerChangeMode = (mode) => {
     if (mode === 'editor') {
       toastr.confirm('By switching you will start editing from scratch', {
         onOk: () => {
@@ -85,11 +81,11 @@ class Step1 extends Component {
     }
   }
 
-  triggerToggleLoadingVegaChart(loading) {
+  triggerToggleLoadingVegaChart = (loading) => {
     this.setState({ loadingVegaChart: loading });
   }
 
-  refreshWidgetPreview() {
+  refreshWidgetPreview = () => {
     this.forceChartUpdate();
   }
 


### PR DESCRIPTION
## Overview
This PR fixes the issue that prevented the Widget Editor from being displayed unless the dataset was manually selected in the back office widget form.

## Testing instructions

1. As admin in production back office, click any dataset
1. Go to Widgets and click "New widget"
2. The widget creator should be displayed 

## [Pivotal task](https://www.pivotaltracker.com/story/show/167541366)
