### PR TITLE
Fix issue with Layer form (published checkbox was always checked)

### DIFF
--- a/components/admin/data/layers/form/LayersForm.js
+++ b/components/admin/data/layers/form/LayersForm.js
@@ -213,7 +213,7 @@ class LayersForm extends PureComponent {
             params[f] !== null ||
             (typeof this.state.form[f] !== 'undefined' || this.state.form[f] !== null)
           ) {
-            newForm[f] = params[f] || this.state.form[f];
+            newForm[f] = (f in params) ? params[f] : this.state.form[f];
           }
         }
       }


### PR DESCRIPTION
## Overview
This PR fixes a problem with the published checkbox in the Layer form. Prior to the fix the published checkbox was always displayed checked regardless of the `published` field value.