### PR TITLE
Fix issue consisting of subscriptions not showing up in the AOI section

### DIFF
--- a/components/areas/AreaCard.js
+++ b/components/areas/AreaCard.js
@@ -217,14 +217,6 @@ class AreaCard extends React.Component {
               activeArea={area}
               onRequestClose={() => this.handleEditSubscription(false)}
             />
-            {/* <AreaSubscriptionModal
-              area={this.props.area}
-              mode={this.state.modal.mode}
-              onRequestClose={() => this.handleEditSubscription(false)}
-              subscriptionDataset
-              subscriptionType
-              subscriptionThreshold
-            /> */}
           </Modal>}
 
       </div>

--- a/components/modal/subscriptions-modal/actions.js
+++ b/components/modal/subscriptions-modal/actions.js
@@ -170,7 +170,7 @@ export const createSubscriptionToArea = createThunkAction('SUBSCRIPTIONS__CREATE
     const { subscriptions, user, common } = getState();
     const { userSelection } = subscriptions;
     const { area, datasets } = userSelection;
-    const { areaId } = area;
+    const areaId = area.id;
     const { locale } = common;
 
     const datasetIds = datasets.map(dataset => dataset.id);


### PR DESCRIPTION
## Overview
This PR fixes the issue that prevented subscriptions from being displayed in the area cards from the section `Areas of interest` in MyRW.

## Testing instructions
Go to `http://localhost:9000/myrw/areas` and try creating/updating a few area subscriptions

## [Pivotal task](https://www.pivotaltracker.com/story/show/167703130)