### PR TITLE
Added unsafe prefix to deprecated methods

### DIFF
--- a/components/admin/data/layers/form/interactions/component.js
+++ b/components/admin/data/layers/form/interactions/component.js
@@ -25,7 +25,7 @@ class InteractionManager extends PureComponent {
     resetInteractions: PropTypes.func.isRequired
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const {
       layer,
       getCurrentLayerInteractions,

--- a/components/admin/data/layers/form/layer-preview/component.js
+++ b/components/admin/data/layers/form/layer-preview/component.js
@@ -38,7 +38,7 @@ class LayerPreviewComponent extends PureComponent {
     generateLayerGroups: PropTypes.func.isRequired
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.handleRefreshPreview();
   }
 

--- a/components/admin/data/layers/table/component.js
+++ b/components/admin/data/layers/table/component.js
@@ -40,7 +40,7 @@ class LayersTable extends PureComponent {
     filters: { name: null, 'user.role': 'ADMIN' }
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.loadLayers();
   }
 
@@ -101,7 +101,7 @@ class LayersTable extends PureComponent {
       'page[number]': pagination.page,
       'page[size]': pagination.limit,
       application: process.env.APPLICATIONS,
-      ...dataset && { dataset },
+      ...(dataset && { dataset }),
       ...filters
     }, { Authorization: token }, true)
       .then(({ layers, meta }) => {

--- a/components/admin/data/widgets/form/component.js
+++ b/components/admin/data/widgets/form/component.js
@@ -53,7 +53,7 @@ class WidgetForm extends PureComponent {
     mode: 'editor'
   });
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { locale } = this.props;
     const { id } = this.state;
 

--- a/components/admin/data/widgets/form/steps/Step1.js
+++ b/components/admin/data/widgets/form/steps/Step1.js
@@ -46,7 +46,7 @@ class Step1 extends Component {
     loadingVegaChart: false
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       form: {
         ...nextProps.form,

--- a/components/admin/faqs/form/steps/Step1.js
+++ b/components/admin/faqs/form/steps/Step1.js
@@ -22,7 +22,7 @@ class Step1 extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ form: nextProps.form });
   }
 

--- a/components/admin/pages/form/steps/Step1.js
+++ b/components/admin/pages/form/steps/Step1.js
@@ -22,7 +22,7 @@ class Step1 extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ form: nextProps.form });
   }
 

--- a/components/admin/pages/table/PagesTable.js
+++ b/components/admin/pages/table/PagesTable.js
@@ -55,7 +55,7 @@ class PagesTable extends PureComponent {
     this.props.getPages();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { filteredPages: pages } = this.props;
     const { filteredPages: nextPages } = nextProps;
     const { pagination } = this.state;
@@ -65,7 +65,7 @@ class PagesTable extends PureComponent {
       pagination: {
         ...pagination,
         size: nextPages.length,
-        ...pagesChanged && { page: 1 },
+        ...(pagesChanged && { page: 1 }),
         pages: Math.ceil(nextPages.length / pagination.limit)
       }
     });

--- a/components/admin/partners/form/steps/Step1.js
+++ b/components/admin/partners/form/steps/Step1.js
@@ -22,7 +22,7 @@ class Step1 extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ form: nextProps.form });
   }
 

--- a/components/admin/partners/table/component.js
+++ b/components/admin/partners/table/component.js
@@ -31,7 +31,7 @@ class AdminPartnersTable extends PureComponent {
 
   state = { pagination: INITIAL_PAGINATION }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { list: partners } = this.props;
     const { list: nextPartners } = nextProps;
     const { pagination } = this.state;
@@ -41,7 +41,7 @@ class AdminPartnersTable extends PureComponent {
       pagination: {
         ...pagination,
         size: nextPartners.length,
-        ...partnersChanged && { page: 1 },
+        ...(partnersChanged && { page: 1 }),
         pages: Math.ceil(nextPartners.length / pagination.limit)
       }
     });

--- a/components/admin/tools/form/steps/Step1.js
+++ b/components/admin/tools/form/steps/Step1.js
@@ -21,7 +21,7 @@ class Step1 extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ form: nextProps.form });
   }
 

--- a/components/admin/tools/table/ToolsTable.js
+++ b/components/admin/tools/table/ToolsTable.js
@@ -44,7 +44,7 @@ class ToolsTable extends PureComponent {
     this.props.getTools();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { filteredTools: tools } = this.props;
     const { filteredTools: nextTools } = nextProps;
     const { pagination } = this.state;
@@ -54,7 +54,7 @@ class ToolsTable extends PureComponent {
       pagination: {
         ...pagination,
         size: nextTools.length,
-        ...toolsChanged && { page: 1 },
+        ...(toolsChanged && { page: 1 }),
         pages: Math.ceil(nextTools.length / pagination.limit)
       }
     });

