### PR TITLE
Added is-highlighted parameter admin/dashboards/ (add/edit) page

### DIFF
--- a/components/dashboards/form/steps/step-1/component.js
+++ b/components/dashboards/form/steps/step-1/component.js
@@ -210,7 +210,7 @@ class Step1 extends PureComponent {
                 name: 'is-highlighted',
                 label: 'Highlight in Dashboards gallery',
                 value: 'is-highlighted',
-                title: 'Is Highlighted',
+                title: 'Is highlighted',
                 defaultChecked: this.props.form['is-highlighted'],
                 checked: this.props.form['is-highlighted']
               }}

--- a/components/dashboards/form/steps/step-1/component.js
+++ b/components/dashboards/form/steps/step-1/component.js
@@ -200,6 +200,24 @@ class Step1 extends PureComponent {
               {Checkbox}
             </Field>
           }
+
+          {/* IS-HIGHLIGHTED */}
+          {!this.props.basic &&
+            <Field
+              ref={(c) => { if (c) FORM_ELEMENTS.elements['is-highlighted'] = c; }}
+              onChange={value => this.props.onChange({ 'is-highlighted': value.checked })}
+              properties={{
+                name: 'is-highlighted',
+                label: 'Highlight in Dashboards gallery',
+                value: 'is-highlighted',
+                title: 'Is Highlighted',
+                defaultChecked: this.props.form['is-highlighted'],
+                checked: this.props.form['is-highlighted']
+              }}
+            >
+              {Checkbox}
+            </Field>
+          }
         </fieldset>
 
         <fieldset className="c-field-container">


### PR DESCRIPTION
## Overview
This PR adds a checkbox to the http://localhost:9000/admin/dashboards/dashboards/29/edit. Checkbox sets 'is-highlighted' parameter. Based on API docs https://resource-watch.github.io/doc-api/index-rw.html#what-is-a-dashboard i set 'is-highlighted' instead of is_highlighted.
   
## Testing instructions
Use staging API. Go to  /admin/dashboards page. Click edit/add dashboard. Check or uncheck Is Highlighted field. Click Save.

## [Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/169733188)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
