### PR TITLE
Show areas when there are no subscriptions

### DIFF
--- a/redactions/user.js
+++ b/redactions/user.js
@@ -481,6 +481,8 @@ export const getUserAreas = createThunkAction(
                 );
                 dispatch(setUserAreas(userAreasWithSubscriptions));
               });
+          } else {
+            dispatch(setUserAreas(userAreas));
           }
         }));
     }


### PR DESCRIPTION
## Overview
This PR fixes the bug that prevented AOI to be displayed when the user didn't have any subscription set up in the app.

## Testing instructions
Go to MyRW --> AOI, make sure that you don't have any subscription created in RW and verify that your AOIs are displayed nonetheless.

## [Pivotal task](https://www.pivotaltracker.com/story/show/168833300)