### PR TITLE
Fix charts overflowing in explore cards

### DIFF
--- a/css/components/datasets/list-item.scss
+++ b/css/components/datasets/list-item.scss
@@ -67,6 +67,7 @@
     height: 100%;
     min-height: 150px;
     flex-shrink: 0;
+    overflow: hidden;
 
     @media screen and (min-width: map-get($breakpoints, medium)) {
       width: 100%;


### PR DESCRIPTION
**Before**: 

![image](https://user-images.githubusercontent.com/545342/72718314-0425fe80-3b76-11ea-9d68-71badc87bd7b.png)

**After:**

![image](https://user-images.githubusercontent.com/545342/72718340-0d16d000-3b76-11ea-843b-08f37e2a2768.png)


## [Pivotal task](https://www.pivotaltracker.com/story/show/170770469)