### PR TITLE
Explore: Collections styles improvements + interaction fixes

### DIFF
--- a/components/collections-panel/collections-panel-component.js
+++ b/components/collections-panel/collections-panel-component.js
@@ -17,7 +17,9 @@ class CollectionsPanel extends PureComponent {
     addCollection: PropTypes.func,
     toggleCollection: PropTypes.func,
     toggleFavourite: PropTypes.func,
-    resourceType: PropTypes.oneOf(['dataset', 'layer', 'widget']).isRequired
+    resourceType: PropTypes.oneOf(['dataset', 'layer', 'widget']).isRequired,
+    onClick: PropTypes.func,
+    onKeyPress: PropTypes.func
   };
 
   static defaultProps = {
@@ -28,7 +30,9 @@ class CollectionsPanel extends PureComponent {
     favouritesLoading: false,
     addCollection: () => {},
     toggleCollection: () => {},
-    toggleFavourite: () => {}
+    toggleFavourite: () => {},
+    onClick: null,
+    onKeyPress: null
   };
 
   state = { newCollectionName: null };
@@ -121,7 +125,19 @@ class CollectionsPanel extends PureComponent {
 
   render() {
     return (
-      <div className="c-collections-panel">
+      <div
+        className="c-collections-panel"
+        onClick={(e) => {
+          if (this.props.onClick) {
+            this.props.onClick(e);
+          }
+        }}
+        onKeyPress={(e) => {
+          if (this.props.onKeyPress) {
+            this.props.onKeyPress(e);
+          }
+        }}
+      >
         <div className="new-collection-container">
           <input
             type="text"

--- a/layout/explore/explore-collections/styles.scss
+++ b/layout/explore/explore-collections/styles.scss
@@ -1,5 +1,5 @@
 @import 'css/settings';
 
 .c-explore-collections {
-    margin-top: 2 * $space;
+    margin: 0px 3 * $space 2 * $space 3 * $space;
 }

--- a/layout/explore/explore-datasets/explore-datasets-actions/component.js
+++ b/layout/explore/explore-datasets/explore-datasets-actions/component.js
@@ -31,7 +31,8 @@ class ExploreDatasetsActionsComponent extends PureComponent {
     return !!layerGroups.find(l => l.dataset === dataset.id);
   }
 
-  handleToggleLayerGroup = () => {
+  handleToggleLayerGroup = (event) => {
+    event.stopPropagation();
     const { dataset, toggleMapLayerGroup, resetMapLayerGroupsInteraction } = this.props;
     const isActive = this.isActive();
 
@@ -77,6 +78,8 @@ class ExploreDatasetsActionsComponent extends PureComponent {
               <CollectionsPanel
                 resource={dataset}
                 resourceType="dataset"
+                onClick={e => e.stopPropagation()}
+                onKeyPress={e => e.stopPropagation()}
               />
             }
             overlayClassName="c-rc-tooltip"
@@ -88,6 +91,7 @@ class ExploreDatasetsActionsComponent extends PureComponent {
             <button
               className="c-button -secondary -compressed"
               tabIndex={-1}
+              onClick={event => event.stopPropagation()}
             >
               <Icon
                 name={starIconName}

--- a/layout/explore/explore-datasets/list/list-item/component.js
+++ b/layout/explore/explore-datasets/list/list-item/component.js
@@ -77,16 +77,8 @@ class DatasetListItem extends React.Component {
     );
   }
 
-  handleClick = (event) => {
-    let classSt = event.target.className;
-    if (typeof classSt !== 'string') {
-      classSt = classSt.baseVal || '';
-    }
-    const isIcon = classSt.indexOf('c-icon') >= 0;
-    const isButton = classSt.indexOf('c-button') >= 0 || classSt.indexOf('c-btn') >= 0;
-    if (!isIcon && !isButton) {
-      Router.pushRoute('explore', { dataset: this.props.dataset.slug });
-    }
+  handleClick = () => {
+    Router.pushRoute('explore', { dataset: this.props.dataset.slug });
   }
 
   render() {

--- a/layout/explore/explore-detail/explore-detail-tags/component.js
+++ b/layout/explore/explore-detail/explore-detail-tags/component.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+// Constants
+import { EXPLORE_SECTIONS } from 'layout/explore/constants';
+
 // styles
 import './styles.scss';
 
@@ -33,6 +36,8 @@ function ExploreDetailTags(props) {
           <button
             className="c-button -secondary -compressed"
             onClick={() => {
+              props.setSelectedDataset(null);
+              props.setSidebarSection(EXPLORE_SECTIONS.ALL_DATA);
               props.setFiltersSelected(getFilterObject(tag));
               props.setDatasetsPage(1);
               props.fetchDatasets();
@@ -50,7 +55,9 @@ ExploreDetailTags.propTypes = {
   tags: PropTypes.object.isRequired,
   setFiltersSelected: PropTypes.func.isRequired,
   setDatasetsPage: PropTypes.func.isRequired,
-  fetchDatasets: PropTypes.func.isRequired
+  fetchDatasets: PropTypes.func.isRequired,
+  setSelectedDataset: PropTypes.func.isRequired,
+  setSidebarSection: PropTypes.func.isRequired
 };
 
 export default ExploreDetailTags;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/76943957-790c7f00-6900-11ea-88ec-3fa916f99868.png)

## Overview
This PR includes minor style improvements for the collections view plus a fix for the click interaction with elements from dataset cards.
_UPDATE: It also fixes the behavior when clicking on tag pills from the dataset explore detail view_

## Testing instructions
Verify that collections' datasets are displayed accordingly and the user interaction flow with the collections tooltip works as expected.