### PR TITLE
Changes to the Planet Pulse page

### DIFF
--- a/layout/app/pulse/component.js
+++ b/layout/app/pulse/component.js
@@ -20,6 +20,7 @@ import LayerCard from 'layout/app/pulse/layer-card';
 import Spinner from 'components/ui/Spinner';
 import GlobeTooltip from 'layout/app/pulse/globe-tooltip';
 import GlobeCesium from 'components/vis/globe-cesium';
+import WelcomeModal from 'layout/app/pulse/welcome-modal';
 
 // utils
 import LayerGlobeManager from 'utils/layers/LayerGlobeManager';
@@ -78,9 +79,7 @@ class LayoutPulse extends PureComponent {
     const newId = (nextLayerActive) ? nextLayerActive.id : null;
     if (lastId !== newId) {
       if (nextLayerActive) {
-        this.setState({
-          interactionConfig: nextLayerActive.attributes.interactionConfig
-        });
+        this.setState({ interactionConfig: nextLayerActive.attributes.interactionConfig });
 
         if (nextLayerActive.threedimensional) {
           const url = nextLayerActive.attributes.layerConfig.pulseConfig.url;
@@ -232,13 +231,14 @@ class LayoutPulse extends PureComponent {
 
     return (
       <Layout
-        title="Planet Pulse — Resource Watch"
-        description="Planet Pulse provides a snapshot of our changing world."
+        title="Near Real-Time Data — Resource Watch"
+        description="Near Real-Time Data provides a snapshot of our changing world."
         className="l-pulse"
       >
         <div
           className="pulse-container -dark"
         >
+          <WelcomeModal />
           <Spinner
             isLoading={
               pulse.loading ||

--- a/layout/app/pulse/welcome-modal/component.js
+++ b/layout/app/pulse/welcome-modal/component.js
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'routes';
+import Modal from 'components/modal/modal-component';
+import Checkbox from 'components/form/Checkbox';
+
+const DONT_SHOW_AGAIN_KEY = 'rw_hide_pulse_welcome';
+
+const WelcomeModal = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  const [hideChecked, hideCheckedChange] = useState(false);
+
+  const getDontShowAgain = () => localStorage.getItem(DONT_SHOW_AGAIN_KEY) === 'true';
+  const dontShowAgain = () => localStorage.setItem(DONT_SHOW_AGAIN_KEY, 'true');
+
+  const closePopup = () => {
+    setIsOpen(false);
+    if (hideChecked) {
+      dontShowAgain();
+    }
+  };
+
+  useEffect(() => {
+    if (getDontShowAgain()) {
+      setIsOpen(false);
+    }
+  }, []);
+
+  return (
+    <Modal isOpen={isOpen} onRequestClose={closePopup}>
+      <div className="c-layer-info-modal">
+        <div className="layer-info-content">
+          <h2>Near Real-Time Data</h2>
+          <p>
+            Track natural disasters, monitor the changing environment, and observe human events with this selection of Resource Watch's most timely data. All data visualized on the globe are frequently updated by the data provider, from twice daily to monthly.
+            <br />Subscribe to alerts to get updates on world events as they unfold.
+          </p>
+          <p>
+            See these and more near real-time data on&nbsp;
+            <Link route="explore">
+              <a>Explore</a>
+            </Link>
+          </p>
+          <div className="row">
+            <div className="column small-12">
+              <div className="buttons" style={{ alignItems: 'center' }}>
+                <Checkbox
+                  properties={{
+                    name: 'hideCheck',
+                    value: 'hideCheck',
+                    title: 'Don\'t show me again',
+                    checked: hideChecked
+                  }}
+                  onChange={({ checked }) => hideCheckedChange(checked)}
+                />
+                <button className="c-btn -primary" onClick={closePopup}>
+                  Continue
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default WelcomeModal;

--- a/layout/app/pulse/welcome-modal/component.js
+++ b/layout/app/pulse/welcome-modal/component.js
@@ -40,23 +40,19 @@ const WelcomeModal = () => {
               <a>Explore</a>
             </Link>
           </p>
-          <div className="row">
-            <div className="column small-12">
-              <div className="buttons" style={{ alignItems: 'center' }}>
-                <Checkbox
-                  properties={{
-                    name: 'hideCheck',
-                    value: 'hideCheck',
-                    title: 'Don\'t show me again',
-                    checked: hideChecked
-                  }}
-                  onChange={({ checked }) => hideCheckedChange(checked)}
-                />
-                <button className="c-btn -primary" onClick={closePopup}>
-                  Continue
-                </button>
-              </div>
-            </div>
+          <div className="buttons" style={{ alignItems: 'center' }}>
+            <Checkbox
+              properties={{
+                name: 'hideCheck',
+                value: 'hideCheck',
+                title: 'Don\'t show me again',
+                checked: hideChecked
+              }}
+              onChange={({ checked }) => hideCheckedChange(checked)}
+            />
+            <button className="c-btn -primary" onClick={closePopup}>
+              Continue
+            </button>
           </div>
         </div>
       </div>

--- a/layout/app/pulse/welcome-modal/index.js
+++ b/layout/app/pulse/welcome-modal/index.js
@@ -1,0 +1,11 @@
+import { Component, createElement } from 'react';
+
+import WelcomeModal from './component';
+
+class WelcomeModalContainer extends Component {
+  render() {
+    return createElement(WelcomeModal, { ...this.props });
+  }
+}
+
+export default WelcomeModalContainer;

--- a/layout/footer/constants.js
+++ b/layout/footer/constants.js
@@ -6,7 +6,7 @@ export const FOOTER_LINKS = [
     pathnames: ['/app/explore', '/app/explore-detail', '/app/pulse'],
     children: [
       { label: 'Explore Datasets', route: 'explore' },
-      { label: 'Planet Pulse', href: '/data/pulse' },
+      { label: 'Near Real-Time Data', href: '/data/pulse' },
       {
         label: 'App Gallery',
         route: 'get_involved_detail',

--- a/layout/header/constants.js
+++ b/layout/header/constants.js
@@ -6,7 +6,7 @@ export const APP_HEADER_ITEMS = [
     pathnames: ['/app/explore', '/app/explore-detail', '/app/pulse'],
     children: [
       { label: 'Explore Datasets', route: 'explore' },
-      { label: 'Planet Pulse', href: '/data/pulse' },
+      { label: 'Near Real-Time Data', href: '/data/pulse' },
       {
         label: 'App Gallery',
         route: 'get_involved_detail',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/71166641-7348c400-2253-11ea-9326-63d91eba4722.png)

## Overview
This PR adds a welcome modal to the Planet Pulse page plus renames the links from the footer and header to "Near Real-Time Data".

## Testing instructions
Go to http://localhost:9000/data/pulse

## [Pivotal task](https://www.pivotaltracker.com/story/show/169544926)