### PR TITLE
URL approach for Explore detail updated

### DIFF
--- a/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
+++ b/components/app/myrw/datasets/pages/my-rw-datasets/dataset-list/dataset-list-card-component.js
@@ -54,7 +54,7 @@ class DatasetsListCard extends PureComponent {
     const linkProps = {
       ...isAdmin && { route: 'admin_data_detail', params: { tab: 'datasets', id: dataset.id } },
       ...!isAdmin && (isOwner ? { route: 'myrw_detail', params: { tab: 'datasets', id: dataset.id } }
-        : { route: 'explore_detail', params: { id: dataset.id } })
+        : { route: 'explore', params: { dataset: dataset.slug } })
     };
 
     return (

--- a/components/datasets/list/list-item/component.js
+++ b/components/datasets/list/list-item/component.js
@@ -42,9 +42,7 @@ class DatasetListItem extends React.Component {
     responsive: PropTypes.object
   };
 
-  static defaultProps = {
-    mode: 'grid'
-  }
+  static defaultProps = { mode: 'grid' }
 
   /**
    * HELPER
@@ -68,9 +66,7 @@ class DatasetListItem extends React.Component {
    * - renderChart
   */
   renderChart = () => {
-    const {
-      dataset, widget, layer, mode
-    } = this.props;
+    const { dataset, widget, layer, mode } = this.props;
 
     const isWidgetMap = widget && widget.widgetConfig.type === 'map';
     const isEmbedWidget = widget && widget.widgetConfig.type === 'embed';
@@ -93,7 +89,7 @@ class DatasetListItem extends React.Component {
 
     return (
       <div className="list-item-chart">
-        <Link route="explore_detail" params={{ id: dataset.id }}>
+        <Link route="explore" params={{ dataset: dataset.slug }}>
           <a>
             <PlaceholderChart />
           </a>
@@ -103,9 +99,7 @@ class DatasetListItem extends React.Component {
   }
 
   render() {
-    const {
-      dataset, metadata, mode, user, actions, tags, responsive
-    } = this.props;
+    const { dataset, metadata, mode, user, actions, tags, responsive } = this.props;
 
     const isInACollection = belongsToACollection(user, dataset);
     const starIconName = classnames({
@@ -136,7 +130,7 @@ class DatasetListItem extends React.Component {
           values={{ deviceWidth: responsive.fakeWidth }}
         >
           <Link
-            route="explore_detail"
+            route="explore"
             params={{ id: this.props.dataset.slug }}
           >
             {this.renderChart()}
@@ -150,8 +144,8 @@ class DatasetListItem extends React.Component {
             <div className="title-container">
               <h4>
                 <Link
-                  route="explore_detail"
-                  params={{ id: this.props.dataset.slug }}
+                  route="explore"
+                  params={{ dataset: this.props.dataset.slug }}
                 >
                   <a>
                     {(metadata && metadata.info && metadata.info.name) || dataset.name}

--- a/components/modal/layer-info-modal/layer-info-modal-component.js
+++ b/components/modal/layer-info-modal/layer-info-modal-component.js
@@ -14,7 +14,7 @@ function LayerInfoModal(props) {
       .then((dataset) => {
         setSlug(dataset.slug);
       });
-  }, []);
+  }, [layer.dataset]);
 
   return (
     <div className="c-layer-info-modal">
@@ -24,7 +24,7 @@ function LayerInfoModal(props) {
           <ReactMarkdown linkTarget="_blank" source={layer.description} />
         </div>
         <div className="c-button-container -j-end">
-          <Link route="explore_detail" params={{ id: slug }}>
+          <Link route="explore" params={{ id: slug }}>
             <a className="c-btn -primary">More info</a>
           </Link>
         </div>

--- a/components/subscriptions/SubscriptionCard.js
+++ b/components/subscriptions/SubscriptionCard.js
@@ -128,7 +128,7 @@ class SubscriptionCard extends React.Component {
   }
 
   handleGoToDataset = () => {
-    Router.pushRoute('explore_detail', { id: this.props.subscription.datasets[0] });
+    Router.pushRoute('explore', { dataset: this.props.subscription.datasets[0] });
   }
 
   render() {

--- a/components/widgets/card/component.js
+++ b/components/widgets/card/component.js
@@ -118,7 +118,7 @@ const WidgetCard = (props) => {
   const handleGoToDataset = () => {
     const { dataset } = widget;
 
-    Router.pushRoute('explore_detail', { id: dataset });
+    Router.pushRoute('explore', { dataset });
   };
 
   const handleDownloadPDF = () => {

--- a/layout/app/pulse/layer-card/component.js
+++ b/layout/app/pulse/layer-card/component.js
@@ -186,8 +186,8 @@ class LayerCardComponent extends PureComponent {
               <div
                 key={widget.id}
                 className="widget-card"
-                onClick={() => Router.pushRoute('explore_detail', { id: widget.dataset })}
-                onKeyDown={() => Router.pushRoute('explore_detail', { id: widget.dataset })}
+                onClick={() => Router.pushRoute('explore', { dataset: widget.dataset })}
+                onKeyDown={() => Router.pushRoute('explore', { dataset: widget.dataset })}
                 role="button"
                 tabIndex={-1}
               >
@@ -205,8 +205,8 @@ class LayerCardComponent extends PureComponent {
           <div className="card-buttons">
             {datasetId &&
               <Link
-                route="explore_detail"
-                params={{ id: datasetId }}
+                route="explore"
+                params={{ dataset: datasetId }}
               >
                 <a className="c-button -tertiary link_button" >Details</a>
               </Link>

--- a/layout/embed/dataset/component.js
+++ b/layout/embed/dataset/component.js
@@ -91,8 +91,8 @@ class LayoutEmbedDataset extends PureComponent {
             <div className="widget-title">
               <h2>
                 <Link
-                  route="explore_detail"
-                  params={{ id: dataset.id }}
+                  route="explore"
+                  params={{ dataset: dataset.slug }}
                 >
                   <a>{datasetName}</a>
                 </Link>

--- a/layout/embed/map/component.js
+++ b/layout/embed/map/component.js
@@ -277,8 +277,8 @@ class LayoutEmbedMap extends PureComponent {
           {!webshot && (
             <div className="widget-title">
               <Link
-                route="explore_detail"
-                params={{ id: dataset }}
+                route="explore"
+                params={{ dataset }}
               >
                 <a target="_blank" rel="noopener noreferrer">
                   <h4>{name}</h4>

--- a/layout/explore/explore-datasets/explore-datasets-actions/component.js
+++ b/layout/explore/explore-datasets/explore-datasets-actions/component.js
@@ -4,9 +4,9 @@ import classnames from 'classnames';
 
 class ExploreDatasetsActionsComponent extends PureComponent {
   static propTypes = {
-    dataset: PropTypes.object,
-    layer: PropTypes.object,
-    layerGroups: PropTypes.array,
+    dataset: PropTypes.object.isRequired,
+    layer: PropTypes.object.isRequired,
+    layerGroups: PropTypes.array.isRequired,
     toggleMapLayerGroup: PropTypes.func.isRequired,
     resetMapLayerGroupsInteraction: PropTypes.func.isRequired,
     setSelectedDataset: PropTypes.func.isRequired
@@ -47,7 +47,7 @@ class ExploreDatasetsActionsComponent extends PureComponent {
 
         <button
           className="c-button -tertiary -compressed"
-          onClick={() => setSelectedDataset(dataset.id)}
+          onClick={() => setSelectedDataset(dataset.slug || dataset.id)}
         >
             Details
         </button>

--- a/layout/myrw/detail/component.js
+++ b/layout/myrw/detail/component.js
@@ -96,8 +96,8 @@ class LayoutMyRWDetail extends PureComponent {
       return alert.map((a, k) => (
         <span>
           <Link
-            route="explore_detail"
-            params={{ id: a.id }}
+            route="explore"
+            params={{ dataset: a.dataset }}
           >
             <a>
               {getLabel(a.dataset)}
@@ -137,7 +137,7 @@ class LayoutMyRWDetail extends PureComponent {
                     (
                       <div className="page-header-info">
                         <ul>
-                          <li>Dataset: <Link route="explore_detail" params={{ id: myrwdetail.dataset.id }}><a>{myrwdetail.dataset.name}</a></Link></li>
+                          <li>Dataset: <Link route="explore" params={{ dataset: myrwdetail.dataset.slug }}><a>{myrwdetail.dataset.name}</a></Link></li>
                         </ul>
                       </div>
                     )}

--- a/pages/app/explore/index.js
+++ b/pages/app/explore/index.js
@@ -41,7 +41,8 @@ class ExplorePage extends PureComponent {
       basemap,
       labels,
       boundaries,
-      layers
+      layers,
+      dataset
     } = query;
 
     // Query
@@ -55,6 +56,8 @@ class ExplorePage extends PureComponent {
     if (dataTypes) dispatch(actions.setFiltersSelected({ key: 'data_types', list: JSON.parse(decodeURIComponent(dataTypes)) }));
     if (frequencies) dispatch(actions.setFiltersSelected({ key: 'frequencies', list: JSON.parse(decodeURIComponent(frequencies)) }));
     if (timePeriods) dispatch(actions.setFiltersSelected({ key: 'time_periods', list: JSON.parse(decodeURIComponent(timePeriods)) }));
+    // Selected dataset --> "Old" Explore Detail
+    if (dataset) dispatch(actions.setSelectedDataset(dataset));
 
     // sets map params from URL
     dispatch(actions.setViewport({
@@ -111,6 +114,8 @@ class ExplorePage extends PureComponent {
     } = this.props;
 
     const query = {
+      // dataset --> "Old" Explore Detail
+      ...!!datasets && datasets.selected && { dataset: datasets.selected },
       // map params
       zoom: viewport.zoom,
       lat: viewport.latitude,

--- a/routes.js
+++ b/routes.js
@@ -43,7 +43,7 @@ routes.add('newsletter-thank-you', '/about/newsletter-thank-you', 'app/newslette
 
 // ----- DATA -----
 // routes.add('data', '/data', 'app/Explore'); // TODO: create the data page
-routes.add('explore', '/data/explore', 'app/explore');
+routes.add('explore', '/data/explore/:dataset?', 'app/explore');
 routes.add('explore_embed', '/embed/data/explore', 'app/explore/embed');
 
 routes.add('pulse', '/data/pulse', 'app/pulse');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/74936678-e48b2b80-53ea-11ea-802f-b439df1fdf56.png)

## Overview
This PR updates the way we were handling routes for **_Explore detail_** and _**Explore**_.
The new approach consists of using the same route for both: `/data/explore` but adding the dataset slug as a parameter in the case of the new Explore detail: `/data/explore/?dataset_slug`.

## Testing instructions
You should be able now to:
- Navigate directly to a dataset detail page by using the URL:  `localhost:9000/data/explore/?dataset_slug`.
- Reload that page and verify that the Explore sidebar reacts accordingly
- Keep the rest of the Explore parameters that are used for the map as you navigate back and forth from Explore to the new "Explore detail sidebar"