--- a/components/app/myrw/datasets/DatasetWidgets.js
+++ b/components/app/myrw/datasets/DatasetWidgets.js
@@ -22,7 +22,7 @@ class DatasetWidgets extends React.Component {
     orderDirection: 'asc'
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.loadWidgets();
   }
 

--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/index.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/index.js
@@ -21,11 +21,11 @@ class DatasetListContainer extends PureComponent {
     resetDatasets: PropTypes.func.isRequired
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.getDatasetsByTab(this.props.subtab);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { pathname, subtab, orderDirection, pagination } = this.props;
     const { page } = pagination;
     const isMyRW = pathname.startsWith('/myrw');

--- a/components/app/myrw/datasets/pages/my-rw-datasets/index.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/index.js
@@ -14,7 +14,7 @@ class MyRWDatasetsMyContainer extends PureComponent {
     setPaginationPage: PropTypes.func
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { subtab } = this.props;
 
     if (subtab !== nextProps.subtab) {

--- a/components/app/myrw/datasets/pages/show.js
+++ b/components/app/myrw/datasets/pages/show.js
@@ -49,7 +49,7 @@ class DatasetsShow extends React.Component {
 
   state = { data: {} };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { id, user } = this.props;
 
     fetchDataset(id, { includes: 'widget,layer,metadata', userId: user.id })

--- a/components/app/myrw/widgets/tabs/edit.js
+++ b/components/app/myrw/widgets/tabs/edit.js
@@ -52,7 +52,7 @@ class WidgetsEdit extends React.Component {
     name: null
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { id } = this.props;
     fetchWidget(id)
       .then((data) => {

--- a/components/app/myrw/widgets/tabs/new.js
+++ b/components/app/myrw/widgets/tabs/new.js
@@ -59,7 +59,7 @@ class WidgetsNew extends React.Component {
     widget: {}
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.loadDatasets();
   }
 

--- a/components/areas/AlertWidget.js
+++ b/components/areas/AlertWidget.js
@@ -88,7 +88,7 @@ class AlertWidget extends React.Component {
       });
   }
 
-  componentWillUpdate(nextProps) {
+  UNSAFE_componentWillUpdate(nextProps) {
     if ((nextProps.subscriptionData !== this.state.subscriptionData) && !this.state.alertTable) {
       this.getAlertHistory(nextProps).then(table => this.setState({ alertTable: table }));
     }

--- a/components/areas/AreaCard.js
+++ b/components/areas/AreaCard.js
@@ -70,7 +70,7 @@ class AreaCard extends React.Component {
     }
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { area: { geostore: geostoreId, name } } = this.props;
 
     fetchGeostore(geostoreId)
@@ -151,7 +151,7 @@ class AreaCard extends React.Component {
               <Map
                 mapConfig={{
                   ...MAP_CONFIG,
-                  ...bbox && { bbox }
+                  ...(bbox && { bbox })
                 }}
                 LayerManager={LayerManager}
                 layerGroups={[{

--- a/components/collections-list/index.js
+++ b/components/collections-list/index.js
@@ -36,7 +36,7 @@ class CollectionsList extends PureComponent {
 
   state = { pagination: INITIAL_PAGINATION };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { filteredCollections } = this.props;
     const { filteredCollections: nextCollections } = nextProps;
     const { pagination } = this.state;

--- a/components/dashboards/form/steps/step-1/component.js
+++ b/components/dashboards/form/steps/step-1/component.js
@@ -52,7 +52,7 @@ class Step1 extends PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ form: nextProps.form });
   }
 

--- a/components/dashboards/list/DashboardsList.js
+++ b/components/dashboards/list/DashboardsList.js
@@ -50,7 +50,7 @@ class DashboardsList extends React.Component {
     this.props.getDashboards(getDashboardsFilters);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.loading !== this.state.loading) {
       this.setState({ loading: nextProps.loading });
     }

--- a/components/dashboards/table/DashboardsTable.js
+++ b/components/dashboards/table/DashboardsTable.js
@@ -39,7 +39,7 @@ class DashboardsTable extends PureComponent {
     loading: false
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.loadDashboards();
   }
 

--- a/components/datasets/form/DatasetsForm.js
+++ b/components/datasets/form/DatasetsForm.js
@@ -50,7 +50,7 @@ class DatasetsForm extends PureComponent {
     form: Object.assign({}, STATE_DEFAULT.form, { application: this.props.application })
   });
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { dataset: datasetId } = this.props;
     // Get the dataset and fill the state with its params if it exists
     if (datasetId) {
@@ -161,7 +161,7 @@ class DatasetsForm extends PureComponent {
               applicationConfig: {
                 ...form.applicationConfig,
                 [process.env.APPLICATIONS]: {
-                  ...form.applicationConfig && form.applicationConfig[process.env.APPLICATIONS],
+                  ...(form.applicationConfig && form.applicationConfig[process.env.APPLICATIONS]),
                   layerOrder: layers.map(_layer => _layer.id)
                 }
               }

--- a/components/datasets/form/steps/component.js
+++ b/components/datasets/form/steps/component.js
@@ -49,7 +49,7 @@ class Step1 extends PureComponent {
     activeSubscriptionModal: null
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ form: nextProps.form });
   }
 

--- a/components/datasets/metadata/form/Source.js
+++ b/components/datasets/metadata/form/Source.js
@@ -36,7 +36,7 @@ class Source extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!isEqual(this.props.values, nextProps.values)) {
       this.setState({
         values: nextProps.values

--- a/components/datasets/metadata/form/SourcesContentModal.js
+++ b/components/datasets/metadata/form/SourcesContentModal.js
@@ -28,7 +28,7 @@ class SourcesContentModal extends React.Component {
     tmpSources: []
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { sources } = this.props;
     if (!sources.length) {
       this.props.setTmpSources([{}]);

--- a/components/datasets/metadata/form/steps/Step1.js
+++ b/components/datasets/metadata/form/steps/Step1.js
@@ -42,7 +42,7 @@ class Step1 extends React.Component {
 
   static defaultProps = { type: 'tabular' };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!isEqual(this.props.sources, nextProps.sources)) {
       this.changeMetadata({ info: { sources: nextProps.sources } });
     }

--- a/components/datasets/similar-datasets/similar-datasets.js
+++ b/components/datasets/similar-datasets/similar-datasets.js
@@ -19,7 +19,7 @@ class SimilarDatasetsContainer extends Component {
     this.props.getSimilarDatasets(this.props.datasetIds);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.datasetIds !== nextProps.datasetIds) {
       this.props.getSimilarDatasets(nextProps.datasetIds);
     }

--- a/components/form/CheckboxGroup.js
+++ b/components/form/CheckboxGroup.js
@@ -16,7 +16,7 @@ export default class CheckboxGroup extends React.Component {
     this.onChange = this.onChange.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!isEqual(nextProps.selected, this.props.selected)) {
       this.setState({
         checked: nextProps.selected

--- a/components/form/Code.js
+++ b/components/form/Code.js
@@ -25,7 +25,7 @@ class Code extends FormElement {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.properties.value) {
       try {
         const stateValueStringify = JSON.stringify(JSON.parse(this.state.value), null, 2);

--- a/components/form/FormElement.js
+++ b/components/form/FormElement.js
@@ -31,7 +31,7 @@ class FormElement extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const hasValue = Object.prototype.hasOwnProperty.call(nextProps.properties, 'value');
     const isNew = nextProps.properties.value !== this.state.value;
     if (hasValue && isNew) {

--- a/components/modal/subscriptions-modal/area/index.js
+++ b/components/modal/subscriptions-modal/area/index.js
@@ -44,7 +44,7 @@ class AreaSubscriptionsModalContainer extends Component {
     clearLocalSubscriptions: PropTypes.func.isRequired
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const {
       activeArea,
       setUserSelection,
@@ -65,7 +65,7 @@ class AreaSubscriptionsModalContainer extends Component {
     setUserSelection({ area: activeArea });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { subscriptionsByArea, setUserSelection } = this.props;
     const { subscriptionsByArea: nextSubscriptions, activeArea: nextActiveArea } = nextProps;
     const subscriptionsChanged = !isEqual(subscriptionsByArea, nextSubscriptions);
@@ -84,7 +84,7 @@ class AreaSubscriptionsModalContainer extends Component {
                 .map(val => ({
                   label: val,
                   value: val,
-                  ...datasetQuery.type.includes(val) && { selected: true }
+                  ...(datasetQuery.type.includes(val) && { selected: true })
                 })), 'label'),
               threshold: datasetQuery.threshold
             };

--- a/components/modal/subscriptions-modal/dataset-manager/component.js
+++ b/components/modal/subscriptions-modal/dataset-manager/component.js
@@ -28,7 +28,7 @@ class DatasetManager extends Component {
 
   state = { selectedDatasets: this.props.selectedDatasets };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { selectedDatasets } = this.props;
     const { selectedDatasets: nextSelectedDatasets } = nextProps;
     const selectedDatasetsChanged = !isEqual(selectedDatasets, nextSelectedDatasets);

--- a/components/modal/subscriptions-modal/dataset/index.js
+++ b/components/modal/subscriptions-modal/dataset/index.js
@@ -42,7 +42,7 @@ class DatasetSubscriptionModalContainer extends Component {
     clearLocalSubscriptions: PropTypes.func.isRequired
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const {
       activeDataset,
       setUserSelection,
@@ -71,9 +71,8 @@ class DatasetSubscriptionModalContainer extends Component {
             .map((val, index) => ({
               label: val,
               value: val,
-              ...(dataset.subscribable || dataset.attributes.subscribable)[val] &&
-                { query: ((dataset.subscribable || dataset.attributes.subscribable)[val] || {}).dataQuery },
-              ...index === 0 && { selected: true }
+              ...((dataset.subscribable || dataset.attributes.subscribable)[val] && { query: ((dataset.subscribable || dataset.attributes.subscribable)[val] || {}).dataQuery }),
+              ...(index === 0 && { selected: true })
             })), 'label'),
           threshold: 1
         }))
@@ -81,7 +80,7 @@ class DatasetSubscriptionModalContainer extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { subscriptions, setUserSelection, activeArea } = this.props;
     const { subscriptions: nextSubscriptions, activeArea: nextActiveArea } = nextProps;
     const subscriptionsChanged = !isEqual(subscriptions, nextSubscriptions);
@@ -104,7 +103,7 @@ class DatasetSubscriptionModalContainer extends Component {
               .map(val => ({
                 label: val,
                 value: val,
-                ...subscriptionTypes.includes(val) && { selected: true }
+                ...(subscriptionTypes.includes(val) && { selected: true })
               })), 'label'),
             threshold: activeArea.subscription.attributes.datasetsQuery[index].threshold
           }))
@@ -136,9 +135,8 @@ class DatasetSubscriptionModalContainer extends Component {
             .map((val, index) => ({
               label: val,
               value: val,
-              ...(dataset.subscribable || dataset.attributes.subscribable)[val] &&
-                { query: ((dataset.subscribable || dataset.attributes.subscribable)[val] || {}).dataQuery },
-              ...index === 0 && { selected: true }
+              ...((dataset.subscribable || dataset.attributes.subscribable)[val] && { query: ((dataset.subscribable || dataset.attributes.subscribable)[val] || {}).dataQuery }),
+              ...(index === 0 && { selected: true })
             })), 'label'),
           threshold: 1
         }))

--- a/components/modal/subscriptions-modal/subscriptions-preview/component.js
+++ b/components/modal/subscriptions-modal/subscriptions-preview/component.js
@@ -18,7 +18,7 @@ class SubscriptionsPreview extends PureComponent {
 
   static defaultProps = { data: [] }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { getUserSubscriptionsPreview } = this.props;
 
     getUserSubscriptionsPreview();

--- a/components/topics/form/steps/Step1.js
+++ b/components/topics/form/steps/Step1.js
@@ -28,7 +28,7 @@ class Step1 extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ form: nextProps.form });
   }
 

--- a/components/topics/list/TopicsList.js
+++ b/components/topics/list/TopicsList.js
@@ -60,7 +60,7 @@ class TopicsList extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.loading !== this.state.loading) {
       this.setState({ loading: nextProps.loading });
     }

--- a/components/topics/table/component.js
+++ b/components/topics/table/component.js
@@ -34,12 +34,12 @@ class TopicsTable extends PureComponent {
 
   state = { pagination: INITIAL_PAGINATION };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { getAllTopics, authorization } = this.props;
     getAllTopics({ includes: 'user' }, { Authorization: authorization });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { topics } = this.props;
     const { topics: nextTopics } = nextProps;
     const { pagination } = this.state;
@@ -49,7 +49,7 @@ class TopicsTable extends PureComponent {
       pagination: {
         ...pagination,
         size: nextTopics.length,
-        ...topicsChanged && { page: 1 },
+        ...(topicsChanged && { page: 1 }),
         pages: Math.ceil(nextTopics.length / pagination.limit)
       }
     });

--- a/components/ui/Button.js
+++ b/components/ui/Button.js
@@ -24,7 +24,7 @@ class Button extends React.Component {
     this.triggerMouseOut = this.triggerMouseOut.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       className: nextProps.className
     });

--- a/components/ui/Modal.js
+++ b/components/ui/Modal.js
@@ -31,7 +31,7 @@ export default class Modal extends React.Component {
   }
 
   // Close modal when esc key is pressed
-  componentWillReceiveProps({ open }) {
+  UNSAFE_componentWillReceiveProps({ open }) {
     const self = this;
     function escKeyPressListener(evt) {
       document.removeEventListener('keydown', escKeyPressListener);

--- a/components/ui/Paginator.js
+++ b/components/ui/Paginator.js
@@ -21,7 +21,7 @@ class Paginator extends PureComponent {
     this.triggerChangePage = this.triggerChangePage.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       size: nextProps.options.size,
       page: nextProps.options.page,

--- a/components/ui/SearchInput.js
+++ b/components/ui/SearchInput.js
@@ -34,7 +34,7 @@ class SearchInput extends PureComponent {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { input } = nextProps;
 
     if (input.value) {

--- a/components/ui/SearchSelect.js
+++ b/components/ui/SearchSelect.js
@@ -27,7 +27,7 @@ export default class SearchSelect extends React.Component {
     this.resetSelectedIndex = this.resetSelectedIndex.bind(this);
   }
 
-  componentWillReceiveProps({ options, value }) {
+  UNSAFE_componentWillReceiveProps({ options, value }) {
     if (!isEqual(this.props.options, options)) {
       this.setState({
         filteredOptions: options,

--- a/components/ui/SliderSelect.js
+++ b/components/ui/SliderSelect.js
@@ -78,7 +78,7 @@ export default class SliderSelect extends React.Component {
     // --------------------------------------------------------
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     // If we get the list of options asynchronously...
     if (newProps.options.length && !this.state.fullList.length) {
       this.setState({

--- a/components/ui/Switch.js
+++ b/components/ui/Switch.js
@@ -25,7 +25,7 @@ class Switch extends React.Component {
     this.onToggle = this.onToggle.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       active: nextProps.active
     });

--- a/components/ui/Table.js
+++ b/components/ui/Table.js
@@ -32,7 +32,7 @@ export default class Table extends React.Component {
   }
 
   /* Component lifecycle */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!isEqual(this.props.data, nextProps.data)) {
       this.setTableData(nextProps);
     }

--- a/components/ui/Tabs.js
+++ b/components/ui/Tabs.js
@@ -12,7 +12,7 @@ export default class Tabs extends React.Component {
     this.state = { selected: props.defaultSelected };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { selected } = nextProps;
     this.setState({ selected });
   }

--- a/components/ui/Tooltip.js
+++ b/components/ui/Tooltip.js
@@ -20,7 +20,7 @@ class Tooltip extends React.Component {
     this.onMouseMove = this.onMouseMove.bind(this);
   }
 
-  componentWillReceiveProps({ tooltip }) {
+  UNSAFE_componentWillReceiveProps({ tooltip }) {
     if (tooltip.follow && tooltip.follow !== this.props.tooltip.follow) {
       document.addEventListener('mousemove', this.onMouseMove);
     }

--- a/components/ui/customtable/CustomTable.js
+++ b/components/ui/customtable/CustomTable.js
@@ -90,13 +90,13 @@ export default class CustomTable extends PureComponent {
     };
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.setState(CustomTable.setTableData(this.props), () => {
       this.filter();
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const currentColumnsKeys = CustomTable.getColumnKeys(this.state.data).sort();
     const nextColumnsKeys = CustomTable.getColumnKeys(nextProps.data).sort();
     this.setState(CustomTable.setTableData(nextProps), () => {
@@ -249,7 +249,7 @@ export default class CustomTable extends PureComponent {
         pagination: {
           ...pagination,
           // page,
-          ...search && (search.value || '').length > 0 ? { page: 1 } : { page },
+          ...(search && (search.value || '').length > 0 ? { page: 1 } : { page }),
           total: filteredData.length
         }
       });

--- a/components/ui/customtable/header/TableFilters.js
+++ b/components/ui/customtable/header/TableFilters.js
@@ -43,7 +43,7 @@ export default class TableFilters extends React.Component {
   }
 
   /* Component lifecycle */
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const selected = (nextProps.selected) ? nextProps.selected : nextProps.values;
     this.setState({
       selected,

--- a/components/ui/map/Map.js
+++ b/components/ui/map/Map.js
@@ -230,7 +230,7 @@ class Map extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // LAYER GROUPS
     const oldlayerGroups = this.props.layerGroups;
     const nextLayerGroups = nextProps.layerGroups;
@@ -374,13 +374,9 @@ class Map extends React.Component {
       nextProps.interactionLatLng &&
       (
         // interactionSelected changed
-        (this.props.interactionSelected !== nextProps.interactionSelected) ||
-
-        // interaction changed
-        (
-          !isEmpty(nextProps.interaction) &&
-          !isEqual(this.props.interaction, nextProps.interaction)
-        )
+        (// interaction changed
+        this.props.interactionSelected !== nextProps.interactionSelected || !isEmpty(nextProps.interaction) &&
+        !isEqual(this.props.interaction, nextProps.interaction))
       )
     ) {
       const popupContainer = document.createElement('div');

--- a/components/vis/globe-cesium/component.js
+++ b/components/vis/globe-cesium/component.js
@@ -162,7 +162,7 @@ class GlobeCesiumComponent extends PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const mainLayer = this.props.layerActive && this.props.layerActive.url;
     const newMainLayer = nextProps.layerActive && nextProps.layerActive.url;
 

--- a/components/widgets/list/WidgetCard.js
+++ b/components/widgets/list/WidgetCard.js
@@ -158,7 +158,7 @@ class WidgetCard extends PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (!isEqual(nextProps.widget, this.props.widget)
       && WidgetCard.isMapWidget(nextProps.widget)) {
       const layerId = (nextProps.widget.widgetConfig.paramsConfig

--- a/components/widgets/metadata/form/MetadataForm.js
+++ b/components/widgets/metadata/form/MetadataForm.js
@@ -36,7 +36,7 @@ class MetadataForm extends React.Component {
     dataset: null
   });
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { widget } = this.props;
     if (widget) {
       fetchWidget(widget, { includes: 'metadata' })

--- a/components/widgets/metadata/form/steps/Step1.js
+++ b/components/widgets/metadata/form/steps/Step1.js
@@ -27,7 +27,7 @@ class Step1 extends React.Component {
     // ---------------------------------------------------------------
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       widgetLinksSelected: nextProps.form.info.widgetLinks &&
         nextProps.form.info.widgetLinks.length > 0,

--- a/components/wysiwyg/widget-block/index.js
+++ b/components/wysiwyg/widget-block/index.js
@@ -25,14 +25,14 @@ class WidgetBlock extends PureComponent {
     setLayers: PropTypes.func.isRequired
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.item.content.widgetId) {
       this.triggerFetch(this.props);
       this.setFavourite(this.props);
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.item.content.widgetId !== this.props.item.content.widgetId) {
       this.triggerFetch(nextProps);
       this.setFavourite(nextProps);

--- a/layout/admin/data-detail/component.js
+++ b/layout/admin/data-detail/component.js
@@ -24,7 +24,7 @@ class LayoutAdminDataDetail extends PureComponent {
 
   state= { data: null }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { query: { id } } = this.props;
 
     if (id === 'new') return;

--- a/layout/admin/pages-detail/component.js
+++ b/layout/admin/pages-detail/component.js
@@ -24,7 +24,7 @@ class LayoutAdminPagesDetail extends PureComponent {
 
   state = { data: null }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { query: { id } } = this.props;
 
     if (id === 'new') return;

--- a/layout/admin/partners-detail/component.js
+++ b/layout/admin/partners-detail/component.js
@@ -24,7 +24,7 @@ class LayoutAdminPartnersDetail extends PureComponent {
 
   state = { data: null }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { query: { id } } = this.props;
 
     if (id === 'new') return;

--- a/layout/admin/tools-detail/component.js
+++ b/layout/admin/tools-detail/component.js
@@ -24,7 +24,7 @@ class LayoutAdminToolsDetail extends PureComponent {
 
   state = { data: null }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { query: { id } } = this.props;
 
     if (id === 'new') return;

--- a/layout/app/catalog/component.js
+++ b/layout/app/catalog/component.js
@@ -25,7 +25,7 @@ class CatalogLayout extends PureComponent {
     totalItems: 0
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.getDatasets();
   }
 

--- a/layout/app/pulse/component.js
+++ b/layout/app/pulse/component.js
@@ -72,7 +72,7 @@ class LayoutPulse extends PureComponent {
     document.addEventListener('click', this.handleMouseClick);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { layerActive } = this.props.layerMenuPulse;
     const nextLayerActive = nextProps.layerMenuPulse.layerActive;
     const lastId = (layerActive) ? layerActive.id : null;

--- a/layout/app/pulse/layer-card/component.js
+++ b/layout/app/pulse/layer-card/component.js
@@ -31,7 +31,7 @@ class LayerCardComponent extends PureComponent {
       showContextLayersInfoModal: false
     };
   }
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if ((nextProps.layerMenuPulse.layerActive && nextProps.layerMenuPulse.layerActive.id) !==
       (this.props.layerMenuPulse.layerActive && this.props.layerMenuPulse.layerActive.id)) {
       this.loadWidgets(nextProps);
@@ -107,7 +107,7 @@ class LayerCardComponent extends PureComponent {
                 onClick={() => this.props.togglePosition()}
               >
                 Rotate globe
-            </button>
+              </button>
             </div>
           }
           <div className="legends">
@@ -218,7 +218,7 @@ class LayerCardComponent extends PureComponent {
                   onClick={() => this.handleToggleSubscribeToDatasetModal(true)}
                 >
                   Subscribe to alerts
-                <Modal
+                  <Modal
                     isOpen={showSubscribeToDatasetModal}
                     onRequestClose={() => this.handleToggleSubscribeToDatasetModal(false)}
                   >

--- a/layout/app/widget-detail/component.js
+++ b/layout/app/widget-detail/component.js
@@ -11,7 +11,7 @@ class LayoutWidgetDetail extends PureComponent {
 
   static defaultProps = { widget: {} }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (typeof window !== 'undefined') window.scrollTo(0, 0);
   }
 

--- a/layout/embed/dataset/component.js
+++ b/layout/embed/dataset/component.js
@@ -27,7 +27,7 @@ class LayoutEmbedDataset extends PureComponent {
     loadingDataset: true
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     fetchDataset(this.props.routes.query.id, { includes: 'widget, metadata' })
       .then(data =>
         this.setState({

--- a/layout/embed/embed/component.js
+++ b/layout/embed/embed/component.js
@@ -30,7 +30,7 @@ class LayoutEmbedEmbed extends PureComponent {
 
   state = { modalOpened: false }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const {
       url,
       user,

--- a/layout/embed/table/component.js
+++ b/layout/embed/table/component.js
@@ -26,7 +26,7 @@ class LayoutEmbedTable extends PureComponent {
     tableData: []
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { routes: { query: { queryURL } } } = this.props;
 
     if (queryURL) this.loadTableData(queryURL);

--- a/layout/embed/text/component.js
+++ b/layout/embed/text/component.js
@@ -22,7 +22,7 @@ class LayoutEmbedText extends PureComponent {
 
   state = { isLoading: this.props.loading };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const {
       getWidget,
       routes: { query: { id } }

--- a/layout/explore/explore-map/explore-map-component.js
+++ b/layout/explore/explore-map/explore-map-component.js
@@ -97,7 +97,7 @@ class ExploreMapComponent extends React.Component {
     loading: {}
   };
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { layerGroups: prevLayerGroups } = this.props;
 
     const { layerGroups: nextLayerGroups } = nextProps;
@@ -174,18 +174,18 @@ class ExploreMapComponent extends React.Component {
     setMapLayerParametrization({
       id,
       nextConfig: {
-        ...decode_config && {
+        ...(decode_config && {
           decodeParams: {
             startDate: dates[0],
             endDate: dates[1]
           }
-        },
-        ...!decode_config && {
+        }),
+        ...(!decode_config && {
           params: {
             startDate: dates[0],
             endDate: dates[1]
           }
-        }
+        })
       }
     });
   }
@@ -406,7 +406,7 @@ class ExploreMapComponent extends React.Component {
                   onChangeLayer={this.onChangeLayerTimeLine}
                   customClass="rw-legend-timeline"
                   {...LEGEND_TIMELINE_PROPERTIES}
-                  { ...lg.layers.length > TIMELINE_THRESHOLD && { dotStyle: { opacity: 0 } }}
+                  {...lg.layers.length > TIMELINE_THRESHOLD && { dotStyle: { opacity: 0 } }}
                 />
               </LegendListItem>
             ))}

--- a/layout/layout/layout-admin/layout-admin-component.js
+++ b/layout/layout/layout-admin/layout-admin-component.js
@@ -65,7 +65,7 @@ class LayoutAdmin extends PureComponent {
 
   state = { modalOpen: false }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     // When a tooltip is shown and the router navigates to a
     // another page, the tooltip stays in place because it is
     // managed in Redux
@@ -106,7 +106,7 @@ class LayoutAdmin extends PureComponent {
     logPageView();
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (this.state.modalOpen !== newProps.modal.open) {
       this.setState({ modalOpen: newProps.modal.open });
     }

--- a/layout/layout/layout-app/component.js
+++ b/layout/layout/layout-app/component.js
@@ -58,7 +58,7 @@ class LayoutApp extends Component {
 
   state = { modalOpen: false }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { user: { token2, email } } = this.props;
 
     // WIDGET EDITOR – change the configuration according to your needs
@@ -91,7 +91,7 @@ class LayoutApp extends Component {
     logPageView();
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (this.state.modalOpen !== newProps.modal.open) {
       this.setState({ modalOpen: newProps.modal.open });
     }

--- a/layout/layout/layout-embed/component.js
+++ b/layout/layout/layout-embed/component.js
@@ -26,7 +26,7 @@ class LayoutEmbed extends PureComponent {
     className: null
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     // When a tooltip is shown and the router navigates to
     // another page, the tooltip stays in place because it is
     // managed in Redux

--- a/layout/myrw/detail/component.js
+++ b/layout/myrw/detail/component.js
@@ -38,7 +38,7 @@ class LayoutMyRWDetail extends PureComponent {
 
   state = { data: null }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const {
       user,
       query: { id, tab },

--- a/pages/admin/dashboards-detail/index.js
+++ b/pages/admin/dashboards-detail/index.js
@@ -33,7 +33,7 @@ class AdminDashboardsDetailPage extends PureComponent {
       .catch((err) => { toastr.error('Error', err.message); });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { tab, id, subtab } = nextProps.url.query;
 
     this.setState({ tab, id, subtab });

--- a/pages/admin/dashboards/index.js
+++ b/pages/admin/dashboards/index.js
@@ -30,7 +30,7 @@ class AdminDashboardsPage extends PureComponent {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { url } = nextProps;
 
     this.setState({

--- a/pages/admin/partners/index.js
+++ b/pages/admin/partners/index.js
@@ -11,7 +11,7 @@ import LayoutAdminPartners from 'layout/admin/partners';
 class AdminPartnersPage extends PureComponent {
   static propTypes = { getAllPartners: PropTypes.func.isRequired }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.getAllPartners();
   }
 

--- a/pages/app/dashboards-detail/index.js
+++ b/pages/app/dashboards-detail/index.js
@@ -20,7 +20,7 @@ class DashboardsDetailPage extends PureComponent {
     return { };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.routes.query.slug !== nextProps.routes.query.slug) {
       window.scrollTo(0, 0);
     }

--- a/pages/app/explore-detail/index.js
+++ b/pages/app/explore-detail/index.js
@@ -53,7 +53,7 @@ class ExploreDetailPage extends PureComponent {
       dispatch(actions.setPartner(null));
     }
 
-    return { ...res && { statusCode: res.statusCode } };
+    return { ...(res && { statusCode: res.statusCode }) };
   }
 
   componentDidMount() {
@@ -64,7 +64,7 @@ class ExploreDetailPage extends PureComponent {
     this.props.setCountView();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (this.props.routes.query.id !== nextProps.routes.query.id) {
       window.scrollTo(0, 0);
       this.props.fetchTags();

--- a/pages/app/search/index.js
+++ b/pages/app/search/index.js
@@ -30,7 +30,7 @@ class SearchPage extends PureComponent {
     return {};
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { term: newTerm, page: newPage } = nextProps;
     const { term: oldTerm, page: oldPage } = this.props;
 

--- a/pages/myrw/detail/index.js
+++ b/pages/myrw/detail/index.js
@@ -11,7 +11,7 @@ import LayoutMyRWDetail from 'layout/myrw/detail';
 class MyRWDetailPage extends PureComponent {
   static propTypes = { getUserAreas: PropTypes.func.isRequired }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.getUserAreas();
   }
 

--- a/pages/myrw/index.js
+++ b/pages/myrw/index.js
@@ -11,7 +11,7 @@ import LayoutMyRW from 'layout/myrw';
 class MyRWPage extends PureComponent {
   static propTypes = { getUserAreas: PropTypes.func.isRequired }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.props.getUserAreas();
   }
 


### PR DESCRIPTION
## Overview
This PR adds UNSAFE prefix to deprecated methods.
These changes are realized by using react-codemode command.
npx react-codemod rename-unsafe-lifecycles
The description of this usage here: https://scotch.io/bar-talk/whats-new-in-react-169

Updated 3 folders: 
/layouts
/components
/pages

## Testing instructions
Build the project. No errors, everything works correctly.
## [Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/169914752)

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
