### PR TITLE
Myrw --> Vizualizations: show most recent widgets first

### DIFF
--- a/components/app/myrw/widgets/tabs/list/initial-state.js
+++ b/components/app/myrw/widgets/tabs/list/initial-state.js
@@ -1,6 +1,6 @@
 export default {
   display: 'grid',
-  sort: 'asc',
+  sort: 'desc',
   search: '',
   pagination: {
     page: 1,


### PR DESCRIPTION
## Overview
This PR updates the way widgest are displayed so that the most recent are shown first.

## Testing instructions
Go to `http://localhost:9000/myrw/widgets/my_widgets` and verify that widgets are sorted by their modification date showing the most recent first.

## [Pivotal task](https://www.pivotaltracker.com/story/show/168335188)