### PR TITLE
Changed preview url for admin dashboards

### DIFF
--- a/components/dashboards/table/DashboardsTable.js
+++ b/components/dashboards/table/DashboardsTable.js
@@ -111,7 +111,6 @@ class DashboardsTable extends PureComponent {
           size,
           pages
         };
-
         this.setState({
           loading: false,
           dashboards: dashboards.map(_dashboard => ({

--- a/components/dashboards/table/td/preview/component.js
+++ b/components/dashboards/table/td/preview/component.js
@@ -12,8 +12,8 @@ class PreviewTD extends PureComponent {
 
     return (
       <td key={index}>
-        <a target="_blank" rel="noopener noreferrer" href={`/data/dashboards/${value}`}>
-          {`${window.location.origin}/data/dashboards/${value}`}
+        <a target="_blank" rel="noopener noreferrer" href={`/dashboards/${value}`}>
+          {`${window.location.origin}/dashboards/${value}`}
         </a>
       </td>
     );


### PR DESCRIPTION
## Overview
This PR changes the preview URL for admin dashboards table
## Testing instructions
Go to http://localhost:9000/admin/dashboards check the dashboards preview links. Follow them.
## [Pivotal task](https://www.pivotaltracker.com/n/projects/1374154/stories/170311595)
---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
