### PR TITLE
Redirects to dashboard pages from old deprecated topic pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,14 @@ app.prepare().then(() => {
   // Redirecting data to data/explore
   server.get('/data', (req, res) => res.redirect('/data/explore'));
 
+  // Redirecting 'topics' to 'dashboards'
+  server.get('/topics', (req, res) => res.redirect('/dashboards'));
+  // Redirecting specific 'topic' pages to new 'dashboard' pages
+  server.get('/topics/:id', (req, res) => {
+    const { id } = req.params;
+    res.redirect(`/dashboards/${id}`);
+  });
+
   // Authentication
   server.get(
     '/auth',


### PR DESCRIPTION
## Overview
This PR sets redirects in the server file so that _old_ topic requests are redirected to the new dashboard pages.

## Testing instructions
Verify that the following URLs `localhost:9000/topics` and `localhost:9000/topics/topic-slug` are properly redirected.

## [Pivotal task](https://www.pivotaltracker.com/story/show/170311514)