### PR TITLE
Explore detail: save button connected to collections tooltip

### DIFF
--- a/components/datasets/list/list-item/component.js
+++ b/components/datasets/list/list-item/component.js
@@ -16,6 +16,7 @@ import { breakpoints } from 'utils/responsive';
 // Tooltip
 import { Tooltip } from 'vizzuality-components';
 import CollectionsPanel from 'components/collections-panel';
+import { getTooltipContainer } from 'utils/tooltip';
 
 // helpers
 import { belongsToACollection } from 'components/collections-panel/collections-panel-helpers';
@@ -43,23 +44,6 @@ class DatasetListItem extends React.Component {
   };
 
   static defaultProps = { mode: 'grid' }
-
-  /**
-   * HELPER
-   * - getTooltipContainer
-   * - fetchDatasets
-  */
-  getTooltipContainer() {
-    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-      if (document.querySelector('.sidebar-content')) {
-        return document.querySelector('.sidebar-content');
-      }
-
-      return document.body;
-    }
-
-    return null;
-  }
 
   /**
    * HELPER
@@ -164,7 +148,7 @@ class DatasetListItem extends React.Component {
                     overlayClassName="c-rc-tooltip"
                     placement="bottomRight"
                     trigger="click"
-                    getTooltipContainer={this.getTooltipContainer}
+                    getTooltipContainer={getTooltipContainer}
                     monitorWindowResize
                   >
                     <button

--- a/layout/explore/explore-datasets-header/explore-datasets-sort/explore-datasets-sort-component.js
+++ b/layout/explore/explore-datasets-header/explore-datasets-sort/explore-datasets-sort-component.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import { Tooltip } from 'vizzuality-components';
+import { getTooltipContainer } from 'utils/tooltip';
 
 // Components
 import Icon from 'components/ui/icon';
@@ -39,18 +40,6 @@ class ExploreDatasetsSortComponent extends PureComponent {
     this.props.fetchDatasets();
   }
 
-  getTooltipContainer() {
-    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-      if (document.querySelector('.sidebar-content')) {
-        return document.querySelector('.sidebar-content');
-      }
-
-      return document.body;
-    }
-
-    return null;
-  }
-
   render() {
     const {
       selected,
@@ -74,7 +63,7 @@ class ExploreDatasetsSortComponent extends PureComponent {
           placement="top"
           trigger={['click']}
           mouseLeaveDelay={0}
-          getTooltipContainer={this.getTooltipContainer}
+          getTooltipContainer={getTooltipContainer}
           destroyTooltipOnHide
         >
           <button

--- a/layout/explore/explore-datasets/explore-datasets-tags/component.js
+++ b/layout/explore/explore-datasets/explore-datasets-tags/component.js
@@ -10,6 +10,8 @@ import { TAGS_BLACKLIST } from 'utils/tags';
 import { Tooltip } from 'vizzuality-components';
 import Tag from 'components/ui/Tag';
 import TagsTooltip from './tooltip';
+import { getTooltipContainer } from 'utils/tooltip';
+
 
 class ExploreDatasetsTagsComponent extends React.Component {
   static propTypes = {
@@ -43,9 +45,7 @@ class ExploreDatasetsTagsComponent extends React.Component {
   }
 
   onVisibleChange = (visible) => {
-    const {
-      vocabulary
-    } = this.props;
+    const { vocabulary } = this.props;
 
     if (visible) {
       this.setState({ tagsLoading: true });
@@ -65,20 +65,8 @@ class ExploreDatasetsTagsComponent extends React.Component {
 
   /**
    * HELPER
-   * - getTooltipContainer
    * - fetchDatasets
   */
