### PR TITLE
Dashboards gallery item (dashboards detail) and topic (topics detail) are open on the same route

### DIFF
--- a/components/dashboards/thumbnail-list/component.js
+++ b/components/dashboards/thumbnail-list/component.js
@@ -19,7 +19,7 @@ class DashboardThumbnailList extends PureComponent {
             style={{ backgroundImage: `url(${_dashboard.photo.original})` }}
           >
             <Link
-              to="dashboards_detail_custom"
+              to="dashboards_detail"
               params={{ slug: _dashboard.slug }}
             >
               <a><span>{_dashboard.name}</span></a>

--- a/layout/app/topics-detail/component.js
+++ b/layout/app/topics-detail/component.js
@@ -100,7 +100,7 @@ class TopicDetailLayout extends PureComponent {
                   <TopicThumbnailList
                     onSelect={({ slug: _slug }) => {
                       // We need to make an amendment in the Wysiwyg to have this working
-                      Router.pushRoute('dashboards_detail', { id: _slug })
+                      Router.pushRoute('dashboards_detail', { slug: _slug, topic: true })
                         .then(() => { window.scrollTo(0, 0); });
                     }}
                   />

--- a/layout/footer/selectors.js
+++ b/layout/footer/selectors.js
@@ -13,7 +13,7 @@ const setDashboardsLinks = (_dashboards) => {
   const dashLinks = _dashboards.map(_dashboard => ({
     label: _dashboard.name,
     route: 'dashboards_detail',
-    params: { id: _dashboard.slug }
+    params: { slug: _dashboard.slug, topic: true }
   }));
   dashLinks.push({
     label: 'More',

--- a/layout/header/constants.js
+++ b/layout/header/constants.js
@@ -20,16 +20,7 @@ export const APP_HEADER_ITEMS = [
     label: 'Dashboards',
     route: 'dashboards',
     pathnames: ['/app/dashboards', '/app/dashboards-detail'],
-    children: [
-      { label: 'Cities', route: 'dashboards_detail', params: { id: 'cities' } },
-      { label: 'Climate', route: 'dashboards_detail', params: { id: 'climate' } },
-      { label: 'Energy', route: 'dashboards_detail', params: { id: 'energy' } },
-      { label: 'Food', route: 'dashboards_detail', params: { id: 'food' } },
-      { label: 'Forests', route: 'dashboards_detail', params: { id: 'forests' } },
-      { label: 'Society', route: 'dashboards_detail', params: { id: 'society' } },
-      { label: 'Oceans', route: 'dashboards_detail', params: { id: 'oceans' } },
-      { label: 'Water', route: 'dashboards_detail', params: { id: 'water' } }
-    ]
+    children: []
   },
   {
     id: 'blog',

--- a/layout/header/header-dashboards/selectors.js
+++ b/layout/header/header-dashboards/selectors.js
@@ -8,7 +8,7 @@ export const parseTopics = createSelector(
     .map(_topic => ({
       label: _topic.name,
       route: 'dashboards_detail',
-      params: { id: _topic.slug }
+      params: { slug: _topic.slug, topic: true }
     }))
 );
 

--- a/layout/topics/component.js
+++ b/layout/topics/component.js
@@ -61,7 +61,7 @@ class TopicsLayout extends PureComponent {
                 <TopicThumbnailList
                   onSelect={({ slug }) => {
                     // We need to make an amendment in the Wysiwyg to have this working
-                    Router.pushRoute('dashboards_detail', { id: slug })
+                    Router.pushRoute('dashboards_detail', { slug, topic: true })
                       .then(() => {
                         window.scrollTo(0, 0);
                       });

--- a/pages/app/dashboards-detail/index.js
+++ b/pages/app/dashboards-detail/index.js
@@ -1,21 +1,67 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import isEmpty from 'lodash/isEmpty';
+
 
 // actions
 import { getDashboard } from 'modules/dashboards/actions';
+import { getTopic, setSelected } from 'modules/topics/actions';
 
 // components
 import LayoutDashboardDetail from 'layout/app/dashboard-detail';
+import TopicDetailLayout from 'layout/app/topics-detail';
+import Error from 'pages/_error';
 
 class DashboardsDetailPage extends PureComponent {
-  static async getInitialProps({ store, query }) {
-    const { slug } = query;
-    await store.dispatch(getDashboard(slug));
-    return {};
+  static propTypes = {
+    topicsDetail: PropTypes.object.isRequired,
+    routes: PropTypes.object.isRequired,
+    setSelected: PropTypes.func.isRequired
+  };
+
+  static async getInitialProps({ store }) {
+    const { dispatch, getState } = store;
+    const { routes: { query: { slug, topic } } } = getState();
+
+    if (topic) {
+      await dispatch(getTopic(slug));
+      // sets current topic in thumbnail list
+      dispatch(setSelected(slug));
+    } else {
+      await store.dispatch(getDashboard(slug));
+    }
+
+    return { };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.routes.query.slug !== nextProps.routes.query.slug) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  componentWillUnmount() {
+    this.props.setSelected(null);
   }
 
   render() {
-    return (<LayoutDashboardDetail />);
+    const { routes: { query: { topic } } } = this.props;
+
+    if (topic) {
+      const { topicsDetail } = this.props;
+      if (isEmpty(topicsDetail)) return <Error statusCode={404} />;
+      return <TopicDetailLayout />;
+    }
+
+    return <LayoutDashboardDetail />;
   }
 }
 
-export default DashboardsDetailPage;
+export default connect(
+  state => ({
+    topicsDetail: state.topics.detail.data,
+    routes: state.routes
+  }),
+  { setSelected }
+)(DashboardsDetailPage);

--- a/routes.js
+++ b/routes.js
@@ -56,8 +56,7 @@ routes.add('pulse', '/data/pulse', 'app/pulse');
 
 // ----- DASHBOARDS -----
 routes.add('dashboards', '/dashboards', 'app/topics');
-routes.add('dashboards_detail', '/dashboards/:id', 'app/topics-detail');
-routes.add('dashboards_detail_custom', '/data/dashboards/:slug', 'app/dashboards-detail');
+routes.add('dashboards_detail', '/dashboards/:slug', 'app/dashboards-detail');
 
 routes.add('widget_detail', '/data/widget/:id', 'app/widget-detail');
 


### PR DESCRIPTION
## Overview
This PR updates the routes for dashboards detail and topics detail pages. 
All dashboard detail pages are available on route /dashboards/:slug. 
All topics detail pages are available on route  /dashboards/:slug?topic=true.
In future PR we will remove topics links from project. topic=true is used to identify topic layout. Topic links will be removed in [this task](https://www.pivotaltracker.com/n/projects/1374154/stories/170311607)
## Testing instructions
Open /dashboards page.
Click on featured dashboards item: you will go to /dashboards/:slug?topic=true
Click on dashboard gallery item: you will go to /dashboards/:slug
## [Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/170311468)
---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
