### PR TITLE
Explore collections

### DIFF
--- a/layout/explore/actions.js
+++ b/layout/explore/actions.js
@@ -161,6 +161,7 @@ export const resetFiltersSort = createAction('EXPLORE/resetFiltersSort');
 export const setSidebarOpen = createAction('EXPLORE/setSidebarOpen');
 export const setSidebarAnchor = createAction('EXPLORE/setSidebarAnchor');
 export const setSidebarSection = createAction('EXPLORE/setSidebarSection');
+export const setSidebarSelectedCollection = createAction('EXPLORE/setSidebarSelectedCollection');
 
 // TAGS TOOLTIP
 export const setTags = createAction('EXPLORE/setTags');

--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -17,20 +17,26 @@ import ExploreMap from 'layout/explore/explore-map';
 import ExploreDetail from 'layout/explore/explore-detail';
 import ExploreTopics from 'layout/explore/explore-topics';
 import ExploreCollections from 'layout/explore/explore-collections';
+import ExploreLogin from 'layout/explore/explore-login';
 
 // utils
 import { breakpoints } from 'utils/responsive';
 import { EXPLORE_SECTIONS } from './constants';
 
 class Explore extends PureComponent {
-  static propTypes = { responsive: PropTypes.object.isRequired };
+  static propTypes = {
+    responsive: PropTypes.object.isRequired,
+    explore: PropTypes.object.isRequired,
+    userIsLoggedIn: PropTypes.bool.isRequired
+  };
 
   state = { mobileWarningOpened: true }
 
   render() {
     const {
       responsive,
-      explore: { datasets: { selected }, sidebar: { section } }
+      explore: { datasets: { selected }, sidebar: { section } },
+      userIsLoggedIn
     } = this.props;
     const { mobileWarningOpened } = this.state;
     return (
@@ -51,8 +57,11 @@ class Explore extends PureComponent {
                   {section === EXPLORE_SECTIONS.TOPICS &&
                     <ExploreTopics />
                   }
-                  {section === EXPLORE_SECTIONS.COLLECTIONS &&
+                  {section === EXPLORE_SECTIONS.COLLECTIONS && userIsLoggedIn &&
                     <ExploreCollections />
+                  }
+                  {section === EXPLORE_SECTIONS.COLLECTIONS && !userIsLoggedIn &&
+                    <ExploreLogin />
                   }
                   {/* <ExploreDatasetsHeader /> */}
                 </div>

--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -16,6 +16,7 @@ import ExploreDatasets from 'layout/explore/explore-datasets';
 import ExploreMap from 'layout/explore/explore-map';
 import ExploreDetail from 'layout/explore/explore-detail';
 import ExploreTopics from 'layout/explore/explore-topics';
+import ExploreCollections from 'layout/explore/explore-collections';
 
 // utils
 import { breakpoints } from 'utils/responsive';
@@ -49,6 +50,9 @@ class Explore extends PureComponent {
                   }
                   {section === EXPLORE_SECTIONS.TOPICS &&
                     <ExploreTopics />
+                  }
+                  {section === EXPLORE_SECTIONS.COLLECTIONS &&
+                    <ExploreCollections />
                   }
                   {/* <ExploreDatasetsHeader /> */}
                 </div>

--- a/layout/explore/constants.js
+++ b/layout/explore/constants.js
@@ -2,5 +2,6 @@ export const EXPLORE_SECTIONS = {
   DISCOVER: 'Discover',
   ALL_DATA: 'All data',
   NEAR_REAL_TIME: 'Near Real-Time',
-  TOPICS: 'Topics'
+  TOPICS: 'Topics',
+  COLLECTIONS: 'Collections'
 };

--- a/layout/explore/explore-collections/component.js
+++ b/layout/explore/explore-collections/component.js
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { toastr } from 'react-redux-toastr';
+
+// Services
+import { fetchDatasets } from 'services/dataset';
+
+// Components
+import DatasetList from 'layout/explore/explore-datasets/list';
+import Spinner from 'components/ui/Spinner';
+
+// Styles
+import './styles.scss';
+
+function ExploreCollectionsComponent(props) {
+  const { collection } = props;
+  const [datasets, setDatasets] = useState([]);
+  const [datasetsLoading, setDatasetsLoading] = useState(false);
+
+  useEffect(() => {
+    const datasetIDs = collection &&
+        collection.resources.filter(elem => elem.type === 'dataset').map(e => e.id) || [];
+    if (datasetIDs.length > 0) {
+      console.log('load datasets:', datasetIDs);
+
+      setDatasetsLoading(true);
+      fetchDatasets({
+        ids: datasetIDs.join(','),
+        includes: 'widget,metadata,layer,vocabulary'
+      })
+        .then((data) => {
+          setDatasets(data);
+          setDatasetsLoading(false);
+        })
+        .catch((err) => {
+          toastr.error('Error loading collection datasets', err);
+          setDatasetsLoading(false);
+        });
+    } else {
+      setDatasets([]);
+    }
+  }, [collection]);
+
+  return (
+    <div className="c-explore-collections">
+      <Spinner isLoading={datasetsLoading} className="-light" />
+      {datasets.length > 0 &&
+        <DatasetList list={datasets} />
+            }
+    </div>
+  );
+}
+
+ExploreCollectionsComponent.propTypes = {
+  setFiltersSelected: PropTypes.func.isRequired,
+  setDatasetsPage: PropTypes.func.isRequired,
+  fetchDatasets: PropTypes.func.isRequired
+};
+
+export default ExploreCollectionsComponent;

--- a/layout/explore/explore-collections/component.js
+++ b/layout/explore/explore-collections/component.js
@@ -8,6 +8,7 @@ import { fetchDatasets } from 'services/dataset';
 // Components
 import DatasetList from 'layout/explore/explore-datasets/list';
 import Spinner from 'components/ui/Spinner';
+import ExploreDatasetsActions from 'layout/explore/explore-datasets/explore-datasets-actions';
 
 // Styles
 import './styles.scss';
@@ -18,11 +19,9 @@ function ExploreCollectionsComponent(props) {
   const [datasetsLoading, setDatasetsLoading] = useState(false);
 
   useEffect(() => {
-    const datasetIDs = collection &&
-        collection.resources.filter(elem => elem.type === 'dataset').map(e => e.id) || [];
+    const datasetIDs = (collection &&
+        collection.resources.filter(elem => elem.type === 'dataset').map(e => e.id)) || [];
     if (datasetIDs.length > 0) {
-      console.log('load datasets:', datasetIDs);
-
       setDatasetsLoading(true);
       fetchDatasets({
         ids: datasetIDs.join(','),
@@ -45,16 +44,15 @@ function ExploreCollectionsComponent(props) {
     <div className="c-explore-collections">
       <Spinner isLoading={datasetsLoading} className="-light" />
       {datasets.length > 0 &&
-        <DatasetList list={datasets} />
-            }
+        <DatasetList
+          list={datasets}
+          actions={<ExploreDatasetsActions />}
+        />
+        }
     </div>
   );
 }
 
-ExploreCollectionsComponent.propTypes = {
-  setFiltersSelected: PropTypes.func.isRequired,
-  setDatasetsPage: PropTypes.func.isRequired,
-  fetchDatasets: PropTypes.func.isRequired
-};
+ExploreCollectionsComponent.propTypes = { collection: PropTypes.func.isRequired };
 
 export default ExploreCollectionsComponent;

--- a/layout/explore/explore-collections/index.js
+++ b/layout/explore/explore-collections/index.js
@@ -1,0 +1,11 @@
+// Redux
+import { connect } from 'react-redux';
+import * as actions from 'layout/explore/actions';
+
+import { getCollection } from './selectors';
+import ExploreCollectionsComponent from './component';
+
+export default connect(
+  state => ({ collection: getCollection(state) }),
+  actions
+)(ExploreCollectionsComponent);

--- a/layout/explore/explore-collections/selectors.js
+++ b/layout/explore/explore-collections/selectors.js
@@ -1,0 +1,11 @@
+import { createSelector } from 'reselect';
+
+const getCollections = state => state.user.collections.items;
+const getSelectedCollection = state => state.explore.sidebar.selectedCollection;
+
+export const getCollection = createSelector(
+  [getCollections, getSelectedCollection],
+  (_collections, _selectedCollection) => _collections.find(c => c.id === _selectedCollection)
+);
+
+export default { getCollection };

--- a/layout/explore/explore-collections/styles.scss
+++ b/layout/explore/explore-collections/styles.scss
@@ -1,0 +1,5 @@
+@import 'css/settings';
+
+.c-explore-collections {
+    height: 100%;
+}

--- a/layout/explore/explore-collections/styles.scss
+++ b/layout/explore/explore-collections/styles.scss
@@ -1,5 +1,5 @@
 @import 'css/settings';
 
 .c-explore-collections {
-    height: 100%;
+    margin-top: 2 * $space;
 }

--- a/layout/explore/explore-login/component.js
+++ b/layout/explore/explore-login/component.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+// Components
+import LoginRequired from 'components/ui/login-required';
+
+// Styles
+import './styles.scss';
+
+function ExploreLogin() {
+  return (
+    <div className="c-explore-login">
+      <div className="card -empty" />
+      <LoginRequired>
+        <div className="card -login">
+          <h4>Log in to start your own data curation</h4>
+          <p>
+              Make your usual data exploration more agile
+              by creating your own dataset collections.
+          </p>
+          <button className="c-button -primary -compressed">
+                        Log in
+          </button>
+        </div>
+      </LoginRequired>
+      <div className="card -empty" />
+      <div className="card -empty" />
+    </div>
+  );
+}
+
+export default ExploreLogin;

--- a/layout/explore/explore-login/index.js
+++ b/layout/explore/explore-login/index.js
@@ -1,0 +1,3 @@
+import ExploreLoginComponent from './component';
+
+export default ExploreLoginComponent;

--- a/layout/explore/explore-login/styles.scss
+++ b/layout/explore/explore-login/styles.scss
@@ -1,0 +1,32 @@
+@import 'css/settings';
+
+.c-explore-login {
+    display: flex;
+    flex-direction: column;
+    margin: 0px 3 * $space 0px 3 * $space;
+
+    .card {
+        margin: 2 * $space 0px 2 * $space 0px;
+
+        &.-empty {
+            height: 130px;
+            background-color: $sea-blue;
+            opacity: 0.05;
+        }
+
+        &.-login {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+
+            h4 {
+                width: 180px;
+            }
+
+            button {
+                width: 100px;
+            }
+        }
+    }
+}

--- a/layout/explore/explore-menu/component.js
+++ b/layout/explore/explore-menu/component.js
@@ -90,7 +90,10 @@ class ExploreMenuComponent extends React.Component {
       search,
       selected,
       section,
-      setSidebarSection
+      selectedCollection,
+      setSidebarSection,
+      setSidebarSelectedCollection,
+      collections
     } = this.props;
 
     return (
@@ -114,9 +117,12 @@ class ExploreMenuComponent extends React.Component {
         <div className="menu-options">
           <div
             className={classnames({
-              'menu-option': true,
-              '-active': section === EXPLORE_SECTIONS.DISCOVER
-})}
+                'menu-option': true,
+                '-active': section === EXPLORE_SECTIONS.DISCOVER
+              })}
+            role="button"
+            tabIndex={0}
+            onKeyPress={() => setSidebarSection(EXPLORE_SECTIONS.DISCOVER)}
             onClick={() => setSidebarSection(EXPLORE_SECTIONS.DISCOVER)}
           >
             <Icon name={`icon-discover-${section === EXPLORE_SECTIONS.DISCOVER ? 'on' : 'off'}`} />
@@ -124,9 +130,12 @@ class ExploreMenuComponent extends React.Component {
           </div>
           <div
             className={classnames({
-              'menu-option': true,
-              '-active': section === EXPLORE_SECTIONS.ALL_DATA
-})}
+                'menu-option': true,
+                '-active': section === EXPLORE_SECTIONS.ALL_DATA
+              })}
+            role="button"
+            tabIndex={0}
+            onKeyPress={() => setSidebarSection(EXPLORE_SECTIONS.ALL_DATA)}
             onClick={() => setSidebarSection(EXPLORE_SECTIONS.ALL_DATA)}
           >
             <Icon name={`icon-all-${section === EXPLORE_SECTIONS.ALL_DATA ? 'on' : 'off'}`} />
@@ -134,9 +143,12 @@ class ExploreMenuComponent extends React.Component {
           </div>
           <div
             className={classnames({
-              'menu-option': true,
-              '-active': section === EXPLORE_SECTIONS.NEAR_REAL_TIME
-})}
+                'menu-option': true,
+                '-active': section === EXPLORE_SECTIONS.NEAR_REAL_TIME
+              })}
+            role="button"
+            tabIndex={0}
+            onKeyPress={() => setSidebarSection(EXPLORE_SECTIONS.NEAR_REAL_TIME)}
             onClick={() => setSidebarSection(EXPLORE_SECTIONS.NEAR_REAL_TIME)}
           >
             <Icon name={`icon-recent-${section === EXPLORE_SECTIONS.NEAR_REAL_TIME ? 'on' : 'off'}`} />
@@ -144,19 +156,42 @@ class ExploreMenuComponent extends React.Component {
           </div>
           <div
             className={classnames({
-              'menu-option': true,
-              '-active': section === EXPLORE_SECTIONS.TOPICS
-})}
+                'menu-option': true,
+                '-active': section === EXPLORE_SECTIONS.TOPICS
+              })}
+            role="button"
+            tabIndex={0}
+            onKeyPress={() => setSidebarSection(EXPLORE_SECTIONS.TOPICS)}
             onClick={() => setSidebarSection(EXPLORE_SECTIONS.TOPICS)}
           >
             <Icon name={`icon-topics-${section === EXPLORE_SECTIONS.TOPICS ? 'on' : 'off'}`} />
             Topics
           </div>
+
+          <hr />
+
+          {collections.map(collection => (
+            <div
+              className={classnames({
+                'menu-option': true,
+                collection: true,
+                '-active': section === EXPLORE_SECTIONS.COLLECTIONS && selectedCollection === collection.id
+                })}
+              role="button"
+              tabIndex={0}
+              onKeyPress={() => {
+                setSidebarSection(EXPLORE_SECTIONS.COLLECTIONS);
+                setSidebarSelectedCollection(collection.id);
+              }}
+              onClick={() => {
+                setSidebarSection(EXPLORE_SECTIONS.COLLECTIONS);
+                setSidebarSelectedCollection(collection.id);
+              }}
+            >
+              <span className="collection-name">{collection.name}</span>
+            </div>
+          ))}
         </div>
-
-        <hr />
-
-        <div className="collections-container" />
       </div >
     );
   }

