### PR TITLE
Added the same width for the main page subheader box.

### DIFF
--- a/components/dashboards/thumbnail-list/styles.scss
+++ b/components/dashboards/thumbnail-list/styles.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-wrap: wrap;
   margin: 0;
-  padding: 0;
+  padding: $space * 9 0 0 0;
   list-style: none;
 
   .thumbnail-list-item {

--- a/css/components/dashboards/dashboards-subheader-block.scss
+++ b/css/components/dashboards/dashboards-subheader-block.scss
@@ -1,5 +1,5 @@
 .c-dashboards-subheader-block {
-  padding-bottom: $space * 9;
+  padding-bottom: 0;
   padding-top: $space * 14;
   p {
     max-width: 430px;

--- a/layout/app/home/component.js
+++ b/layout/app/home/component.js
@@ -84,7 +84,7 @@ class LayoutHome extends PureComponent {
           <div className="l-container">
             <header>
               <div className="row">
-                <div className="column small-12 medium-8">
+                <div className="column small-12 medium-6">
                   <h2>Latest stories</h2>
                   <p>Discover data insights on the Resource Watch blog.</p>
                 </div>
@@ -117,14 +117,12 @@ class LayoutHome extends PureComponent {
             <div className="dashboards-container">
               <header>
                 <div className="row">
-                  <div className="column small-12 medium-8">
-                    <div className="c-dashboards-subheader-block">
-                      <h2>Featured dashboards</h2>
-                      <p>
-                        Discover collections of curated data on the major
-                        challenges facing human society and the planet
-                      </p>
-                    </div>
+                  <div className="column small-12 medium-6">
+                    <h2>Featured dashboards</h2>
+                    <p>
+                      Discover collections of curated data on the major
+                      challenges facing human society and the planet.
+                    </p>
                   </div>
                 </div>
               </header>
@@ -149,11 +147,11 @@ class LayoutHome extends PureComponent {
           <div className="l-container">
             <header>
               <div className="row">
-                <div className="column small-12 medium-8">
+                <div className="column small-12 medium-6">
                   <h2>Dive into the data</h2>
                   <p>
-                    Create overlays, share visualizations, and subscribe to updates on your favorite
-                    issues.
+                    Create overlays, share visualizations, and
+                    subscribe to updates on your favorite issues.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Overview
This PR fixes the text width for the subheader description block on main page. 
## Testing instructions
Go to main page. Check the width of subheader boxes.

## [Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/170446045)

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
