### PR TITLE
Fix for Markdown link styles

### DIFF
--- a/css/components/ui/markdown.scss
+++ b/css/components/ui/markdown.scss
@@ -14,4 +14,9 @@
   ol {
     list-style: decimal outside none;
   }
+
+  a {
+    color: $sea-blue;
+    text-decoration: underline;
+  }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/62277305-2a2fd900-b446-11e9-9ae3-28bb1735fc38.png)

## Overview
This PR fixes an issue that prevented some links to appear correctly.

## Testing instructions
Go to http://localhost:9000/data/explore/soc_016-African-and-Asian-Conflict-and-Protest-Events and verify that links are in color blue and underlined.

## [Pivotal task](https://www.pivotaltracker.com/story/show/167631201)