### PR TITLE
Fix issue with widget creation in MyRW

### DIFF
--- a/services/WidgetService.js
+++ b/services/WidgetService.js
@@ -34,7 +34,8 @@ export default class WidgetService {
   saveUserWidget(widget, datasetId, token) {
     const widgetObj = {
       application: [process.env.APPLICATIONS],
-      env: process.env.API_ENV,
+      // env: process.env.API_ENV, This is commented out since otherwise the widget ends up
+      // having a env value equals to `production,preproduction`, which is not allowed.
       published: false,
       default: false,
       dataset: datasetId


### PR DESCRIPTION
## Overview
This PR prevents the `env` property to have the value `production,preproduction` which was occurring prior to this fix.

## Testing instructions
Create a new widget in MyRW