-  getTooltipContainer() {
-    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-      if (document.querySelector('.sidebar-content')) {
-        return document.querySelector('.sidebar-content');
-      }
-
-      return document.body;
-    }
-
-    return null;
-  }
 
   fetchDatasets = debounce((page) => {
     this.props.setDatasetsPage(page);
@@ -137,7 +125,7 @@ class ExploreDatasetsTagsComponent extends React.Component {
               trigger="click"
               monitorWindowResize
               destroyTooltipOnHide
-              getTooltipContainer={this.getTooltipContainer}
+              getTooltipContainer={getTooltipContainer}
               onVisibleChange={this.onVisibleChange}
             >
               <button>

--- a/layout/explore/explore-detail/component.js
+++ b/layout/explore/explore-detail/component.js
@@ -31,7 +31,7 @@ class ExploreDetailComponent extends React.Component {
         <Spinner isLoading={loading} className="-light" />
         { metadata &&
           <Fragment>
-            <ExploreDetailHeader />
+            <ExploreDetailHeader dataset={dataset} />
             <div className="content">
               <div id="overview" className="row">
                 <div className="column small-12">

--- a/layout/explore/explore-detail/explore-detail-header/component.js
+++ b/layout/explore/explore-detail/explore-detail-header/component.js
@@ -3,12 +3,20 @@ import PropTypes from 'prop-types';
 
 // Components
 import Icon from 'components/ui/icon';
+import LoginRequired from 'components/ui/login-required';
+
+// Tooltip
+import { Tooltip } from 'vizzuality-components';
+import CollectionsPanel from 'components/collections-panel';
+import { getTooltipContainer } from 'utils/tooltip';
 
 // Styles
 import './styles.scss';
 
 function ExploreDetailHeaderComponent(props) {
-  const { setSelectedDataset } = props;
+  const { dataset, setSelectedDataset } = props;
+
+
   return (
     <div className="c-explore-detail-header">
       <button
@@ -18,12 +26,30 @@ function ExploreDetailHeaderComponent(props) {
         {'< ALL DATASETS'}
       </button>
       <div className="right-buttons">
+        {/* Collections tooltip */}
+        <LoginRequired>
+          <Tooltip
+            overlay={
+              <CollectionsPanel
+                resource={dataset}
+                resourceType="dataset"
+              />
+            }
+            overlayClassName="c-rc-tooltip"
+            placement="bottomRight"
+            trigger="click"
+            getTooltipContainer={getTooltipContainer}
+            monitorWindowResize
+          >
+            <button className="c-btn -secondary -compressed">
+              <Icon className="-small" name="icon-star-full" />
+              <span>SAVE</span>
+            </button>
+          </Tooltip>
+        </LoginRequired>
+
         <button className="c-btn -secondary -compressed">
-          <Icon className="-small" name="icon-star-full" className="-small" />
-          <span>SAVE</span>
-        </button>
-        <button className="c-btn -secondary -compressed">
-          <Icon className="-small" name="icon-arrow-up-2" className="-small" />
+          <Icon className="-small" name="icon-arrow-up-2" />
           <span>SHARE</span>
         </button>
       </div>
@@ -32,6 +58,7 @@ function ExploreDetailHeaderComponent(props) {
 }
 
 ExploreDetailHeaderComponent.propTypes = {
+  dataset: PropTypes.object.isRequired,
   // Store
   setSelectedDataset: PropTypes.func.isRequired
 };

--- a/layout/explore/explore-detail/explore-detail-header/styles.scss
+++ b/layout/explore/explore-detail/explore-detail-header/styles.scss
@@ -10,6 +10,7 @@
     padding: 2 * $space 8 * $space 2 * $space 8 * $space;
 
     .right-buttons {
+        display: flex;
         button:first-child {
             margin-right: $space;
         }

--- a/utils/tooltip.js
+++ b/utils/tooltip.js
@@ -1,0 +1,13 @@
+export const getTooltipContainer = () => {
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    if (document.querySelector('.sidebar-content')) {
+      return document.querySelector('.sidebar-content');
+    }
+
+    return document.body;
+  }
+
+  return null;
+};
+
+export default { getTooltipContainer };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/75149160-a3a05900-5701-11ea-9386-77d4496e2f91.png)

## Overview
This PR implements the feature to "save" a dataset into a collection from the new Explore detail section.
_NOTE: It also creates a new file `utils/tooltip.js` to centralize code that was repeated in different components across the app._

## Testing instructions
Go to a dataset detail's page and click on the `SAVE` button.