### PR TITLE
Planet pulse - css dropdown menu fix (for responsive desctop)

### DIFF
--- a/layout/app/pulse/layer-menu-dropdown/styles.scss
+++ b/layout/app/pulse/layer-menu-dropdown/styles.scss
@@ -58,4 +58,17 @@ $translate-dropdown: 5px;
       }
     }
   }
+
+  @media screen and (max-width: map-get($breakpoints, medium)) {
+    top: auto;
+    bottom: 55px;
+
+    &:after {
+      content: "";
+      position: absolute;
+      top: auto;
+      bottom: -8px;
+    }  
+    
+  }
 }


### PR DESCRIPTION
## Overview
This PR fixes CSS for dropdown menu on planet pulse page.  
## Testing instructions
Go to http://localhost:9000/data/pulse
Change browser window size < 780px. Hover data dropdowns.
## [Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/165562659)
---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
