### PR TITLE
Explore discover: highlighted datasets

### DIFF
--- a/layout/explore/explore-discover/component.js
+++ b/layout/explore/explore-discover/component.js
@@ -1,14 +1,42 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { toastr } from 'react-redux-toastr';
+
+// Services
+import { fetchDatasets } from 'services/dataset';
 
 // Constants
 import { EXPLORE_SECTIONS } from 'layout/explore/constants';
+
+// Components
+import Spinner from 'components/ui/Spinner';
+
+// Responsive
+import MediaQuery from 'react-responsive';
+import { breakpoints } from 'utils/responsive';
+
+// Explore components
+import DatasetList from 'layout/explore/explore-datasets/list';
+import ExploreDatasetsActions from 'layout/explore/explore-datasets/explore-datasets-actions';
 
 // Styles
 import './styles.scss';
 
 function ExploreDiscover(props) {
-  const { setSidebarSection } = props;
+  const { setSidebarSection, responsive } = props;
+  const [highlightedDatasets, setHighlightedDatasets] = useState({ loading: true, list: [] });
+  const { loading, list } = highlightedDatasets;
+
+  useEffect(() => {
+    fetchDatasets({
+      'page[size]': 4,
+      isHighlighted: true,
+      includes: 'layer, metadata'
+    })
+      .then(data => setHighlightedDatasets({ loading: false, list: data }))
+      .catch(err => toastr.error('Error loading highlighted datasets', err));
+  }, []);
+
   return (
     <div className="c-explore-discover">
       <div className="trending-datasets discover-section">
@@ -24,6 +52,20 @@ function ExploreDiscover(props) {
                         SEE ALL DATA
           </div>
         </div>
+        <Spinner isLoading={loading} className="-light -relative" />
+        {!loading &&
+          <DatasetList
+            list={list}
+            actions={
+              <MediaQuery
+                minDeviceWidth={breakpoints.medium}
+                values={{ deviceWidth: responsive.fakeWidth }}
+              >
+                <ExploreDatasetsActions />
+              </MediaQuery>
+            }
+          />
+        }
       </div>
       <div className="related-topics discover-section">
         <div className="header">
@@ -66,6 +108,9 @@ function ExploreDiscover(props) {
   );
 }
 
-ExploreDiscover.propTypes = { setSidebarSection: PropTypes.func.isRequired };
+ExploreDiscover.propTypes = {
+  setSidebarSection: PropTypes.func.isRequired,
+  responsive: PropTypes.object.isRequired
+};
 
 export default ExploreDiscover;

--- a/layout/explore/explore-discover/index.js
+++ b/layout/explore/explore-discover/index.js
@@ -5,6 +5,6 @@ import * as actions from 'layout/explore/actions';
 import ExploreDiscoverComponent from './component';
 
 export default connect(
-  null,
+  state => ({ responsive: state.responsive }),
   actions
 )(ExploreDiscoverComponent);

--- a/layout/explore/explore-discover/styles.scss
+++ b/layout/explore/explore-discover/styles.scss
@@ -6,12 +6,13 @@
     margin: 2 * $space 3 * $space 2 * $space 3 * $space;
 
     .discover-section {
-        margin-top: 2 * $space;
+        margin: 2 * $space 0px 2 * $space 0px;
 
         .header {
             display: flex;
             align-items: center;
             justify-content: space-between;
+            margin-bottom: 2 * $space;
     
             h4 {
                 margin: 0px;
@@ -26,6 +27,14 @@
 
             a {
                 text-decoration: none;
+            }
+        }
+
+        &.trending-datasets {
+            min-height: 200px;
+            
+            .column {
+                padding: 0px;
             }
         }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/76423826-a2308b00-63a7-11ea-95da-c6afeb9ba2fe.png)

## Overview
This PR adds the highlighted datasets to the `Discover` section.

## Testing instructions
Verify that 4 datasets are loading.
⚠️ Bear in mind that the `isHighlighted` filter has not been implemented yet in the API. Thus the datasets being currently returned are arbitrary.