### PR TITLE
forgotten password - moves to axios and logger

### DIFF
--- a/layout/forgot-password/component.js
+++ b/layout/forgot-password/component.js
@@ -29,7 +29,7 @@ class ForgotPassword extends PureComponent {
         .then(() => {
           toastr.success('Reset password requested', 'Please, check your inbox and follow instructions to reset your password.');
         })
-        .catch(({ message }) => { toastr.error('Something went wrong', `${message}`); });
+        .catch(() => { toastr.error('Reset password', 'Something went wrong during the process. Please, try again.'); });
     }, 0);
   }
 


### PR DESCRIPTION
## Overview
Moves `forgottenPassword` method to `axios` and `logger`.

## Testing instructions
Try the forgotten password process as usual.

## Pivotal task
Provide the link to the task(s), if any.

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
