### PR TITLE
Some improvements related to some of the Explore user workflows

### DIFF
--- a/components/ui/map/map-thumbnail/index.js
+++ b/components/ui/map/map-thumbnail/index.js
@@ -25,17 +25,11 @@ class MapThumbnail extends React.Component {
   async componentDidMount() {
     const { width, height } = this.getSize();
 
-    const {
-      zoom, lat, lng, layerSpec
-    } = this.props;
+    const { zoom, lat, lng, layerSpec } = this.props;
 
-    const thumbnail = await getLayerImage({
-      width, height, zoom, lat, lng, layerSpec
-    });
+    const thumbnail = await getLayerImage({ width, height, zoom, lat, lng, layerSpec });
 
-    const basemap = await getBasemapImage({
-      width, height, zoom, lat, lng, layerSpec
-    });
+    const basemap = await getBasemapImage({ width, height, zoom, lat, lng, layerSpec });
 
     this.setStateAsync({
       imageSrc: thumbnail,

--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -1,4 +1,4 @@
-import React, { PureComponent, Fragment } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import MediaQuery from 'react-responsive';
 
@@ -32,7 +32,17 @@ class Explore extends PureComponent {
     userIsLoggedIn: PropTypes.bool.isRequired
   };
 
-  state = { mobileWarningOpened: true }
+  state = {
+    mobileWarningOpened: true,
+    exploreSectionAlreadyLoaded: !this.props.explore.datasets.selected
+  };
+
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    if (!nextProps.explore.datasets.selected && this.props.explore.datasets.selected
+      && !this.state.exploreSectionAlreadyLoaded) {
+      this.setState({ exploreSectionAlreadyLoaded: true });
+    }
+  }
 
   render() {
     const {
@@ -40,7 +50,8 @@ class Explore extends PureComponent {
       explore: { datasets: { selected }, sidebar: { section } },
       userIsLoggedIn
     } = this.props;
-    const { mobileWarningOpened } = this.state;
+    const { mobileWarningOpened, exploreSectionAlreadyLoaded } = this.state;
+    const exploreSectionShouldBeLoaded = !selected || exploreSectionAlreadyLoaded;
     return (
       <Layout
         title="Explore Data Sets — Resource Watch"
@@ -49,30 +60,34 @@ class Explore extends PureComponent {
       >
         <div className="c-page-explore">
           <ExploreSidebar>
-            <Fragment>
-              <ExploreMenu />
-              <div className="explore-sidebar-content">
-                {section === EXPLORE_SECTIONS.ALL_DATA &&
-                  <ExploreDatasets />
-                }
-                {section === EXPLORE_SECTIONS.TOPICS &&
-                  <ExploreTopics />
-                }
-                {section === EXPLORE_SECTIONS.COLLECTIONS && userIsLoggedIn &&
-                  <ExploreCollections />
-                }
-                {section === EXPLORE_SECTIONS.COLLECTIONS && !userIsLoggedIn &&
-                  <ExploreLogin />
-                }
-                {section === EXPLORE_SECTIONS.DISCOVER &&
-                  <ExploreDiscover />
-                }
-                {section === EXPLORE_SECTIONS.NEAR_REAL_TIME &&
-                  <ExploreNearRealTime />
-                }
-                {/* <ExploreDatasetsHeader /> */}
-              </div>
-            </Fragment>
+            <ExploreMenu />
+            <div className="explore-sidebar-content">
+              {section === EXPLORE_SECTIONS.ALL_DATA &&
+                exploreSectionShouldBeLoaded &&
+                <ExploreDatasets />
+              }
+              {section === EXPLORE_SECTIONS.TOPICS &&
+                exploreSectionShouldBeLoaded &&
+                <ExploreTopics />
+              }
+              {section === EXPLORE_SECTIONS.COLLECTIONS && userIsLoggedIn
+                && exploreSectionShouldBeLoaded &&
+                <ExploreCollections />
+              }
+              {section === EXPLORE_SECTIONS.COLLECTIONS && !userIsLoggedIn
+                && exploreSectionShouldBeLoaded &&
+                <ExploreLogin />
+              }
+              {section === EXPLORE_SECTIONS.DISCOVER &&
+                exploreSectionShouldBeLoaded &&
+                <ExploreDiscover />
+              }
+              {section === EXPLORE_SECTIONS.NEAR_REAL_TIME
+                && exploreSectionShouldBeLoaded &&
+                <ExploreNearRealTime />
+              }
+              {/* <ExploreDatasetsHeader /> */}
+            </div>
             {selected && <ExploreDetail /> }
           </ExploreSidebar>
 

--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -37,8 +37,8 @@ class Explore extends PureComponent {
     exploreSectionAlreadyLoaded: !this.props.explore.datasets.selected
   };
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (!nextProps.explore.datasets.selected && this.props.explore.datasets.selected
+  componentDidUpdate(prevProps) {
+    if (!this.props.explore.datasets.selected && prevProps.explore.datasets.selected
       && !this.state.exploreSectionAlreadyLoaded) {
       this.setState({ exploreSectionAlreadyLoaded: true });
     }

--- a/layout/explore/explore-detail/explore-detail-buttons/component.js
+++ b/layout/explore/explore-detail/explore-detail-buttons/component.js
@@ -20,7 +20,7 @@ function ExploreDetailButtons(props) {
 
   const { dataset: { metadata, subscribable } } = props;
   const { info } = metadata[0];
-  const isSubscribable = Object.keys(subscribable).length > 0;
+  const isSubscribable = subscribable && Object.keys(subscribable).length > 0;
   const numberOfButtons = (info.data_download_original_link ? 1 : 0) +
     (info.learn_more_link ? 1 : 0) + (isSubscribable ? 1 : 0) +
     (info.data_download_link ? 1 : 0);

--- a/layout/explore/explore-detail/initial-state.js
+++ b/layout/explore/explore-detail/initial-state.js
@@ -1,6 +1,6 @@
 export default {
   dataset: null,
   tags: [],
-  datasetLoading: false,
+  datasetLoading: true,
   tagsLoading: false
 };


### PR DESCRIPTION
## Overview
This PR fixes the following issues:
1. When loading the explore detail section, the loader appears from the very beginning. Previously a message saying that data could not be loaded was momentarily displayed.
2. Fix issue consisting of the app breaking when a dataset didn't have the `subscribable` property initialized.
3. Fix issue with map previews in Explore not loading properly when the first page loaded was explore detail, (instead of navigating to this section from any other explore section). 

## Testing instructions
Steps to reproduce the issue number `3.` on the explore site:
1. Go to https://explore.resourcewatch.org/data/explore/Environmental-Democracy-Index-1490086842552?section=Discover&zoom=3&lat=0&lng=0&pitch=0&bearing=0&basemap=dark&labels=light&page=1&sort=most-viewed&sortDirection=-1
2. Click on the button `ALL DATASETS`. 
3. You should see how the map previews appear distorted.