### PR TITLE
Feature/add source and date

### DIFF
--- a/layout/explore/explore-detail/component.js
+++ b/layout/explore/explore-detail/component.js
@@ -4,6 +4,11 @@ import PropTypes from 'prop-types';
 // Components
 import Spinner from 'components/ui/Spinner';
 import ReadMore from 'components/ui/ReadMore';
+
+// Utils
+import { getDateConsideringTimeZone } from 'utils/utils';
+
+// Explore detail components
 import ExploreDetailHeader from './explore-detail-header';
 import ExploreDetailFooter from './explore-detail-footer';
 import FurtherInformation from './further-information';
@@ -27,6 +32,8 @@ class ExploreDetailComponent extends React.Component {
     const { dataset, loading } = this.props;
     const metadata = dataset && dataset.metadata && dataset.metadata[0];
     const layers = dataset && dataset.layer;
+    const dateLastUpdated = getDateConsideringTimeZone(dataset && dataset.dataLastUpdated);
+
 
     return (
       <div className="c-explore-detail">
@@ -40,7 +47,12 @@ class ExploreDetailComponent extends React.Component {
                   <h2>{metadata.info && metadata.info.name}</h2>
                 </div>
                 <div className="source-date">
-                  {metadata.source}
+                  <div className="source" title={metadata.source} >
+                    {metadata.source}
+                  </div>
+                  <div className="date">
+                    {dateLastUpdated ? `UPDATED ON ${dateLastUpdated}`.toUpperCase() : ''}
+                  </div>
                 </div>
                 <div className="functions">
                   {metadata.info && metadata.info.functions}
@@ -54,10 +66,8 @@ class ExploreDetailComponent extends React.Component {
                   />
                 </div>
               </div>
-              <div id="layers" className="row">
-                <div className="column small-12">
-                  <DatasetLayers layers={layers} dataset={dataset} />
-                </div>
+              <div id="layers" className="metadata-section">
+                <DatasetLayers layers={layers} dataset={dataset} />
               </div>
               <div id="visualization" className="metadata-section">
                 <h3>Customize visualization</h3>

--- a/layout/explore/explore-detail/component.js
+++ b/layout/explore/explore-detail/component.js
@@ -33,22 +33,23 @@ class ExploreDetailComponent extends React.Component {
           <Fragment>
             <ExploreDetailHeader />
             <div className="content">
-              <div id="overview" className="row">
-                <div className="column small-12">
-                  <div className="title">
-                    <h2>{metadata.info && metadata.info.name}</h2>
-                  </div>
-                  <div className="functions">
-                    {metadata.info && metadata.info.functions}
-                  </div>
-                  <div className="buttons" />
-                  <div className="description">
-                    <ReadMore
-                      markdown
-                      text={metadata.description}
-                      limitChar={DEFAULT_LIMIT_CHAR_FOR_METADATA_FIELDS}
-                    />
-                  </div>
+              <div id="overview" className="overview metadata-section">
+                <div className="title">
+                  <h2>{metadata.info && metadata.info.name}</h2>
+                </div>
+                <div className="source-date">
+                  {metadata.source}
+                </div>
+                <div className="functions">
+                  {metadata.info && metadata.info.functions}
+                </div>
+                <div className="buttons" />
+                <div className="description">
+                  <ReadMore
+                    markdown
+                    text={metadata.description}
+                    limitChar={DEFAULT_LIMIT_CHAR_FOR_METADATA_FIELDS}
+                  />
                 </div>
               </div>
               <div id="layers" className="row">
@@ -56,20 +57,14 @@ class ExploreDetailComponent extends React.Component {
                   <h3>Dataset layers</h3>
                 </div>
               </div>
-              <div id="visualization" className="row">
-                <div className="column small-12">
-                  <h3>Customize visualization</h3>
-                </div>
+              <div id="visualization" className="metadata-section">
+                <h3>Customize visualization</h3>
               </div>
-              <div id="further_information" className="row">
-                <div className="column small-12">
-                  <FurtherInformation metadata={metadata} />
-                </div>
+              <div id="further_information" className="metadata-section">
+                <FurtherInformation metadata={metadata} />
               </div>
-              <div id="related_content" className="row">
-                <div className="column small-12">
-                  <h3>Related content</h3>
-                </div>
+              <div id="related_content" className="metadata-section">
+                <h3>Related content</h3>
               </div>
             </div>
             <ExploreDetailFooter />

--- a/layout/explore/explore-detail/styles.scss
+++ b/layout/explore/explore-detail/styles.scss
@@ -9,28 +9,32 @@
             background-color: white;
             margin-bottom: 2 * $space;
             padding: 8 * $space 8 * $space 8 * $space 8 * $space;
-            
-            .overview {
-                .title {
-                    margin-top: $space * 4;
-                }
-                .source-date {
-                    display: flex;
-                    width: 100%;
-                    justify-content: space-between;
-                    .source {
-                        max-width: 100px;
-                        text-overflow: ellipsis;
-                    }
-                    
-                }   
-            }
         }
         h3 {
             margin-bottom: 5 * $space;
         }
         h4 {
             margin: 0px;
+        }
+
+        .overview {
+            .title {
+                margin-top: $space * 4;
+            }
+            .source-date {
+                display: flex;
+                width: 100%;
+                justify-content: space-between;
+                margin: 2 * $space 0px 5 * $space 0px;
+                font-size: $font-size-extra-small;
+
+                .source {
+                    width: 200px;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                    overflow: hidden;
+                }
+            }   
         }
     }
 }

--- a/layout/explore/explore-detail/styles.scss
+++ b/layout/explore/explore-detail/styles.scss
@@ -5,21 +5,32 @@
         min-height: 100%;
         background-color: $color-12;
 
-        .row {
+        .metadata-section {
             background-color: white;
             margin-bottom: 2 * $space;
             padding: 8 * $space 8 * $space 8 * $space 8 * $space;
-            .column {
+            
+            .overview {
                 .title {
                     margin-top: $space * 4;
                 }
-                h3 {
-                    margin-bottom: 5 * $space;
-                }
-                h4 {
-                    margin: 0px;
-                }
+                .source-date {
+                    display: flex;
+                    width: 100%;
+                    justify-content: space-between;
+                    .source {
+                        max-width: 100px;
+                        text-overflow: ellipsis;
+                    }
+                    
+                }   
             }
+        }
+        h3 {
+            margin-bottom: 5 * $space;
+        }
+        h4 {
+            margin: 0px;
         }
     }
 }

--- a/layout/explore/explore-detail/styles.scss
+++ b/layout/explore/explore-detail/styles.scss
@@ -29,10 +29,10 @@
                 font-size: $font-size-extra-small;
 
                 .source {
-                    width: 200px;
                     text-overflow: ellipsis;
                     white-space: nowrap;
                     overflow: hidden;
+                    margin-right: 4 * $space;
                 }
             }   
         }


### PR DESCRIPTION
![imagen](https://user-images.githubusercontent.com/545342/75243759-c6e30b00-57ca-11ea-9d6b-42ebd0452ffb.png)

## Overview
This PR adds the dataset source and `dataLastUpdated` date to the Explore detail section. Ellipsis is used for sources that don't fit in the space allocated for them.
Besides that, styles for the Explore detail sub-sections have been modified so that `row` and `column` are not used - we didn't need them for this in the end.

## Testing instructions
Check a dataset detail page such as http://localhost:9000/data/explore/for006nrt-Active-Fires-VIIRS_old_replacement
Check this dataset detail page to see the ellipsis working: http://localhost:9000/data/explore/Powerwatch
_NOTE: Bear in mind that not all datasets have this date, only or mostly the Near-real-time ones._