### PR TITLE
Added is featured option to admin/dashboards new/edit page

### DIFF
--- a/components/dashboards/form/steps/step-1/component.js
+++ b/components/dashboards/form/steps/step-1/component.js
@@ -218,6 +218,24 @@ class Step1 extends PureComponent {
               {Checkbox}
             </Field>
           }
+
+          {/* IS-FEATURED */}
+          {!this.props.basic &&
+            <Field
+              ref={(c) => { if (c) FORM_ELEMENTS.elements['is-featured'] = c; }}
+              onChange={value => this.props.onChange({ 'is-featured': value.checked })}
+              properties={{
+                name: 'is-featured',
+                label: 'Add to Featured dashboards',
+                value: 'is-featured',
+                title: 'Featured',
+                defaultChecked: this.props.form['is-featured'],
+                checked: this.props.form['is-featured']
+              }}
+            >
+              {Checkbox}
+            </Field>
+          }
         </fieldset>
 
         <fieldset className="c-field-container">


### PR DESCRIPTION
## Overview
This PR adds a checkbox to the http://localhost:9000/admin/dashboards/dashboards/29/edit. Checkbox sets 'is-featured' parameter. 
## Testing instructions
Use staging API. Go to /admin/dashboards page. Click edit/add dashboard. Check or uncheck Featured field. Click Save.
## [Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/170311595)

⚠️  **This PR is blocked until the following API task has been completed:** https://www.pivotaltracker.com/story/show/170311586
