### PR TITLE
Various improvements for datasets

### DIFF
--- a/components/admin/data/datasets/pages/new/component.js
+++ b/components/admin/data/datasets/pages/new/component.js
@@ -8,7 +8,7 @@ import DatasetsForm from 'components/datasets/form/DatasetsForm';
 class DatasetsNew extends PureComponent {
   static propTypes = { user: PropTypes.object.isRequired }
 
-  handleSubmit = () => { Router.pushRoute('admin_data', { tab: 'datasets' }); }
+  handleSubmit = (id) => { Router.pushRoute('admin_data_detail', { tab: 'datasets', id }); }
 
   render() {
     const { user: { token } } = this.props;

--- a/components/admin/data/datasets/pages/new/component.js
+++ b/components/admin/data/datasets/pages/new/component.js
@@ -19,6 +19,7 @@ class DatasetsNew extends PureComponent {
           application={[process.env.APPLICATIONS]}
           authorization={token}
           onSubmit={this.handleSubmit}
+          basic={false}
         />
       </div>
     );

--- a/components/admin/data/datasets/pages/show/component.js
+++ b/components/admin/data/datasets/pages/show/component.js
@@ -51,6 +51,7 @@ class DatasetsShow extends PureComponent {
                   application={[process.env.APPLICATIONS]}
                   authorization={user.token}
                   dataset={id}
+                  basic={false}
                   onSubmit={() => { Router.pushRoute('admin_data', { tab: 'datasets' }); }}
                 />)
               }

--- a/components/admin/data/datasets/pages/show/component.js
+++ b/components/admin/data/datasets/pages/show/component.js
@@ -52,7 +52,6 @@ class DatasetsShow extends PureComponent {
                   authorization={user.token}
                   dataset={id}
                   basic={false}
-                  onSubmit={() => { Router.pushRoute('admin_data', { tab: 'datasets' }); }}
                 />)
               }
 
@@ -61,7 +60,6 @@ class DatasetsShow extends PureComponent {
                   application={process.env.APPLICATIONS}
                   authorization={user.token}
                   dataset={id}
-                  onSubmit={() => { Router.pushRoute('admin_data', { tab: 'datasets', id }); }}
                 />)
               }
 

--- a/components/datasets/form/DatasetsForm.js
+++ b/components/datasets/form/DatasetsForm.js
@@ -192,7 +192,7 @@ class DatasetsForm extends PureComponent {
                 'Success',
                 `The dataset "${data.id}" - "${data.name}" has been uploaded correctly`
               );
-              if (this.props.onSubmit) this.props.onSubmit();
+              if (this.props.onSubmit) this.props.onSubmit(data.id);
             })
             .catch((err) => {
               this.setState({ submitting: false });

--- a/pages/app/explore-detail/index.js
+++ b/pages/app/explore-detail/index.js
@@ -23,7 +23,7 @@ class ExploreDetailPage extends PureComponent {
     setCountView: PropTypes.func.isRequired
   };
 
-  static async getInitialProps({ store, res  }) {
+  static async getInitialProps({ store, res }) {
     const { dispatch, getState } = store;
     const { routes: { query: { id: queryId } } } = getState();
 
@@ -33,7 +33,7 @@ class ExploreDetailPage extends PureComponent {
     // Check if the dataset exists and it is published
     const { exploreDetail } = store.getState();
     const dataset = exploreDetail.data;
-    if ((!dataset && res) || (dataset && res && !dataset.published)) res.statusCode = 404;
+    // if ((!dataset && res) || (dataset && res && !dataset.published)) res.statusCode = 404;
 
     const { id, vocabulary } = dataset;
 

--- a/pages/app/explore-detail/index.js
+++ b/pages/app/explore-detail/index.js
@@ -33,6 +33,7 @@ class ExploreDetailPage extends PureComponent {
     // Check if the dataset exists and it is published
     const { exploreDetail } = store.getState();
     const dataset = exploreDetail.data;
+    // This line has temporarily been commented out meanwhile we implement a more robust and structured approach for this
     // if ((!dataset && res) || (dataset && res && !dataset.published)) res.statusCode = 404;
 
     const { id, vocabulary } = dataset;


### PR DESCRIPTION
## Overview
This PR includes the following improvements:
1. Remove front-end 'wall' preventing unpublished datasets to be visible in Explore detail
2. The user should stay in the dataset form page after clicking on save/update
3. Fix for an issue that prevented some fields to appear in the dataset form page from the back office _(e.g. the published check box)_.

## Testing instructions
1. Try opening the dataset detail page for a dataset that has `published=false`, e.g. the following http://localhost:9000/data/explore/8d84f6c6-8e7d-410e-a408-cbfb2555b35d
2. Go to a dataset form in the back office and try updating/creating a dataset to verify that you're not redirected to the datasets table page.

## Pivotal tasks
- https://www.pivotaltracker.com/story/show/168309844
- https://www.pivotaltracker.com/story/show/168309771