### PR TITLE
Dashboad-detail force content update after changing page

### DIFF
--- a/components/dashboards/detail/component.js
+++ b/components/dashboards/detail/component.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 // components
@@ -9,8 +9,26 @@ import WidgetBlockEdition from 'components/wysiwyg/widget-block-edition';
 class DashboardDetail extends PureComponent {
   static propTypes = { dashboard: PropTypes.object.isRequired }
 
+  state = { isUpdate: false }
+
+  componentDidUpdate(prevProps) {
+    const { dashboard: { content: prevContent } } = prevProps;
+    const { dashboard: { content } } = this.props;
+    const { isUpdate } = this.state;
+    if (content !== prevContent && !isUpdate) {
+      this.changeUpdateStatus(true);
+    } else if (content === prevContent && isUpdate) {
+      this.changeUpdateStatus(false);
+    }
+  }
+
+  changeUpdateStatus = (status) => {
+    this.setState({ isUpdate: status });
+  }
+
   render() {
     const { dashboard: { content } } = this.props;
+    const { isUpdate } = this.state;
     let items = [];
 
     // TO-DO: review this error handling
@@ -19,19 +37,23 @@ class DashboardDetail extends PureComponent {
     } catch (e) { console.error(e); }
 
     return (
-      <Wysiwyg
-        readOnly
-        items={items}
-        blocks={{
-          widget: {
-            Component: WidgetBlock,
-            EditionComponent: WidgetBlockEdition,
-            icon: 'icon-widget',
-            label: 'Visualization',
-            renderer: 'modal'
-          }
-        }}
-      />
+      <Fragment>
+        {!isUpdate && (
+          <Wysiwyg
+            readOnly
+            items={items}
+            blocks={{
+              widget: {
+                Component: WidgetBlock,
+                EditionComponent: WidgetBlockEdition,
+                icon: 'icon-widget',
+                label: 'Visualization',
+                renderer: 'modal'
+              }
+            }}
+          />
+        )}
+      </Fragment>
     );
   }
 }


### PR DESCRIPTION
## Overview
This PR fixes content update on dashboard-detail page
## Testing instructions
Go to dashboard-detail page. Click on dashboard in menu. After loading click another dashboard in the menu. The content will be updated.
## Pivotal task
Provide the link to the task(s), if any.

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
