### PR TITLE
Fix topic cards styles

### DIFF
--- a/layout/explore/explore-topics/component.js
+++ b/layout/explore/explore-topics/component.js
@@ -26,9 +26,13 @@ function ExploreTopicsComponent(props) {
               onClick={() => clickHandler(topic.id)}
               onKeyPress={() => clickHandler(topic.id)}
             >
-              <div className="topic-overlay" style={{ backgroundColor: topic.backgroundColor }} />
-              <div className="topic-gradient" />
-              <div className="topic-image" style={{ backgroundImage: `url(${topic.backgroundURL}` }} />
+              <div
+                className="topic-image"
+                style={{
+ background: `linear-gradient(${topic.backgroundColor},${topic.backgroundColor}),
+                linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.30)),url(${topic.backgroundURL})`
+}}
+              />
               <div className="topic-title">
                 {topic.label}
               </div>

--- a/layout/explore/explore-topics/styles.scss
+++ b/layout/explore/explore-topics/styles.scss
@@ -17,30 +17,12 @@
                 border-radius: 4px;
                 box-shadow: 0 2px 6px 0 rgba(0,0,0,0.1);
                 
-                .topic-overlay {
-                    position: absolute;
-                    top: 0px;
-                    left: 0px;
-                    width: 100%;
-                    height: 100%;
-                    opacity: 0.7;
-                    border-radius: 4px;
-                }
-
-                .topic-gradient {
-                    position: absolute;
-                    top: 0px;
-                    left: 0px;
-                    width: 100%;
-                    height: 100%;
-                    background: linear-gradient(0deg, rgba(0,0,0,30) 0%, rgba(0,0,0,0) 100%);
-                }
-
                 .topic-image {
                     width: 100%;
                     height: 100%;
                     border-radius: 4px;
                     background-size: cover;
+                    transition: all $animation-time-2 $ease-in-out-sine;
                 }
 
                 .topic-title {
@@ -53,7 +35,6 @@
                 &:hover {
                     box-shadow: 0 20px 30px rgba($black, .2);
                     transform: translateY(-4px);
-                    transition: all $animation-time-2 $ease-in-out-sine;
                 }
             }
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/75960557-8bc69300-5ec0-11ea-8e5b-afb94c0cd895.png)

## Overview
This PR fixes the styles for the topic cards included in the Topics section from Explore.

## Testing instructions
Go to http://localhost:9000/data/explore?section=Topics