### PR TITLE
Fix for error saving widgets from dataset detail page

### DIFF
--- a/services/WidgetsService.js
+++ b/services/WidgetsService.js
@@ -76,7 +76,7 @@ export default class WidgetsService {
         type,
         body: {
           ...body,
-          ...type !== 'PATCH' && { application: [process.env.APPLICATIONS] }
+          ...type !== 'PATCH' && { application: process.env.APPLICATIONS }
         },
         headers: [{
           key: 'Content-Type',


### PR DESCRIPTION
## Overview
This PR includes a fix for the issue that prevented users from saving widgets from the dataset detail page.

## Testing instructions
Go to any dataset detail page once you're logged in and try saving the widget shown by default.

## [Pivotal task](https://www.pivotaltracker.com/story/show/168017056)