### PR TITLE
Restore backoffice interaction to provide column names for selection

### DIFF
--- a/components/admin/data/layers/form/interactions/actions.js
+++ b/components/admin/data/layers/form/interactions/actions.js
@@ -26,7 +26,8 @@ export const getAvailableLayerInteractions = createThunkAction('LAYER-INTERACTIO
   if (layer && layer.provider !== 'wms') {
     const url = getFieldUrl({ id: layer.dataset });
     return fetchFields(url)
-      .then((rawFields) => {
+      .then((response) => {
+        const rawFields = response.fields;
         const parsedFields = ((rawFields && Object.keys(rawFields)) || []).map((fKey) => {
           const { type } = rawFields[fKey] || null;
           return { label: fKey || '', value: fKey || '', type };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/71160433-d3396d80-2247-11ea-9a1a-c1536a987a4d.png)

## Overview
This PR fixes the issue consisting of a wrong initialization of the columns interaction selector from the layer form in the back office.

## Testing instructions
Go to http://localhost:9000/admin/data/layers/dabcca67-037c-4d11-afc4-69559edec4dc/edit?dataset=de452a4c-a55c-464d-9037-8c3e9fe48365 and verify that all fields appear in the drop-down selector.

## [Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/169470700)