### PR TITLE
Main page - topics section to featured dashboards

### DIFF
--- a/layout/app/home/component.js
+++ b/layout/app/home/component.js
@@ -8,7 +8,7 @@ import YouTube from 'react-youtube';
 // components
 import Layout from 'layout/layout/layout-app';
 import Banner from 'components/app/common/Banner';
-import TopicThumbnailList from 'components/topics/thumbnail-list';
+import DashboardThumbnailList from 'components/dashboards/thumbnail-list';
 import BlogFeed from 'components/blog/feed';
 import ExploreCards from 'layout/app/home/explore-cards';
 
@@ -26,21 +26,19 @@ import {
 import './styles.scss';
 
 class LayoutHome extends PureComponent {
-  static propTypes = { responsive: PropTypes.object.isRequired }
+  static propTypes = {
+    responsive: PropTypes.object.isRequired,
+    dashFeatured: PropTypes.array
+  }
+
+  static defaultProps = { dashFeatured: [] };
 
   state = { videoReady: false }
 
   onVideoStateChange = ({ data }) => { this.setState({ videoReady: data === 1 }); };
 
-  handleTopicSelection = ({ slug }) => {
-    // TO-DO: we need to make an amendment in the Wysiwyg to have this working
-    Router.pushRoute('topics_detail', { id: slug }).then(() => {
-      window.scrollTo(0, 0);
-    });
-  }
-
   render() {
-    const { responsive: { fakeWidth } } = this.props;
+    const { responsive: { fakeWidth }, dashFeatured } = this.props;
     const { videoReady } = this.state;
     const videoForegroundClass = classnames(
       'video-foreground',
@@ -116,21 +114,31 @@ class LayoutHome extends PureComponent {
 
         <section className="l-section -secondary">
           <div className="l-container">
-            <header>
-              <div className="row">
-                <div className="column small-12 medium-8">
-                  <h2>Topics</h2>
-                  <p>
-                    Find facts and figures on people and the environment, <br />
-                    or visualize the latest data on the world today.
-                  </p>
+            <div className="dashboards-container">
+              <header>
+                <div className="row">
+                  <div className="column small-12 medium-8">
+                    <div className="c-dashboards-subheader-block">
+                      <h2>Featured dashboards</h2>
+                      <p>
+                        Discover collections of curated data on the major
+                        challenges facing human society and the planet
+                      </p>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </header>
-            <div className="topics-container">
+              </header>
               <div className="row">
                 <div className="column small-12">
-                  <TopicThumbnailList onSelect={this.handleTopicSelection} />
+                  <DashboardThumbnailList
+                    onSelect={({ slug }) => {
+                      Router.pushRoute('dashboards_detail', { slug })
+                        .then(() => {
+                          window.scrollTo(0, 0);
+                        });
+                    }}
+                    dashboards={dashFeatured}
+                  />
                 </div>
               </div>
             </div>

--- a/layout/app/home/index.js
+++ b/layout/app/home/index.js
@@ -4,6 +4,9 @@ import { connect } from 'react-redux';
 import LayoutHome from './component';
 
 export default connect(
-  state => ({ responsive: state.responsive }),
+  state => ({
+    responsive: state.responsive,
+    dashFeatured: state.dashboards.featured.list
+  }),
   null
 )(LayoutHome);

--- a/layout/app/home/styles.scss
+++ b/layout/app/home/styles.scss
@@ -82,10 +82,9 @@
       align-items: center;
     }
   }
-
-  .topics-container {
-    .c-topics-thumbnail-list {
-      margin-top: 50px;
+  .dashboards-container {
+    .c-dashboards-subheader-block {
+      padding-top: 0;
     }
   }
 

--- a/pages/app/home/index.js
+++ b/pages/app/home/index.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 
 // actions
 import { getLatestPosts, getSpotlightPosts } from 'modules/blog/actions';
+import { getFeaturedDashboards } from 'modules/dashboards/actions';
 
 // components
 import LayoutHome from 'layout/app/home';
@@ -15,7 +16,8 @@ class HomePage extends PureComponent {
         spotlightPosts,
         latestPostsError,
         spotlightPostsError
-      }
+      },
+      dashboards: { featured }
     } = getState();
 
 
@@ -26,6 +28,8 @@ class HomePage extends PureComponent {
       await dispatch(getLatestPosts());
       await dispatch(getSpotlightPosts());
     }
+
+    if (!featured.list.length) await dispatch(getFeaturedDashboards());
 
     return {};
   }


### PR DESCRIPTION
## Overview
This PR adds featured dashboards to the main page and remove topics section from the main page
## Testing instructions
Go to the homepage. Check "Featured dashboards" section
## [Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/170446045)
---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
