### PR TITLE
Use metadata title in subscribe to alerts modal from explore detail

### DIFF
--- a/components/modal/subscriptions-modal/dataset/component.js
+++ b/components/modal/subscriptions-modal/dataset/component.js
@@ -147,7 +147,8 @@ class DatasetSubscriptionsModal extends PureComponent {
 
     const { success } = subscription;
 
-    if (Object.keys(activeDataset).length) headerText = `Subscribe to ${activeDataset.name || activeDataset.attributes.name}`;
+    const datasetName = activeDataset && activeDataset.metadata && activeDataset.metadata.name;
+    if (Object.keys(activeDataset).length) headerText = `Subscribe to ${datasetName}`;
     if (activeArea) headerText = `${activeArea.attributes.name} subscriptions`;
 
     const paragraphText = success ?


### PR DESCRIPTION
## Overview
This PR fixes the dataset name used in the `Subscribe to alerts` modal from the Explore detail page.

## Testing instructions
E.g. go to http://localhost:9000/data/explore/VIIRS-Active-Fire-Global-1490086842549 and click on the button `Subscribe to alerts`

## [Pivotal task](https://www.pivotaltracker.com/story/show/168598521)