### PR TITLE
Back office: explore form logic

### DIFF
--- a/components/admin/data/explore-form/index.js
+++ b/components/admin/data/explore-form/index.js
@@ -1,3 +1,7 @@
+import { connect } from 'react-redux';
 import ExploreFormComponent from './component';
 
-export default ExploreFormComponent;
+export default connect(
+  state => ({ token: state.user.token }),
+  null
+)(ExploreFormComponent);

--- a/components/datasets/form/DatasetsForm.js
+++ b/components/datasets/form/DatasetsForm.js
@@ -216,7 +216,7 @@ class DatasetsForm extends PureComponent {
   }
 
   // HELPERS
-  setFormFromParams(params) {
+  setFormFromParams(params) {    
     const form = Object.keys(this.state.form);
     const newForm = {};
 
@@ -234,7 +234,7 @@ class DatasetsForm extends PureComponent {
           newForm[f] = params[f] || this.state.form[f];
         }
       }
-    });
+    });    
     return newForm;
   }
 

--- a/components/datasets/form/constants.js
+++ b/components/datasets/form/constants.js
@@ -92,7 +92,8 @@ export const STATE_DEFAULT = {
       country: []
     },
     subscribable: [],
-    mainDateField: ''
+    mainDateField: '',
+    applicationConfig: { rw: { highlighted: 'false' }}
   }
 };
 

--- a/components/datasets/form/steps/component.js
+++ b/components/datasets/form/steps/component.js
@@ -273,7 +273,8 @@ class Step1 extends PureComponent {
               properties={{
                 name: 'isHighlighted',
                 label: 'Do you want to set this dataset as highlighted?',
-                value: 'isHighlighted',
+                value: this.state.form.applicationConfig && this.state.form.applicationConfig.rw &&
+                  this.state.form.applicationConfig.rw.highlighted,
                 title: 'Highlighted',
                 defaultChecked: !dataset ? user.role === 'ADMIN' :
                   this.props.form.applicationConfig && this.props.form.applicationConfig.rw

--- a/components/datasets/form/steps/component.js
+++ b/components/datasets/form/steps/component.js
@@ -269,13 +269,15 @@ class Step1 extends PureComponent {
               ref={(c) => {
                 if (c) FORM_ELEMENTS.elements.isHighlighted = c;
               }}
-              onChange={value => this.props.onChange({ isHighlighted: value.checked })}
+              onChange={value => this.props.onChange({ applicationConfig: { rw: { highlighted: value.checked } } })}
               properties={{
                 name: 'isHighlighted',
                 label: 'Do you want to set this dataset as highlighted?',
                 value: 'isHighlighted',
                 title: 'Highlighted',
-                defaultChecked: !dataset ? user.role === 'ADMIN' : this.props.form.isHighlighted
+                defaultChecked: !dataset ? user.role === 'ADMIN' :
+                  this.props.form.applicationConfig && this.props.form.applicationConfig.rw
+                  && this.props.form.applicationConfig.rw.highlighted
               }}
             >
               {Checkbox}

--- a/layout/explore/explore-discover/component.js
+++ b/layout/explore/explore-discover/component.js
@@ -39,12 +39,12 @@ function ExploreDiscover(props) {
     // ---- Highlighted datasets ----
     fetchDatasets({
       'page[size]': 4,
-      isHighlighted: true,
+      'applicationConfig.rw.highlighted': 'true',
       includes: 'layer,metadata,widget'
     })
       .then(data => setHighlightedDatasets({ loading: false, list: data }))
       .catch(err => toastr.error('Error loading highlighted datasets', err));
-    
+
     // ----- Recently updated datasets -------
     fetchDatasets({
       'page[size]': 4,
@@ -65,9 +65,7 @@ function ExploreDiscover(props) {
       .catch(err => toastr.error('Error loading recently added datasets', err));
   }, []);
 
-  const {
-    relatedTopics
-  } = config;
+  const { relatedTopics } = config;
 
   return (
     <div className="c-explore-discover">


### PR DESCRIPTION
## Overview
This PR adds the logic necessary to use the highlighted datasets feature.

## Testing
This PR needs to be tested on the *staging* environment since the API endpoint has only been deployed to that environment. Please verify:
- Explore form: http://localhost:9000/admin/data/explore
- Explore discover section: http://localhost:9000/data/explore?section=Discover _verify here that the section `Trending datasets` load the right datasets_
- Dataset form: check that the `Highlighted` checkbox works as expected.