### PR TITLE
Mapbox migration: add `layerType` to first level of layer object

### DIFF
--- a/components/admin/data/layers/form/layer-preview/actions.js
+++ b/components/admin/data/layers/form/layer-preview/actions.js
@@ -27,7 +27,8 @@ export const generateLayerGroups = createThunkAction('ADMIN_LAYER_PREVIEW_GENERA
       provider: layer.provider,
       slug: layer.slug,
       iso: layer.iso,
-      description: layer.description
+      description: layer.description,
+      ...layer.layerConfig.layerType && { layerType: layer.layerConfig.layerType }
     }]
   }];
   dispatch(setLayerGroups({ layerGroups }));

--- a/components/map/selectors.js
+++ b/components/map/selectors.js
@@ -85,6 +85,7 @@ export const getUpdatedLayers = (activeLayersPointer, parametrizationPointer) =>
 
         return {
           ..._activeLayer,
+          ..._activeLayer.layerConfig.layerType && { layerType: _activeLayer.layerConfig.layerType },
           ..._activeLayer.layerConfig.params_config && {
             params: {
               ...reduceParams(_activeLayer.layerConfig.params_config),

--- a/components/map/selectors.js
+++ b/components/map/selectors.js
@@ -32,7 +32,8 @@ export const getUpdatedLayerGroups = statePointer => createSelector(
           {
             // all params should go under timeline_config attribute
             timelineParams
-          }
+          },
+        ..._layer.layerConfig.layerType && { layerType: _layer.layerConfig.layerType }
       });
     })
   }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -8766,16 +8766,15 @@ layer-manager@^1.10.0:
     supercluster "^4.1.1"
     wri-json-api-serializer "^1.0.1"
 
-layer-manager@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/layer-manager/-/layer-manager-2.0.1.tgz#c1f067533c95465d2edab8b6e35591c7c30116c1"
-  integrity sha512-+6BggiEsPqQcEv0b/XxR7xh6ALWCva0Tz/7gJGdwoquXGfSIvUWTA0JwFYWmrfI139s/s6mkhBlR/ZuCMyBO1A==
+layer-manager@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/layer-manager/-/layer-manager-2.0.6.tgz#15e36e7d9b101dd128755e5e0d2e36d663fad53b"
+  integrity sha512-PPcv1yRvzcZ+S7sKAGazzMVg2YxCaEhLLDxqi2wRSqxsrtjxwXDGokxFUfRjFV7m80T+TVOJ8iYpv/GQRUp5tA==
   dependencies:
-    axios "^0.18.0"
-    lodash "^4.17.11"
-    prop-types "^15.6.2"
+    axios "^0.19.0"
+    lodash "^4.17.15"
+    prop-types "^15.7.2"
     supercluster "^4.1.1"
-    wri-json-api-serializer "^1.0.1"
 
 lazy-cache@^0.2.3:
   version "0.2.7"


### PR DESCRIPTION
## Overview
This PR copies the value of the field `layerConfig --> layerType` to the first level of the layer object, _(this is needed for the `layer-manager` version `2.0.6`)_.

## Testing instructions
Check the Explore section.

## [Pivotal task](https://www.pivotaltracker.com/story/show/171179341)
