### PR TITLE
Fix the problem when dialogs temporary load when the page loads first time

### DIFF
--- a/css/components/ui/modal.scss
+++ b/css/components/ui/modal.scss
@@ -17,6 +17,7 @@
   &.-hidden {
     opacity: 0;
     visibility: hidden;
+    z-index: -1;
 
     .modal-container {
       transform: translateY(-35px);
@@ -121,5 +122,12 @@
     .modal-container {
       max-width: $max-width-modal-medium;
     }
+  }
+}
+
+
+.c-we-modal {
+  &.-hidden {
+    z-index: -1;
   }
 }


### PR DESCRIPTION
## Overview
This PR fixes the problem when dialogs load dialog temporary load when the page loads first time.
Fixed for Modal element and WidgetModal element. Problem: looks like css sometimes loads with delay and we set modal CSS with transition. 
Since this problem happens in a few components (in widget-editor also), i realized a simple CSS fix that helps to resolve problem in both components and save all transitions and current component code.
## Testing instructions
This issue reproduces only when the build project is running. Use yarn build and yarn start commands.
Reload the main page a few times. The error is not reproduced. 
## [Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/170468472)
---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
