### PR TITLE
Fix/interaction popup 0 format

### DIFF
--- a/components/map/popup/component.js
+++ b/components/map/popup/component.js
@@ -114,7 +114,7 @@ class LayerPopup extends PureComponent {
   formatValue(item, data) {
     if (item.type === 'date' && item.format && data) {
       data = moment(data).format(item.format);
-    } else if (item.type === 'number' && item.format && data) {
+    } else if (item.type === 'number' && item.format && (data || data ===0)) {
       data = numeral(data).format(item.format);
     }
 

--- a/components/ui/map/popup/LayerPopup.js
+++ b/components/ui/map/popup/LayerPopup.js
@@ -85,7 +85,7 @@ class LayerPopup extends React.Component {
   formatValue(item, data) {
     if (item.type === 'date' && item.format && data) {
       data = moment(data).format(item.format);
-    } else if (item.type === 'number' && item.format && data) {
+    } else if (item.type === 'number' && item.format && (data || data === 0)) {
       data = numeral(data).format(item.format);
     }
 


### PR DESCRIPTION
## Overview
The formatValue function formatting the data for map interaction popups short circuits in cases when the data value is `0`, and gets set to `-` when it should be `0`. This PR amends the formatValue function logic for number type data. 

## Testing instructions
To test if it works, go to [populations in coastal zones data on Resource Watch](https://resourcewatch.org/data/explore/Populations-in-Coastal-Zones) --> click Open in Map to view layer --> click on landlocked country --> Popup value should read `0%` instead of `-%`

## Pivotal task
na

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
