### PR TITLE
Layout for Discover section

### DIFF
--- a/css/_settings.scss
+++ b/css/_settings.scss
@@ -53,6 +53,7 @@ $primary-color: $color-primary;
 $secondary-color: $sea-blue;
 
 // Typography
+$font-size-tiny: 10px;
 $font-size-extra-small: 12px;
 $font-size-small: 13px;
 $font-size-normal: 14px;

--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -16,6 +16,7 @@ import ExploreDatasets from 'layout/explore/explore-datasets';
 import ExploreMap from 'layout/explore/explore-map';
 import ExploreDetail from 'layout/explore/explore-detail';
 import ExploreTopics from 'layout/explore/explore-topics';
+import ExploreDiscover from 'layout/explore/explore-discover';
 
 // utils
 import { breakpoints } from 'utils/responsive';
@@ -49,6 +50,9 @@ class Explore extends PureComponent {
                   }
                   {section === EXPLORE_SECTIONS.TOPICS &&
                     <ExploreTopics />
+                  }
+                  {section === EXPLORE_SECTIONS.DISCOVER &&
+                    <ExploreDiscover />
                   }
                   {/* <ExploreDatasetsHeader /> */}
                 </div>

--- a/layout/explore/explore-discover/component.js
+++ b/layout/explore/explore-discover/component.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Constants
+import { EXPLORE_SECTIONS } from 'layout/explore/constants';
+
+// Styles
+import './styles.scss';
+
+function ExploreDiscover(props) {
+  const { setSidebarSection } = props;
+  return (
+    <div className="c-explore-discover">
+      <div className="trending-datasets discover-section">
+        <div className="header">
+          <h4>Trending datasets</h4>
+          <div
+            className="header-button"
+            role="button"
+            tabIndex={-1}
+            onClick={() => setSidebarSection(EXPLORE_SECTIONS.ALL_DATA)}
+            onKeyPress={() => setSidebarSection(EXPLORE_SECTIONS.ALL_DATA)}
+          >
+                        SEE ALL DATA
+          </div>
+        </div>
+      </div>
+      <div className="related-topics discover-section">
+        <div className="header">
+          <h4>Related topics</h4>
+          <div
+            className="header-button"
+            role="button"
+            tabIndex={-1}
+            onClick={() => setSidebarSection(EXPLORE_SECTIONS.TOPICS)}
+            onKeyPress={() => setSidebarSection(EXPLORE_SECTIONS.TOPICS)}
+          >
+                        SEE ALL
+          </div>
+        </div>
+      </div>
+      <div className="recent-updated discover-section">
+        <div className="header">
+          <h4>Recent updated</h4>
+          <div
+            className="header-button"
+            role="button"
+            tabIndex={-1}
+            onClick={() => setSidebarSection(EXPLORE_SECTIONS.ALL_DATA)}
+            onKeyPress={() => setSidebarSection(EXPLORE_SECTIONS.ALL_DATA)}
+          >
+                        SEE ALL DATA
+          </div>
+        </div>
+      </div>
+      <div className="related-dashboards discover-section">
+        <div className="header">
+          <h4>Related dashboards</h4>
+          {/* <Link/> didn't work for some reason... */}
+          <a href="/dashboards" className="header-button">
+                        SEE ALL
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ExploreDiscover.propTypes = { setSidebarSection: PropTypes.func.isRequired };
+
+export default ExploreDiscover;

--- a/layout/explore/explore-discover/index.js
+++ b/layout/explore/explore-discover/index.js
@@ -1,0 +1,10 @@
+// Redux
+import { connect } from 'react-redux';
+import * as actions from 'layout/explore/actions';
+
+import ExploreDiscoverComponent from './component';
+
+export default connect(
+  null,
+  actions
+)(ExploreDiscoverComponent);

--- a/layout/explore/explore-discover/styles.scss
+++ b/layout/explore/explore-discover/styles.scss
@@ -1,0 +1,32 @@
+@import 'css/settings';
+
+.c-explore-discover {
+    display: flex;
+    flex-direction: column;
+    margin: 2 * $space 3 * $space 2 * $space 3 * $space;
+
+    .discover-section {
+        margin-top: 2 * $space;
+
+        .header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+    
+            h4 {
+                margin: 0px;
+            }
+    
+            .header-button {
+                font-size: $font-size-tiny;
+                font-weight: bold;
+                color: $dark-pink;
+                cursor: pointer;
+            }
+
+            a {
+                text-decoration: none;
+            }
+        }
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/76071116-04e3ea00-5f96-11ea-825e-e8bfbb21eedf.png)

## Overview
This PR adds the main layout for the `Discover` section. We can't make more progress on this until it's decided how we are going to load (and if we can) for each of the suggested sub-sections.

## Testing instructions
Go to localhost:9000/data/explore?section=Discover