--- a/layout/explore/explore-menu/component.js
+++ b/layout/explore/explore-menu/component.js
@@ -21,9 +21,12 @@ class ExploreMenuComponent extends React.Component {
     options: PropTypes.object,
     selected: PropTypes.object,
     search: PropTypes.string,
-    sortSelected: PropTypes.string,
+    sortSelected: PropTypes.string.isRequired,
     shouldAutoUpdateSortDirection: PropTypes.bool,
     section: PropTypes.string.isRequired,
+    collections: PropTypes.array.isRequired,
+    userIsLoggedIn: PropTypes.bool.isRequired,
+    selectedCollection: PropTypes.string.isRequired,
 
     // ACTIONS
     fetchDatasets: PropTypes.func.isRequired,
@@ -37,7 +40,8 @@ class ExploreMenuComponent extends React.Component {
     toggleFiltersSelected: PropTypes.func.isRequired,
     resetFiltersSelected: PropTypes.func.isRequired,
     resetFiltersSort: PropTypes.func.isRequired,
-    setSidebarSection: PropTypes.func.isRequired
+    setSidebarSection: PropTypes.func.isRequired,
+    setSidebarSelectedCollection: PropTypes.func.isRequired
   }
 
   onChangeSearch = (search) => {
@@ -93,6 +97,7 @@ class ExploreMenuComponent extends React.Component {
       selectedCollection,
       setSidebarSection,
       setSidebarSelectedCollection,
+      userIsLoggedIn,
       collections
     } = this.props;
 
@@ -170,7 +175,7 @@ class ExploreMenuComponent extends React.Component {
 
           <hr />
 
-          {collections.map(collection => (
+          {userIsLoggedIn && collections.map(collection => (
             <div
               className={classnames({
                 'menu-option': true,
@@ -191,6 +196,21 @@ class ExploreMenuComponent extends React.Component {
               <span className="collection-name">{collection.name}</span>
             </div>
           ))}
+
+          {!userIsLoggedIn &&
+            <div
+              className={classnames({
+                  'menu-option': true,
+                  '-active': section === EXPLORE_SECTIONS.COLLECTIONS
+                })}
+              role="button"
+              tabIndex={0}
+              onKeyPress={() => setSidebarSection(EXPLORE_SECTIONS.COLLECTIONS)}
+              onClick={() => setSidebarSection(EXPLORE_SECTIONS.COLLECTIONS)}
+            >
+              <span className="collection-name">Your favorites</span>
+            </div>
+          }
         </div>
       </div >
     );

--- a/layout/explore/explore-menu/index.js
+++ b/layout/explore/explore-menu/index.js
@@ -4,6 +4,8 @@ import * as actions from 'layout/explore/actions';
 
 import ExploreMenuComponent from './component';
 
+import { getCollectionsFiltered } from './selectors';
+
 export default connect(
   state => ({
     // Store
@@ -13,7 +15,7 @@ export default connect(
     section: state.explore.sidebar.section,
     selectedCollection: state.explore.sidebar.selectedCollection,
     userIsLoggedIn: !!state.user.id,
-    collections: state.user.collections.items
+    collections: getCollectionsFiltered(state)
   }),
   actions
 )(ExploreMenuComponent);

--- a/layout/explore/explore-menu/index.js
+++ b/layout/explore/explore-menu/index.js
@@ -12,6 +12,7 @@ export default connect(
     sortSelected: state.explore.sort.selected,
     section: state.explore.sidebar.section,
     selectedCollection: state.explore.sidebar.selectedCollection,
+    userIsLoggedIn: !!state.user.id,
     collections: state.user.collections.items
   }),
   actions

--- a/layout/explore/explore-menu/index.js
+++ b/layout/explore/explore-menu/index.js
@@ -10,7 +10,9 @@ export default connect(
     ...state.explore.filters,
     shouldAutoUpdateSortDirection: state.explore.sort.isSetFromDefaultState,
     sortSelected: state.explore.sort.selected,
-    section: state.explore.sidebar.section
+    section: state.explore.sidebar.section,
+    selectedCollection: state.explore.sidebar.selectedCollection,
+    collections: state.user.collections.items
   }),
   actions
 )(ExploreMenuComponent);

--- a/layout/explore/explore-menu/selectors.js
+++ b/layout/explore/explore-menu/selectors.js
@@ -1,0 +1,13 @@
+import { createSelector } from 'reselect';
+
+const getCollections = state => state.user.collections.items;
+
+export const getCollectionsFiltered = createSelector(
+  [getCollections],
+  _collections =>
+    // only return collections that have at least one dataset
+    _collections.filter(col => col.resources.find(r => r.type === 'dataset'))
+
+);
+
+export default { getCollectionsFiltered };

--- a/layout/explore/explore-menu/styles.scss
+++ b/layout/explore/explore-menu/styles.scss
@@ -28,6 +28,7 @@
 
             &.-active {
                 border-left: $space solid $sea-blue;
+                background-color: rgba(44,117,176,0.05);
 
                 .c-icon {
                     margin: 0px 5 * $space 0px 3 * $space;

--- a/layout/explore/explore-menu/styles.scss
+++ b/layout/explore/explore-menu/styles.scss
@@ -22,11 +22,18 @@
                 margin: 0px 5 * $space 0px 4 * $space;
             }
 
+            .collection-name {
+                margin-left: 5 * $space;
+            }
+
             &.-active {
                 border-left: $space solid $sea-blue;
 
                 .c-icon {
                     margin: 0px 5 * $space 0px 3 * $space;
+                }
+                .collection-name {
+                    margin-left: 4 * $space;
                 }
             }
         }

--- a/layout/explore/index.js
+++ b/layout/explore/index.js
@@ -13,7 +13,8 @@ export { actions, reducers, initialState };
 export default connect(
   state => ({
     responsive: state.responsive,
-    explore: state.explore
+    explore: state.explore,
+    userIsLoggedIn: !!state.user.id
   }),
   actions
 )(LayoutExplore);

--- a/layout/explore/initial-state.js
+++ b/layout/explore/initial-state.js
@@ -87,7 +87,8 @@ export default {
   sidebar: {
     open: true,
     anchor: null,
-    section: EXPLORE_SECTIONS.DISCOVER
+    section: EXPLORE_SECTIONS.DISCOVER,
+    selectedCollection: null
   },
 
   tags: {

--- a/layout/explore/reducers.js
+++ b/layout/explore/reducers.js
@@ -385,6 +385,10 @@ export default {
     const sidebar = { ...state.sidebar, section: action.payload };
     return { ...state, sidebar };
   },
+  [actions.setSidebarSelectedCollection]: (state, action) => {
+    const sidebar = { ...state.sidebar, selectedCollection: action.payload };
+    return { ...state, sidebar };
+  },
 
   //
   // TAGS

--- a/pages/app/explore/index.js
+++ b/pages/app/explore/index.js
@@ -43,7 +43,8 @@ class ExplorePage extends PureComponent {
       boundaries,
       layers,
       dataset,
-      section
+      section,
+      selectedCollection
     } = query;
 
     // Query
@@ -61,6 +62,8 @@ class ExplorePage extends PureComponent {
     if (dataset) dispatch(actions.setSelectedDataset(dataset));
     // Selected sidebar section (all data/discover/near-real/time... etc)
     if (section) dispatch(actions.setSidebarSection(section));
+    // Selected collection (if any)
+    if (selectedCollection) dispatch(actions.setSidebarSelectedCollection(selectedCollection));
 
     // sets map params from URL
     dispatch(actions.setViewport({
@@ -113,7 +116,7 @@ class ExplorePage extends PureComponent {
           boundaries,
           layerGroups
         },
-        sidebar: { anchor, section }
+        sidebar: { anchor, section, selectedCollection }
       }
     } = this.props;
 
@@ -122,6 +125,7 @@ class ExplorePage extends PureComponent {
       ...!!datasets && datasets.selected && { dataset: datasets.selected },
       ...!!anchor && { hash: anchor },
       section,
+      selectedCollection,
       // map params
       zoom: viewport.zoom,
       lat: viewport.latitude,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/76067147-30afa180-5f8f-11ea-9255-d3e874128d71.png)

![image](https://user-images.githubusercontent.com/545342/76067188-4624cb80-5f8f-11ea-9c2d-6f30ab608277.png)

## Overview
This PR adds the user collections feature to the Explore section.

## Testing instructions
Test the interface both logged in and logged out to see the two different visual states of the component.
_NOTE: Only datasets from the collection are shown, (no widgets, dashboards, ...)_
_Also we still need to decide what to do when the user selects a collection that has no dataset included in it_.