### PR TITLE
Applications read-only field added to dataset form in the back office

### DIFF
--- a/components/datasets/form/steps/Step1.js
+++ b/components/datasets/form/steps/Step1.js
@@ -194,7 +194,8 @@ class Step1 extends React.Component {
                 name: 'applications',
                 label: 'Applications',
                 disabled: true,
-                default: '-',
+                readOnly: true,
+                default: application,
                 value: application
               }}
             >

--- a/components/datasets/form/steps/Step1.js
+++ b/components/datasets/form/steps/Step1.js
@@ -144,7 +144,7 @@ class Step1 extends React.Component {
   render() {
     const { user, columns, loadingColumns, basic } = this.props;
     const { dataset, subscribableSelected } = this.state;
-    const { provider, columnFields } = this.state.form;
+    const { provider, columnFields, application } = this.state.form;
 
     // Reset FORM_ELEMENTS
     FORM_ELEMENTS.elements = {};
@@ -184,6 +184,21 @@ class Step1 extends React.Component {
               }}
             >
               {Select}
+            </Field>}
+
+          {(user.role === 'ADMIN' && !basic && !!dataset) &&
+            <Field
+              ref={(c) => { if (c) FORM_ELEMENTS.elements.applications = c; }}
+              className="-fluid"
+              properties={{
+                name: 'applications',
+                label: 'Applications',
+                disabled: true,
+                default: '-',
+                value: application
+              }}
+            >
+              {Input}
             </Field>}
 
           {user.role === 'ADMIN' && !basic &&


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/63846955-1d42ce80-c98d-11e9-812b-01ce89342ce0.png)

## Overview
This PR adds a read-only field to the dataset form in the back office showing the applications the dataset is currently associated to.

## Testing instructions
Check any dataset form in the back office.

## [Pivotal task](https://www.pivotaltracker.com/story/show/168161903)
