### PR TITLE
Fix explore detail buttons not appearing

### DIFF
--- a/layout/explore-detail/explore-detail-buttons/explore-detail-buttons-component.js
+++ b/layout/explore-detail/explore-detail-buttons/explore-detail-buttons-component.js
@@ -34,7 +34,7 @@ class ExploreDetailButtons extends PureComponent {
   */
   getDatasetMetadata() {
     const { dataset } = this.props;
-    return dataset.metadata || {};
+    return (dataset.metadata && dataset.metadata[0]) || {};
   }
 
   getDatasetName() {


### PR DESCRIPTION
## Overview
This PR fixes the bug that prevented learn more and download buttons to appear in explore detail.

## Testing instructions
Go to https://localhost:9000/data/explore/wat005c-Access-to-an-Improved-Water-Source-Rural and verify that the `Learn more` and `Download` buttons are displayed.

## [Pivotal task](https://www.pivotaltracker.com/story/show/170363357)