### PR TITLE
Add checkbox to newsletter page

### DIFF
--- a/layout/app/newsletter/component.js
+++ b/layout/app/newsletter/component.js
@@ -174,7 +174,7 @@ class LayoutNewsletter extends PureComponent {
                       onChange={value =>
                         this.onChange({ resource_watch_feature_test_group: value.checked })}
                       properties={{
-                        name: 'published',
+                        name: 'resource_watch_feature_test_group',
                         defaultChecked: true,
                         title: 'Are you interested in testing or providing feedback on new features?'
                       }}

--- a/layout/app/newsletter/component.js
+++ b/layout/app/newsletter/component.js
@@ -8,6 +8,7 @@ import Breadcrumbs from 'components/ui/Breadcrumbs';
 import Field from 'components/form/Field';
 import Input from 'components/form/Input';
 import Select from 'components/form/SelectInput';
+import Checkbox from 'components/form/Checkbox';
 import Modal from 'components/modal/modal-component';
 import NewsletterConfirmationModal from 'components/modal/newsletter-confirmation-modal';
 
@@ -168,6 +169,19 @@ class LayoutNewsletter extends PureComponent {
                     </Field>
                   </div>
 
+                  <div className="form-row">
+                    <Field
+                      onChange={value =>
+                        this.onChange({ resource_watch_feature_test_group: value.checked })}
+                      properties={{
+                        name: 'published',
+                        defaultChecked: true,
+                        title: 'Are you interested in testing or providing feedback on new features?'
+                      }}
+                    >
+                      {Checkbox}
+                    </Field>
+                  </div>
                   { /* pardot honeypot field */}
                   <Field
                     className="-pi-hidden"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/65582452-bd384b80-df7d-11e9-95d7-318acd711812.png)

## Overview
This PR adds a checkbox to the Newsletter page according to the specification included in the PT task.

## Testing instructions
Go to http://localhost:9000/about/newsletter and verify that the new checkbox is displayed and the new field is sent as part of the request.

## [Pivotal task](https://www.pivotaltracker.com/story/show/168664531)