### PR TITLE
Explore detail: prevent data loading when coming back from this section

### DIFF
--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -49,32 +49,30 @@ class Explore extends PureComponent {
       >
         <div className="c-page-explore">
           <ExploreSidebar>
-            {!selected && (
-              <Fragment>
-                <ExploreMenu />
-                <div className="explore-sidebar-content">
-                  {section === EXPLORE_SECTIONS.ALL_DATA &&
-                    <ExploreDatasets />
-                  }
-                  {section === EXPLORE_SECTIONS.TOPICS &&
-                    <ExploreTopics />
-                  }
-                  {section === EXPLORE_SECTIONS.COLLECTIONS && userIsLoggedIn &&
-                    <ExploreCollections />
-                  }
-                  {section === EXPLORE_SECTIONS.COLLECTIONS && !userIsLoggedIn &&
-                    <ExploreLogin />
-                  }
-                  {section === EXPLORE_SECTIONS.DISCOVER &&
-                    <ExploreDiscover />
-                  }
-                  {section === EXPLORE_SECTIONS.NEAR_REAL_TIME &&
-                    <ExploreNearRealTime />
-                  }
-                  {/* <ExploreDatasetsHeader /> */}
-                </div>
-              </Fragment>
-            )}
+            <Fragment>
+              <ExploreMenu />
+              <div className="explore-sidebar-content">
+                {section === EXPLORE_SECTIONS.ALL_DATA &&
+                  <ExploreDatasets />
+                }
+                {section === EXPLORE_SECTIONS.TOPICS &&
+                  <ExploreTopics />
+                }
+                {section === EXPLORE_SECTIONS.COLLECTIONS && userIsLoggedIn &&
+                  <ExploreCollections />
+                }
+                {section === EXPLORE_SECTIONS.COLLECTIONS && !userIsLoggedIn &&
+                  <ExploreLogin />
+                }
+                {section === EXPLORE_SECTIONS.DISCOVER &&
+                  <ExploreDiscover />
+                }
+                {section === EXPLORE_SECTIONS.NEAR_REAL_TIME &&
+                  <ExploreNearRealTime />
+                }
+                {/* <ExploreDatasetsHeader /> */}
+              </div>
+            </Fragment>
             {selected && <ExploreDetail /> }
           </ExploreSidebar>
 

--- a/layout/explore/explore-collections/component.js
+++ b/layout/explore/explore-collections/component.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { toastr } from 'react-redux-toastr';
+import classnames from 'classnames';
 
 // Services
 import { fetchDatasets } from 'services/dataset';
@@ -14,7 +15,7 @@ import ExploreDatasetsActions from 'layout/explore/explore-datasets/explore-data
 import './styles.scss';
 
 function ExploreCollectionsComponent(props) {
-  const { collection } = props;
+  const { collection, selectedDataset } = props;
   const [datasets, setDatasets] = useState([]);
   const [datasetsLoading, setDatasetsLoading] = useState(false);
 
@@ -41,7 +42,11 @@ function ExploreCollectionsComponent(props) {
   }, [collection]);
 
   return (
-    <div className="c-explore-collections">
+    <div className={classnames({
+        'c-explore-collections': true,
+        '-hidden': selectedDataset
+      })}
+    >
       <Spinner isLoading={datasetsLoading} className="-light -relative" />
       {datasets.length > 0 &&
         <DatasetList
@@ -53,6 +58,9 @@ function ExploreCollectionsComponent(props) {
   );
 }
 
-ExploreCollectionsComponent.propTypes = { collection: PropTypes.func.isRequired };
+ExploreCollectionsComponent.propTypes = {
+  collection: PropTypes.func.isRequired,
+  selectedDataset: PropTypes.string.isRequired
+};
 
 export default ExploreCollectionsComponent;

--- a/layout/explore/explore-collections/index.js
+++ b/layout/explore/explore-collections/index.js
@@ -6,6 +6,9 @@ import { getCollection } from './selectors';
 import ExploreCollectionsComponent from './component';
 
 export default connect(
-  state => ({ collection: getCollection(state) }),
+  state => ({
+    collection: getCollection(state),
+    selectedDataset: state.explore.datasets.selected
+  }),
   actions
 )(ExploreCollectionsComponent);

--- a/layout/explore/explore-collections/styles.scss
+++ b/layout/explore/explore-collections/styles.scss
@@ -2,4 +2,8 @@
 
 .c-explore-collections {
     margin: 0px 3 * $space 2 * $space 3 * $space;
+
+    &.-hidden {
+        display: none;
+    }
 }

--- a/layout/explore/explore-datasets/component.js
+++ b/layout/explore/explore-datasets/component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
 import { Link } from 'routes';
+import classnames from 'classnames';
 
 // Responsive
 import MediaQuery from 'react-responsive';
@@ -14,8 +15,8 @@ import Spinner from 'components/ui/Spinner';
 import { TOPICS } from 'layout/explore/explore-topics/constants';
 
 // Explore components
-import DatasetList from './list';
 import ExploreDatasetsSort from 'layout/explore/explore-datasets-header/explore-datasets-sort';
+import DatasetList from './list';
 import ExploreDatasetsTags from './explore-datasets-tags';
 import ExploreDatasetsActions from './explore-datasets-actions';
 
@@ -41,21 +42,6 @@ class ExploreDatasetsComponent extends React.Component {
     setFiltersSearch: PropTypes.func.isRequired
   };
 
-  // onTagSelected = (tag) => {
-  //   const options = Object.keys(this.props.options).map(o => this.props.options[o]);
-
-  //   const tab = (options.find((o) => {
-  //     const labels = (tag && tag.labels) || [];
-  //     return o.type === labels[1];
-  //   }) || {}).value || 'custom';
-
-  //   this.props.toggleFiltersSelected({
-  //     tab,
-  //     tag
-  //   });
-  //   this.fetchDatasets(1);
-  // }
-
   fetchDatasets = debounce((page) => {
     this.props.setDatasetsPage(page);
     this.props.fetchDatasets();
@@ -63,21 +49,29 @@ class ExploreDatasetsComponent extends React.Component {
 
   render() {
     const {
-      list,
-      page,
-      limit,
-      total,
+      datasets: {
+        selected,
+        list,
+        total,
+        limit,
+        page,
+        loading
+      },
       responsive,
       selectedTags,
-      search,
-      loading
+      search
     } = this.props;
 
     const relatedDashboards =
       TOPICS.filter(topic => selectedTags.find(tag => tag.id === topic.id));
 
+    const classValue = classnames({
+      'c-explore-datasets': true,
+      '-hidden': selected
+    });
+
     return (
-      <div className="c-explore-datasets">
+      <div className={classValue}>
         {loading && <Spinner isLoading className="-light" />}
         <div className="explore-datasets-header">
           <div className="left-container">

--- a/layout/explore/explore-datasets/index.js
+++ b/layout/explore/explore-datasets/index.js
@@ -10,7 +10,7 @@ import ExploreDatasetsComponent from './component';
 export default connect(
   state => ({
     // Store
-    ...state.explore.datasets,
+    datasets: state.explore.datasets,
     list: getUpdatedDatasets(state),
     ...state.explore.filters,
     responsive: state.responsive,

--- a/layout/explore/explore-datasets/styles.scss
+++ b/layout/explore/explore-datasets/styles.scss
@@ -141,4 +141,8 @@
         max-width: 300px;
         margin-bottom: 3 * $space;
     }
+
+    &.-hidden {
+        display: none;
+    }
 }

--- a/layout/explore/explore-detail/styles.scss
+++ b/layout/explore/explore-detail/styles.scss
@@ -1,10 +1,13 @@
 @import 'css/settings';
 
 .c-explore-detail {
-    width: 100%;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 530px;
+    min-height: 100%;
     
     .content {
-        min-height: 100%;
         background-color: $color-12;
 
         .metadata-section {

--- a/layout/explore/explore-discover/component.js
+++ b/layout/explore/explore-discover/component.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { toastr } from 'react-redux-toastr';
+import classnames from 'classnames';
 
 // Constants
 import { EXPLORE_SECTIONS } from 'layout/explore/constants';
@@ -26,7 +27,7 @@ import ExploreDatasetsActions from 'layout/explore/explore-datasets/explore-data
 import './styles.scss';
 
 function ExploreDiscover(props) {
-  const { setSidebarSection, responsive } = props;
+  const { setSidebarSection, responsive, selectedDataset } = props;
   const [config, setConfig] = useState(null);
   const [highlightedDatasets, setHighlightedDatasets] = useState({ loading: true, list: [] });
   const [recentUpdatedDatasets, setRecentUpdatedDatasets] = useState({ loading: true, list: [] });
@@ -74,7 +75,11 @@ function ExploreDiscover(props) {
   const relatedTopics = config && config.explore.discover['related-topics'];
 
   return (
-    <div className="c-explore-discover">
+    <div className={classnames({
+        'c-explore-discover': true,
+        '-hidden': selectedDataset
+      })}
+    >
       <div className="trending-datasets discover-section">
         <div className="header">
           <h4>{config && config.explore.discover.subtitles['highlighted-datasets']}</h4>
@@ -197,7 +202,8 @@ ExploreDiscover.propTypes = {
   setDatasetsPage: PropTypes.func.isRequired,
   fetchDatasets: PropTypes.func.isRequired,
   setFiltersSelected: PropTypes.func.isRequired,
-  responsive: PropTypes.object.isRequired
+  responsive: PropTypes.object.isRequired,
+  selectedDataset: PropTypes.string.isRequired
 };
 
 export default ExploreDiscover;

--- a/layout/explore/explore-discover/index.js
+++ b/layout/explore/explore-discover/index.js
@@ -5,6 +5,9 @@ import * as actions from 'layout/explore/actions';
 import ExploreDiscoverComponent from './component';
 
 export default connect(
-  state => ({ responsive: state.responsive }),
+  state => ({
+    responsive: state.responsive,
+    selectedDataset: state.explore.datasets.selected
+  }),
   actions
 )(ExploreDiscoverComponent);

--- a/layout/explore/explore-discover/styles.scss
+++ b/layout/explore/explore-discover/styles.scss
@@ -68,4 +68,8 @@
             }
         }
     }
+
+    &.-hidden {
+        display: none;
+    }
 }

--- a/layout/explore/explore-menu/component.js
+++ b/layout/explore/explore-menu/component.js
@@ -20,13 +20,14 @@ class ExploreMenuComponent extends React.Component {
     tags: PropTypes.array,
     options: PropTypes.object,
     selected: PropTypes.object,
-    search: PropTypes.string,
+    search: PropTypes.string.isRequired,
     sortSelected: PropTypes.string.isRequired,
     shouldAutoUpdateSortDirection: PropTypes.bool,
     section: PropTypes.string.isRequired,
     collections: PropTypes.array.isRequired,
     userIsLoggedIn: PropTypes.bool.isRequired,
     selectedCollection: PropTypes.string.isRequired,
+    selectedDataset: PropTypes.string.isRequired,
 
     // ACTIONS
     fetchDatasets: PropTypes.func.isRequired,
@@ -114,11 +115,16 @@ class ExploreMenuComponent extends React.Component {
       setSidebarSection,
       setSidebarSelectedCollection,
       userIsLoggedIn,
-      collections
+      collections,
+      selectedDataset
     } = this.props;
 
     return (
-      <div className="c-explore-menu" >
+      <div className={classnames({
+        'c-explore-menu': true,
+        '-hidden': selectedDataset
+      })}
+      >
 
         <DatasetSearch
           open={open}

--- a/layout/explore/explore-menu/index.js
+++ b/layout/explore/explore-menu/index.js
@@ -15,7 +15,8 @@ export default connect(
     section: state.explore.sidebar.section,
     selectedCollection: state.explore.sidebar.selectedCollection,
     userIsLoggedIn: !!state.user.id,
-    collections: getCollectionsFiltered(state)
+    collections: getCollectionsFiltered(state),
+    selectedDataset: state.explore.datasets.selected
   }),
   actions
 )(ExploreMenuComponent);

--- a/layout/explore/explore-menu/styles.scss
+++ b/layout/explore/explore-menu/styles.scss
@@ -50,4 +50,8 @@
     hr {
         margin: 2 * $space 5 * $space 2 * $space 5 * $space;
     }
+
+    &.-hidden {
+        display: none;
+    }
 }

--- a/layout/explore/explore-near-real-time/component.js
+++ b/layout/explore/explore-near-real-time/component.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 // Components
 import Spinner from 'components/ui/Spinner';
@@ -16,10 +17,18 @@ import ExploreDatasetsActions from 'layout/explore/explore-datasets/explore-data
 import './styles.scss';
 
 function ExploreNearRealTimeComponent(props) {
-  const { datasets: { today, week, month, loading }, responsive } = props;
+  const {
+    datasets: { today, week, month, loading },
+    responsive,
+    selectedDataset
+  } = props;
 
   return (
-    <div className="c-explore-near-real-time">
+    <div className={classnames({
+        'c-explore-near-real-time': true,
+        '-hidden': selectedDataset
+      })}
+    >
       <Spinner isLoading={loading} className="-light -relative" />
       {today.length > 0 &&
         <div className="explore-near-real-time-section">
@@ -90,7 +99,8 @@ function ExploreNearRealTimeComponent(props) {
 
 ExploreNearRealTimeComponent.propTypes = {
   datasets: PropTypes.array.isRequired,
-  responsive: PropTypes.object.isRequired
+  responsive: PropTypes.object.isRequired,
+  selectedDataset: PropTypes.string.isRequired
 };
 
 export default ExploreNearRealTimeComponent;

--- a/layout/explore/explore-near-real-time/index.js
+++ b/layout/explore/explore-near-real-time/index.js
@@ -66,6 +66,9 @@ ExploreNearRealTimeContainer.defaultProps = { datasetID: null };
 
 
 export default connect(
-  state => ({ responsive: state.responsive }),
+  state => ({
+    responsive: state.responsive,
+    selectedDataset: state.explore.datasets.selected
+  }),
   actions
 )(ExploreNearRealTimeContainer);

--- a/layout/explore/explore-near-real-time/styles.scss
+++ b/layout/explore/explore-near-real-time/styles.scss
@@ -25,4 +25,8 @@
             padding: 0px;
         }
     }
+
+    &.-hidden {
+        display: none;
+    }
 }


### PR DESCRIPTION
## Overview
This PR prevents data loading when going from Explore detail back to other sections such as Discover, All Data, or Near-Real-Time.

## Testing instructions
Try going back and forth from Explore detail to the rest of the Explore sections.