### PR TITLE
Featured dashboard + partners requests run after strarting aplication only once

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -50,7 +50,10 @@ class RWApp extends App {
 
     // sets user data coming from a request (server) or the store (client)
     const { user } = isServer ? req : store.getState();
-
+    const {
+      dashboards: { featured: { list: featuredDashboards } },
+      partners: { published: { list: publishedPartners } }
+    } = store.getState();
     if (user) {
       store.dispatch(setUser(user));
       await store.dispatch(getUserFavourites());
@@ -62,11 +65,13 @@ class RWApp extends App {
     }
 
     // fetches published featured dashboards to populate dashboars menu in the app header and footer
-    if (!containsString(pathname, PAGES_WITHOUT_DASHBOARDS)) {
+    if (!containsString(pathname, PAGES_WITHOUT_DASHBOARDS) && !featuredDashboards.length) {
       await store.dispatch(getFeaturedDashboards());
     }
     // fetches partners for footer
-    if (!containsString(pathname, FULLSCREEN_PAGES)) await store.dispatch(getPublishedPartners());
+    if (!containsString(pathname, FULLSCREEN_PAGES) && !publishedPartners.length) {
+      await store.dispatch(getPublishedPartners());
+    }
 
     // mobile detection
     if (isServer) {


### PR DESCRIPTION
Overview
This PR adds additional check for calling featured dashboard and partners requests only once.
## Testing instructions
Run application. Open Network console. Check requests, that application sends when you change pages. partners and featured dashboards are not calling but you can see data on the website.
## Pivotal tasks:
- https://www.pivotaltracker.com/n/projects/1374154/stories/171051982
- https://www.pivotaltracker.com/n/projects/1374154/stories/171051927

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
