### PR TITLE
Explore Discover section: load configuration from external file

### DIFF
--- a/layout/explore/explore-discover/component.js
+++ b/layout/explore/explore-discover/component.js
@@ -7,7 +7,7 @@ import { EXPLORE_SECTIONS } from 'layout/explore/constants';
 import { TOPICS } from 'layout/explore/explore-topics/constants';
 
 // Services
-import { fetchRWConfig } from 'services/config';
+import { fetchExploreConfig } from 'services/config';
 import { fetchDatasets } from 'services/dataset';
 
 // Components
@@ -27,51 +27,53 @@ import './styles.scss';
 
 function ExploreDiscover(props) {
   const { setSidebarSection, responsive } = props;
-  const [config, setConfig] = useState({ relatedTopics: [] });
+  const [config, setConfig] = useState(null);
   const [highlightedDatasets, setHighlightedDatasets] = useState({ loading: true, list: [] });
   const [recentUpdatedDatasets, setRecentUpdatedDatasets] = useState({ loading: true, list: [] });
   const [recentlyAddedDatasets, setRecentlyAddedDatasets] = useState({ loading: true, list: [] });
 
   useEffect(() => {
-    const tempConfig = fetchRWConfig();
-    setConfig(tempConfig);
+    fetchExploreConfig()
+      .then((result) => {
+        setConfig(result);
 
-    // ---- Highlighted datasets ----
-    fetchDatasets({
-      'page[size]': 4,
-      'applicationConfig.rw.highlighted': 'true',
-      includes: 'layer,metadata,widget'
-    })
-      .then(data => setHighlightedDatasets({ loading: false, list: data }))
-      .catch(err => toastr.error('Error loading highlighted datasets', err));
+        // ---- Highlighted datasets ----
+        fetchDatasets({
+          'page[size]': 4,
+          'applicationConfig.rw.highlighted': 'true',
+          includes: 'layer,metadata,widget'
+        })
+          .then(data => setHighlightedDatasets({ loading: false, list: data }))
+          .catch(err => toastr.error('Error loading highlighted datasets', err));
 
-    // ----- Recently updated datasets -------
-    fetchDatasets({
-      'page[size]': 4,
-      sort: '-dataLastUpdated',
-      includes: 'layer,metadata,widget',
-      'concepts[0][0]': 'near_real_time'
-    })
-      .then(data => setRecentUpdatedDatasets({ loading: false, list: data }))
-      .catch(err => toastr.error('Error loading recently updated datasets', err));
+        // ----- Recently updated datasets -------
+        fetchDatasets({
+          'page[size]': 4,
+          sort: '-dataLastUpdated',
+          includes: 'layer,metadata,widget',
+          'concepts[0][0]': 'near_real_time'
+        })
+          .then(data => setRecentUpdatedDatasets({ loading: false, list: data }))
+          .catch(err => toastr.error('Error loading recently updated datasets', err));
 
-    // ----- Recently added datasets --------
-    fetchDatasets({
-      'page[size]': 4,
-      sort: '-createdAt',
-      includes: 'layer,metadata,widget'
-    })
-      .then(data => setRecentlyAddedDatasets({ loading: false, list: data }))
-      .catch(err => toastr.error('Error loading recently added datasets', err));
+        // ----- Recently added datasets --------
+        fetchDatasets({
+          'page[size]': 4,
+          sort: '-createdAt',
+          includes: 'layer,metadata,widget'
+        })
+          .then(data => setRecentlyAddedDatasets({ loading: false, list: data }))
+          .catch(err => toastr.error('Error loading recently added datasets', err));
+      });
   }, []);
 
-  const { relatedTopics } = config;
+  const relatedTopics = config && config.explore.discover['related-topics'];
 
   return (
     <div className="c-explore-discover">
       <div className="trending-datasets discover-section">
         <div className="header">
-          <h4>Trending datasets</h4>
+          <h4>{config && config.explore.discover.subtitles['highlighted-datasets']}</h4>
           <div
             className="header-button"
             role="button"
@@ -99,7 +101,7 @@ function ExploreDiscover(props) {
       </div>
       <div className="related-topics discover-section">
         <div className="header">
-          <h4>Related topics</h4>
+          <h4>{config && config.explore.discover.subtitles['related-topics']}</h4>
           <div
             className="header-button"
             role="button"
@@ -110,7 +112,7 @@ function ExploreDiscover(props) {
                         SEE ALL
           </div>
         </div>
-        {relatedTopics.length > 0 &&
+        {relatedTopics && relatedTopics.length > 0 &&
           <TopicsList
             topics={TOPICS.filter(t => relatedTopics.find(rT => rT === t.id))}
             onClick={(id) => {
@@ -126,7 +128,7 @@ function ExploreDiscover(props) {
       </div>
       <div className="recently-added discover-section">
         <div className="header">
-          <h4>Recently added datasets</h4>
+          <h4>{config && config.explore.discover.subtitles['recently-added-datasets']}</h4>
           <div
             className="header-button"
             role="button"
@@ -154,7 +156,7 @@ function ExploreDiscover(props) {
       </div>
       <div className="recent-updated discover-section">
         <div className="header">
-          <h4>Recent updated datasets</h4>
+          <h4>{config && config.explore.discover.subtitles['recently-updated-datasets']}</h4>
           <div
             className="header-button"
             role="button"

--- a/services/config.js
+++ b/services/config.js
@@ -1,44 +1,18 @@
 // utils
-import { WRIAPI } from 'utils/axios';
 import { logger } from 'utils/logs';
 
 
 /**
  * Fetch RW config
  */
-export const fetchRWConfig = (token) => {
-  logger.info('Fetch RW config');
-  //   return WRIAPI.get(`rwConfig?env=${process.env.API_ENV}`, { headers: { Authorization: token } })
-  //     .then(response => response.data)
-  //     .catch(({ response }) => {
-  //       const { status, statusText } = response;
-  //       logger.error(`Error fetching RW config: ${status}: ${statusText}`);
-  //       throw new Error(`Error fetching RW config: ${status}: ${statusText}`);
-  //     });
-  // TEMPORARY: DATA MOCK RETURNED
-  return ({
-    relatedTopics: ['water', 'society', 'food_and_agriculture', 'energy']
+export const fetchExploreConfig = () =>
+  new Promise((resolve, reject) => {
+    logger.info('Fetch RW config');
+    const xhr = new XMLHttpRequest();
+    xhr.open('get', 'https://raw.githubusercontent.com/resource-watch/resource-watch/develop/public/static/data/ExploreConfig.json');
+    xhr.onload = () => resolve(JSON.parse(xhr.response));
+    xhr.onerror = () => reject(new Error('There was an error loading the Explore config'));
+    xhr.send();
   });
-};
 
-/**
- * Update RW config
- *
- */
-export const updateRWConfig = (config, token) => {
-  logger.info('Update RW config');
-  return WRIAPI.post(`rwConfig?env=${process.env.API_ENV}`,
-    config,
-    { headers: { Authorization: token } })
-    .then(response => response.data)
-    .catch(({ response }) => {
-      const { status, statusText } = response;
-      logger.error(`Error updating RW config: ${status}: ${statusText}`);
-      throw new Error(`Error updating RW config: ${status}: ${statusText}`);
-    });
-};
-
-export default {
-  fetchRWConfig,
-  updateRWConfig
-};
+export default { fetchExploreConfig };

--- a/services/config.js
+++ b/services/config.js
@@ -1,18 +1,18 @@
+import axios from 'axios';
+
 // utils
 import { logger } from 'utils/logs';
 
-
 /**
- * Fetch RW config
+ * Fetch Explore config
  */
 export const fetchExploreConfig = () =>
   new Promise((resolve, reject) => {
     logger.info('Fetch RW config');
-    const xhr = new XMLHttpRequest();
-    xhr.open('get', 'https://raw.githubusercontent.com/resource-watch/resource-watch/develop/public/static/data/ExploreConfig.json');
-    xhr.onload = () => resolve(JSON.parse(xhr.response));
-    xhr.onerror = () => reject(new Error('There was an error loading the Explore config'));
-    xhr.send();
+
+    axios.get('https://raw.githubusercontent.com/resource-watch/resource-watch/develop/public/static/data/ExploreConfig.json')
+      .then(response => resolve(response.data))
+      .catch(error => reject(new Error('There was an error loading the Explore config', error)));
   });
 
 export default { fetchExploreConfig };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/77048118-39a86600-69c6-11ea-81d0-eb7a81309c7f.png)

## Overview
This PR adds the logic to load the visual configuration for the Discover section from an external github file located [here](https://github.com/resource-watch/resource-watch/blob/develop/public/static/data/ExploreConfig.json)

## Testing instructions
Verify that the interface loads according to the content included in the config file.
