### PR TITLE
Prevent wrong env values to be set when creating/updating subscriptions

### DIFF
--- a/services/user.js
+++ b/services/user.js
@@ -186,7 +186,6 @@ export default class UserService {
     const bodyObj = {
       name,
       application: process.env.APPLICATIONS,
-      env: process.env.API_ENV,
       language: language || 'en',
       datasets,
       datasetsQuery,
@@ -214,7 +213,6 @@ export default class UserService {
   updateSubscriptionToArea(subscriptionId, datasets, datasetsQuery, user, language) {
     const bodyObj = {
       application: process.env.APPLICATIONS,
-      env: process.env.API_ENV,
       language: language || 'en',
       datasets,
       datasetsQuery


### PR DESCRIPTION
## Overview
This PR fixes the issue consisting of setting wrong `env` values when creating/updating a subscription.

## Testing instructions
Follow the instructions specified in the PT task mentioned below.

## [Pivotal task](https://www.pivotaltracker.com/story/show/168381824)