### PR TITLE
Fix "Dataset not found" error when saving widgets

### DIFF
--- a/components/admin/data/widgets/form/component.js
+++ b/components/admin/data/widgets/form/component.js
@@ -28,12 +28,13 @@ class WidgetForm extends PureComponent {
     showEditor: PropTypes.bool,
     widgetEditor: PropTypes.object.isRequired,
     locale: PropTypes.string.isRequired,
-    newState: PropTypes.bool.isRequired
+    newState: PropTypes.bool.isRequired,
+    dataset: PropTypes.string
   };
 
   static defaultProps = {
     id: null,
-    // dataset: null,
+    dataset: null,
     showEditor: true
   };
 
@@ -43,7 +44,10 @@ class WidgetForm extends PureComponent {
     this.state = Object.assign({}, STATE_DEFAULT, {
       id: props.id,
       loading: !!props.id,
-      form: STATE_DEFAULT.form,
+      form: {
+        ...STATE_DEFAULT.form,
+        dataset: props.dataset
+      },
       mode: 'editor'
     });
 

--- a/components/admin/data/widgets/form/index.js
+++ b/components/admin/data/widgets/form/index.js
@@ -7,7 +7,8 @@ export default connect(
   state => ({
     widgetEditor: state.widgetEditor,
     locale: state.common.locale,
-    newState: state.routes.query.id === 'new'
+    newState: state.routes.query.id === 'new',
+    dataset: state.routes.query.dataset
   }),
   null
 )(WidgetForm);


### PR DESCRIPTION
## Overview
This PR fixes an issue that prevented the creation of widgets when a user accessed the Widget creation form via a specific dataset.

## Testing instructions
Go the back office, select a dataset and then go to the widgets section and click "New". You should be able to create a widget now without having any issues.

## [Pivotal task](https://www.pivotaltracker.com/story/show/167707248)