### PR TITLE
datasets from collections should link to different pages depending on user and ownership

### DIFF
--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
@@ -105,15 +105,13 @@ class DatasetsListCard extends PureComponent {
 
           {isOwner && !isAdmin &&
             <div className="actions">
-              <a
-                onKeyPress={this.handleDelete}
-                role="button"
+              <button
                 className="c-button -secondary -compressed"
-                tabIndex={0}
                 onClick={this.handleDelete}
+                type="button"
               >
                 Delete
-              </a>
+              </button>
             </div>
           }
         </div>

--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
@@ -13,17 +13,10 @@ import CollectionsPanel from 'components/collections-panel';
 import { belongsToACollection } from 'components/collections-panel/collections-panel-helpers';
 
 class DatasetsListCard extends PureComponent {
-  static defaultProps = {
-    routes: {
-      index: '',
-      detail: ''
-    },
-    dataset: {}
-  };
+  static defaultProps = { dataset: {} };
 
   static propTypes = {
     dataset: PropTypes.object,
-    routes: PropTypes.object,
     user: PropTypes.object.isRequired,
     onDatasetRemoved: PropTypes.func.isRequired
   };
@@ -45,12 +38,13 @@ class DatasetsListCard extends PureComponent {
   }
 
   render() {
-    const { dataset, routes, user } = this.props;
+    const { dataset, user } = this.props;
 
-    const isOwnerOrAdmin = (dataset.userId === user.id || user.role === 'ADMIN');
+    const isOwner = dataset.userId === user.id;
+    const isAdmin = user.role === 'ADMIN';
     const isInACollection = belongsToACollection(user, dataset);
 
-    const classNames = classnames({ '-owner': isOwnerOrAdmin });
+    const classNames = classnames({ '-owner': isOwner && !isAdmin });
 
     const starIconName = classnames({
       'icon-star-full': isInACollection,
@@ -61,9 +55,9 @@ class DatasetsListCard extends PureComponent {
       <div className={`c-card c-datasets-list-card ${classNames}`}>
         <div className="card-container">
           <header className="card-header">
-            {isOwnerOrAdmin &&
+            {isAdmin &&
               <Link
-                route={routes.detail}
+                route="admin_data_detail"
                 params={{ tab: 'datasets', id: dataset.id }}
               >
                 <a>
@@ -74,10 +68,23 @@ class DatasetsListCard extends PureComponent {
               </Link>
             }
 
-            {!isOwnerOrAdmin &&
+            {!isAdmin && !isOwner &&
               <Link
                 route="explore_detail"
                 params={{ id: dataset.id }}
+              >
+                <a>
+                  <Title className="-default">
+                    {this.getDatasetName()}
+                  </Title>
+                </a>
+              </Link>
+            }
+
+            {!isAdmin && isOwner &&
+              <Link
+                route="myrw_detail"
+                params={{ tab: 'datasets', id: dataset.id }}
               >
                 <a>
                   <Title className="-default">
@@ -121,7 +128,7 @@ class DatasetsListCard extends PureComponent {
             }
           </div>
 
-          {isOwnerOrAdmin &&
+          {isOwner && !isAdmin &&
             <div className="actions">
               <a
                 onKeyPress={this.handleDelete}

--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
@@ -51,48 +51,23 @@ class DatasetsListCard extends PureComponent {
       'icon-star-empty': !isInACollection
     });
 
+    const linkProps = {
+      ...isAdmin && { route: 'admin_data_detail', params: { tab: 'datasets', id: dataset.id } },
+      ...!isAdmin && (isOwner ? { route: 'myrw_detail', params: { tab: 'datasets', id: dataset.id } }
+        : { route: 'explore_detail', params: { id: dataset.id } })
+    };
+
     return (
       <div className={`c-card c-datasets-list-card ${classNames}`}>
         <div className="card-container">
           <header className="card-header">
-            {isAdmin &&
-              <Link
-                route="admin_data_detail"
-                params={{ tab: 'datasets', id: dataset.id }}
-              >
-                <a>
-                  <Title className="-default">
-                    {this.getDatasetName()}
-                  </Title>
-                </a>
-              </Link>
-            }
-
-            {!isAdmin && !isOwner &&
-              <Link
-                route="explore_detail"
-                params={{ id: dataset.id }}
-              >
-                <a>
-                  <Title className="-default">
-                    {this.getDatasetName()}
-                  </Title>
-                </a>
-              </Link>
-            }
-
-            {!isAdmin && isOwner &&
-              <Link
-                route="myrw_detail"
-                params={{ tab: 'datasets', id: dataset.id }}
-              >
-                <a>
-                  <Title className="-default">
-                    {this.getDatasetName()}
-                  </Title>
-                </a>
-              </Link>
-            }
+            <Link {...linkProps}>
+              <a>
+                <Title className="-default">
+                  {this.getDatasetName()}
+                </Title>
+              </a>
+            </Link>
 
             <Title className="-small">
               {dataset.provider}

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -396,7 +396,17 @@ class WidgetCard extends PureComponent {
   }
 
   handleEditWidget = () => {
-    Router.pushRoute('myrw_detail', { tab: 'widgets', subtab: 'edit', id: this.props.widget.id });
+    const { user: { role, id }, widget } = this.props;
+    const isOwner = widget.userId === id;
+    const isAdmin = role === 'ADMIN';
+
+    if (isAdmin) {
+      Router.pushRoute('admin_data_detail', { tab: 'widgets', subtab: 'edit', id: widget.id, dataset: widget.dataset });
+    } else if (isOwner) {
+      Router.pushRoute('myrw_detail', { tab: 'widgets', subtab: 'edit', id: widget.id });
+    } else {
+      Router.pushRoute('myrw_detail', { tab: 'widget_detail', id: widget.id });
+    }
   }
 
   handleGoToDataset = () => {


### PR DESCRIPTION
## Overview
This PR improves the links dataset cards are pointing to when visualizing the datasets included in a user collection in MyRW.

## Testing instructions
Go to `http://localhost:9000/myrw/collections`, create a collection that includes both datasets that you own and public ones. Check that the cards are pointing to the right pages according to the specification included in the PT tasks linked below.
_This feature should ideally be tested both by a `"normal"` user account and an `admin` account._

## [Pivotal task](https://www.pivotaltracker.com/story/show/167509722)

_PS: The `delete` button is only shown for normal users on purpose since it makes more sense for admins to manage contents directly from the back office_
