### PR TITLE
Fix couple minor errors in Areas of interest (Account)

### DIFF
--- a/components/modal/subscriptions-modal/dataset-manager/component.js
+++ b/components/modal/subscriptions-modal/dataset-manager/component.js
@@ -142,7 +142,7 @@ class DatasetManager extends Component {
       <div className="c-dataset-manager">
         {selectedDatasets.map((_selectedDataset, index) => (
           <div
-            key={_selectedDataset.id}
+            key={index}
             className="selectors-container"
           >
             <Field

--- a/services/subscriptions.js
+++ b/services/subscriptions.js
@@ -30,7 +30,7 @@ export const fetchSubscriptions = (token, params) => {
 
       return WRISerializer(data);
     })
-    .catch(({ response }) => {
+    .catch(({ response = {} }) => {
       const { status, statusText } = response;
       logger.error(`Error fetching subscriptions: ${status}: ${statusText}`);
       throw new Error(`Error fetching subscriptions: ${status}: ${statusText}`);


### PR DESCRIPTION
## Overview
1. Fixed warning in the browser console

> Encountered two children with the same key, `815eaa09-d626-495e-91e2-523cb07de475`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

2. Fixed Unhandled Rejection

> Cannot read property 'status' of undefined 
./services/subscriptions.js:33

## Testing instructions
1. Areas of Interest > Area Options > Edit subscriptions > select two the same Datasets.
2. Fired couple times. Now I can't reproduce.

## Pivotal task
https://www.pivotaltracker.com/n/projects/1374154/stories/168839729