### PR TITLE
Explore detail component plus header buttons

### DIFF
--- a/layout/app/pulse/layer-pill/actions.js
+++ b/layout/app/pulse/layer-pill/actions.js
@@ -31,8 +31,6 @@ export const toggleContextualLayer = createThunkAction('layer-pill/toggleContext
             response,
             {
               onLayerAddedSuccess: function success(result) {
-                console.log('result', result);
-
                 newContextLayers.push(result);
                 dispatch(setContextLayers(newContextLayers));
               }

--- a/layout/explore/actions.js
+++ b/layout/explore/actions.js
@@ -19,6 +19,7 @@ export const setDatasetsPage = createAction('EXPLORE/setDatasetsPage');
 export const setDatasetsTotal = createAction('EXPLORE/setDatasetsTotal');
 export const setDatasetsLimit = createAction('EXPLORE/setDatasetsLimit');
 export const setDatasetsMode = createAction('EXPLORE/setDatasetsMode');
+export const setSelectedDataset = createAction('EXPLORE/setSelectedDataset');
 
 export const fetchDatasets = createThunkAction('EXPLORE/fetchDatasets', () => (dispatch, getState) => {
   const { explore, common } = getState();

--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -25,7 +25,7 @@ class Explore extends PureComponent {
   state = { mobileWarningOpened: true }
 
   render() {
-    const { responsive, explore: { datasets: { selected: { id } } } } = this.props;
+    const { responsive, explore: { datasets: { selected } } } = this.props;
     const { mobileWarningOpened } = this.state;
     return (
       <Layout
@@ -37,14 +37,14 @@ class Explore extends PureComponent {
           <ExploreSidebar>
             <div className="row">
               <div className="column small-12">
-                {!id && (
+                {!selected && (
                   <Fragment>
                     <ExploreHeader />
                     <ExploreDatasetsHeader />
                     <ExploreDatasets />
-                  </Fragment> 
+                  </Fragment>
                 )}
-                {id && <ExploreDetail /> }
+                {selected && <ExploreDetail /> }
               </div>
             </div>
           </ExploreSidebar>

--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import MediaQuery from 'react-responsive';
 
@@ -14,6 +14,7 @@ import ExploreHeader from 'layout/explore/explore-header';
 import ExploreDatasetsHeader from 'layout/explore/explore-datasets-header';
 import ExploreDatasets from 'layout/explore/explore-datasets';
 import ExploreMap from 'layout/explore/explore-map';
+import ExploreDetail from 'layout/explore/explore-detail';
 
 // utils
 import { breakpoints } from 'utils/responsive';
@@ -24,7 +25,7 @@ class Explore extends PureComponent {
   state = { mobileWarningOpened: true }
 
   render() {
-    const { responsive } = this.props;
+    const { responsive, explore: { datasets: { selected: { id } } } } = this.props;
     const { mobileWarningOpened } = this.state;
     return (
       <Layout
@@ -36,9 +37,14 @@ class Explore extends PureComponent {
           <ExploreSidebar>
             <div className="row">
               <div className="column small-12">
-                <ExploreHeader />
-                <ExploreDatasetsHeader />
-                <ExploreDatasets />
+                {!id && (
+                  <Fragment>
+                    <ExploreHeader />
+                    <ExploreDatasetsHeader />
+                    <ExploreDatasets />
+                  </Fragment> 
+                )}
+                {id && <ExploreDetail /> }
               </div>
             </div>
           </ExploreSidebar>

--- a/layout/explore/explore-datasets/explore-datasets-actions/component.js
+++ b/layout/explore/explore-datasets/explore-datasets-actions/component.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Link } from 'routes';
 
 class ExploreDatasetsActionsComponent extends PureComponent {
   static propTypes = {
@@ -9,7 +8,8 @@ class ExploreDatasetsActionsComponent extends PureComponent {
     layer: PropTypes.object,
     layerGroups: PropTypes.array,
     toggleMapLayerGroup: PropTypes.func.isRequired,
-    resetMapLayerGroupsInteraction: PropTypes.func.isRequired
+    resetMapLayerGroupsInteraction: PropTypes.func.isRequired,
+    setSelectedDataset: PropTypes.func.isRequired
   };
 
   isActive = () => {
@@ -47,7 +47,7 @@ class ExploreDatasetsActionsComponent extends PureComponent {
 
         <button
           className="c-button -tertiary -compressed"
-          onClick={() => setSelectedDataset(dataset)}
+          onClick={() => setSelectedDataset(dataset.id)}
         >
             Details
         </button>

--- a/layout/explore/explore-datasets/explore-datasets-actions/component.js
+++ b/layout/explore/explore-datasets/explore-datasets-actions/component.js
@@ -26,7 +26,7 @@ class ExploreDatasetsActionsComponent extends PureComponent {
   }
 
   render() {
-    const { dataset, layer } = this.props;
+    const { dataset, layer, setSelectedDataset } = this.props;
     const isActive = this.isActive();
 
     return (
@@ -45,14 +45,12 @@ class ExploreDatasetsActionsComponent extends PureComponent {
           {isActive ? 'Remove from map' : 'Add to map'}
         </button>
 
-        <Link
-          route="explore_detail"
-          params={{ id: dataset.slug }}
+        <button
+          className="c-button -tertiary -compressed"
+          onClick={() => setSelectedDataset(dataset)}
         >
-          <a className="c-button -tertiary -compressed">
             Details
-          </a>
-        </Link>
+        </button>
       </div>
     );
   }

--- a/layout/explore/explore-detail/actions.js
+++ b/layout/explore/explore-detail/actions.js
@@ -1,0 +1,12 @@
+import { createAction } from 'redux-tools';
+
+export const SET_DATASET = 'SET_DATASET';
+export const SET_LOADING = 'SET_LOADING';
+
+export const setDataset = createAction(SET_DATASET);
+export const setLoading = createAction(SET_LOADING);
+
+export default {
+  setDataset,
+  setLoading
+};

--- a/layout/explore/explore-detail/component.js
+++ b/layout/explore/explore-detail/component.js
@@ -10,9 +10,11 @@ import './styles.scss';
 
 class ExploreDetailComponent extends React.Component {
   static propTypes = {
-    dataset: PropTypes.object.isRequired,
+    dataset: PropTypes.object,
     loading: PropTypes.bool.isRequired
   };
+
+  static defaultProps = { dataset: null };
 
 
   render() {

--- a/layout/explore/explore-detail/component.js
+++ b/layout/explore/explore-detail/component.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Components
+import ExploreDetailHeader from './explore-detail-header';
+
+class ExploreDetailComponent extends React.Component {
+  static propTypes = { dataset: PropTypes.object.isRequired };
+
+
+  render() {
+    const { dataset: { id, data } } = this.props;
+
+    return (
+      <div className="c-explore-detail">
+        <ExploreDetailHeader />
+      </div>
+    );
+  }
+}
+
+export default ExploreDetailComponent;

--- a/layout/explore/explore-detail/component.js
+++ b/layout/explore/explore-detail/component.js
@@ -2,18 +2,34 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 // Components
+import Spinner from 'components/ui/Spinner';
 import ExploreDetailHeader from './explore-detail-header';
 
+// Styles
+import './styles.scss';
+
 class ExploreDetailComponent extends React.Component {
-  static propTypes = { dataset: PropTypes.object.isRequired };
+  static propTypes = {
+    dataset: PropTypes.object.isRequired,
+    loading: PropTypes.bool.isRequired
+  };
 
 
   render() {
-    const { dataset: { id, data } } = this.props;
+    const { dataset, loading } = this.props;
+    const metadata = dataset && dataset.metadata && dataset.metadata[0];
 
     return (
       <div className="c-explore-detail">
+        <Spinner isLoading={loading} className="-light" />
         <ExploreDetailHeader />
+        <div className="row">
+          <div className="column small-12">
+            <div className="title">
+              <h2>{metadata && metadata.info.name}</h2>
+            </div>
+          </div>
+        </div>
       </div>
     );
   }

--- a/layout/explore/explore-detail/explore-detail-header/component.js
+++ b/layout/explore/explore-detail/explore-detail-header/component.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+// Components
+import Icon from 'components/ui/icon';
+
 // Styles
 import './styles.scss';
 
@@ -16,10 +19,12 @@ function ExploreDetailHeaderComponent(props) {
       </button>
       <div className="right-buttons">
         <button className="c-btn -secondary -compressed">
-                    SAVE
+          <Icon className="-small" name="icon-star-full" className="-small" />
+          <span>SAVE</span>
         </button>
         <button className="c-btn -secondary -compressed">
-                    SHARE
+          <Icon className="-small" name="icon-arrow-up-2" className="-small" />
+          <span>SHARE</span>
         </button>
       </div>
     </div>

--- a/layout/explore/explore-detail/explore-detail-header/component.js
+++ b/layout/explore/explore-detail/explore-detail-header/component.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Styles
+import './styles.scss';
+
+function ExploreDetailHeaderComponent(props) {
+  const { setSelectedDataset } = props;
+  return (
+    <div className="c-explore-detail-header">
+      <button
+        className="c-btn -primary -compressed"
+        onClick={() => setSelectedDataset(null)}
+      >
+        {'< ALL DATASETS'}
+      </button>
+      <div className="right-buttons">
+        <button className="c-btn -secondary -compressed">
+                    SAVE
+        </button>
+        <button className="c-btn -secondary -compressed">
+                    SHARE
+        </button>
+      </div>
+    </div>
+  );
+}
+
+ExploreDetailHeaderComponent.propTypes = {
+  // Store
+  setSelectedDataset: PropTypes.func.isRequired
+};
+
+export default ExploreDetailHeaderComponent;

--- a/layout/explore/explore-detail/explore-detail-header/index.js
+++ b/layout/explore/explore-detail/explore-detail-header/index.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux';
+import * as actions from 'layout/explore/actions';
+
+// component
+import ExploreDetailHeaderComponent from './component';
+
+export default connect(
+  null,
+  actions
+)(ExploreDetailHeaderComponent);

--- a/layout/explore/explore-detail/explore-detail-header/styles.scss
+++ b/layout/explore/explore-detail/explore-detail-header/styles.scss
@@ -1,0 +1,13 @@
+@import 'css/settings';
+
+.c-explore-detail-header {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+
+    .right-buttons {
+        button:first-child {
+            margin-right: $space;
+        }
+    }
+}

--- a/layout/explore/explore-detail/index.js
+++ b/layout/explore/explore-detail/index.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+import * as actions from 'layout/explore/actions';
+
+// component
+import ExploreDetailComponent from './component';
+
+export default connect(
+  state => ({
+    // Store
+    dataset: state.explore.datasets.selected
+  }),
+  actions
+)(ExploreDetailComponent);

--- a/layout/explore/explore-detail/index.js
+++ b/layout/explore/explore-detail/index.js
@@ -1,13 +1,61 @@
+import React, { useReducer, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { toastr } from 'react-redux-toastr';
 import * as actions from 'layout/explore/actions';
+
+// services
+import { fetchDataset } from 'services/dataset';
 
 // component
 import ExploreDetailComponent from './component';
 
+// store
+import reducer from './reducer';
+import initialState from './initial-state';
+import {
+  setDataset,
+  setLoading
+} from './actions';
+
+const ExploreDetailContainer = (props) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { datasetID } = props;
+
+  const getDataset = () => {
+    dispatch(setLoading(true));
+
+    fetchDataset(datasetID, { includes: 'metadata,layer,vocabulary' })
+      .then((data) => {
+        dispatch(setDataset(data));
+        dispatch(setLoading(false));
+      })
+      .catch((error) => {
+        dispatch(setLoading(false));
+        toastr.error('Error loading dataset data', error);
+      });
+  };
+
+  useEffect(() => {
+    if (datasetID) {
+      getDataset();
+    }
+  }, [datasetID]);
+
+  return (
+    <ExploreDetailComponent
+      {...state}
+    />);
+};
+
+ExploreDetailContainer.propTypes = { datasetID: PropTypes.string };
+ExploreDetailContainer.defaultProps = { datasetID: null };
+
+
 export default connect(
   state => ({
     // Store
-    dataset: state.explore.datasets.selected
+    datasetID: state.explore.datasets.selected
   }),
   actions
-)(ExploreDetailComponent);
+)(ExploreDetailContainer);

--- a/layout/explore/explore-detail/initial-state.js
+++ b/layout/explore/explore-detail/initial-state.js
@@ -1,0 +1,4 @@
+export default {
+  dataset: null,
+  loading: false
+};

--- a/layout/explore/explore-detail/reducer.js
+++ b/layout/explore/explore-detail/reducer.js
@@ -1,0 +1,15 @@
+import {
+  SET_LOADING,
+  SET_DATASET
+} from './actions';
+
+export default (state, { type, payload }) => {
+  switch (type) {
+    case SET_LOADING:
+      return { ...state, loading: payload };
+    case SET_DATASET:
+      return { ...state, dataset: payload };
+    default:
+      throw new Error('action not found');
+  }
+};

--- a/layout/explore/explore-detail/styles.scss
+++ b/layout/explore/explore-detail/styles.scss
@@ -1,0 +1,7 @@
+@import 'css/settings';
+
+.c-explore-detail {
+    .title {
+        margin-top: $space * 4;
+    }
+}

--- a/layout/explore/index.js
+++ b/layout/explore/index.js
@@ -8,11 +8,12 @@ import initialState from './initial-state';
 import LayoutExplore from './component';
 
 // Mandatory
-export {
-  actions, reducers, initialState
-};
+export { actions, reducers, initialState };
 
 export default connect(
-  state => ({ responsive: state.responsive }),
+  state => ({
+    responsive: state.responsive,
+    explore: state.explore
+  }),
   actions
 )(LayoutExplore);

--- a/layout/explore/initial-state.js
+++ b/layout/explore/initial-state.js
@@ -11,10 +11,7 @@ export default {
     limit: 12,
     total: 0,
     mode: 'grid', // 'grid' or 'list'
-    selected: {
-      id: null,
-      data: {}
-    }
+    selected: null
   },
   filters: {
     open: false,

--- a/layout/explore/initial-state.js
+++ b/layout/explore/initial-state.js
@@ -10,7 +10,11 @@ export default {
     page: 1,
     limit: 12,
     total: 0,
-    mode: 'grid' // 'grid' or 'list'
+    mode: 'grid', // 'grid' or 'list'
+    selected: {
+      id: null,
+      data: {}
+    }
   },
   filters: {
     open: false,

--- a/layout/explore/reducers.js
+++ b/layout/explore/reducers.js
@@ -42,7 +42,7 @@ export default {
     return { ...state, datasets };
   },
   [actions.setSelectedDataset]: (state, action) => {
-    const datasets = { ...state.datasets, selected: { ...state.datasets.selected, id: action.payload } };
+    const datasets = { ...state.datasets, selected: action.payload };
     return { ...state, datasets };
   },
 

--- a/layout/explore/reducers.js
+++ b/layout/explore/reducers.js
@@ -41,6 +41,10 @@ export default {
     logEvent('Explore Menu', 'Change dataset view', action.payload);
     return { ...state, datasets };
   },
+  [actions.setSelectedDataset]: (state, action) => {
+    const datasets = { ...state.datasets, selected: { ...state.datasets.selected, id: action.payload } };
+    return { ...state, datasets };
+  },
 
 
   //


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/74831924-82f98d00-5316-11ea-832f-9dc7119bf23d.png)

## Overview
This PR includes a first draft of the Explore detail component integrated into the sidebar. The header including the buttons has been included as well as the dataset title. The dataset info is loaded by means of a hook using `userReducer` and `useEffect`.

## Testing instructions
Go to `localhost:9000/data/explore` and verify that the sidebar shows the Explore detail component when clicking on one of the dataset cards `Details` button.