### PR TITLE
Remove button to clone a topic when creating a dashboard

### DIFF
--- a/components/dashboards/template-selector/component.js
+++ b/components/dashboards/template-selector/component.js
@@ -1,9 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import HeaderTopics from './import-selector';
-
-
 // constants
 import { TEMPLATES } from './constants';
 
@@ -38,7 +35,7 @@ class TemplateSelector extends PureComponent {
               {TEMPLATES.map(_template => (
                 <li
                   key={_template.value}
-                  className='template-list-item'
+                  className="template-list-item"
                   onClick={() => this.onChangeTemplate(_template.value)}
                 >
                   <h4 className="template-name">{_template.label}</h4>
@@ -46,8 +43,6 @@ class TemplateSelector extends PureComponent {
                 </li>
 
               ))}
-              <HeaderTopics />
-
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Overview
This PR temporarily removes the button to clone a topic page into a dashboard as part of the create dashboard form.