### PR TITLE
Explore: fix sidebar scroll behavior

### DIFF
--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import MediaQuery from 'react-responsive';
 
@@ -26,107 +26,105 @@ import ExploreFavorites from 'layout/explore/explore-favorites';
 import { breakpoints } from 'utils/responsive';
 import { EXPLORE_SECTIONS } from './constants';
 
-class Explore extends PureComponent {
-  static propTypes = {
-    responsive: PropTypes.object.isRequired,
-    explore: PropTypes.object.isRequired,
-    userIsLoggedIn: PropTypes.bool.isRequired
-  };
+function Explore(props) {
+  const {
+    responsive,
+    explore: { datasets: { selected }, sidebar: { section } },
+    userIsLoggedIn
+  } = props;
+  const [mobileWarningOpened, setMobileWarningOpened] = useState(true);
+  const [exploreSectionAlreadyLoaded, setExploreSectionAlreadyLoaded] = useState(!selected);
+  const exploreSectionShouldBeLoaded = !selected || exploreSectionAlreadyLoaded;
 
-  state = {
-    mobileWarningOpened: true,
-    exploreSectionAlreadyLoaded: !this.props.explore.datasets.selected
-  };
-
-  componentDidUpdate(prevProps) {
-    if (!this.props.explore.datasets.selected && prevProps.explore.datasets.selected
-      && !this.state.exploreSectionAlreadyLoaded) {
-      this.setState({ exploreSectionAlreadyLoaded: true });
+  useEffect(() => {
+    if (!exploreSectionAlreadyLoaded) {
+      setExploreSectionAlreadyLoaded(true);
     }
-  }
+    // Scroll to top of the div 'sidebar-content-container' should go here
+  }, [exploreSectionAlreadyLoaded, selected]);
 
-  render() {
-    const {
-      responsive,
-      explore: { datasets: { selected }, sidebar: { section } },
-      userIsLoggedIn
-    } = this.props;
-    const { mobileWarningOpened, exploreSectionAlreadyLoaded } = this.state;
-    const exploreSectionShouldBeLoaded = !selected || exploreSectionAlreadyLoaded;
-    return (
-      <Layout
-        title="Explore Data Sets — Resource Watch"
-        description="Browse more than 200 global data sets on the state of our planet."
-        className="-fullscreen"
-      >
-        <div className="c-page-explore">
-          <ExploreSidebar>
-            <ExploreMenu />
-            <div className="explore-sidebar-content">
-              {section === EXPLORE_SECTIONS.ALL_DATA &&
-                exploreSectionShouldBeLoaded &&
-                <ExploreDatasets />
-              }
-              {section === EXPLORE_SECTIONS.TOPICS &&
-                exploreSectionShouldBeLoaded &&
-                <ExploreTopics />
-              }
-              {section === EXPLORE_SECTIONS.COLLECTIONS && userIsLoggedIn
-                && exploreSectionShouldBeLoaded &&
-                <ExploreCollections />
-              }
-              {section === EXPLORE_SECTIONS.FAVORITES && userIsLoggedIn
-                && exploreSectionShouldBeLoaded &&
-                <ExploreFavorites />
-              }
-              {(section === EXPLORE_SECTIONS.COLLECTIONS ||
-                section === EXPLORE_SECTIONS.FAVORITES) && !userIsLoggedIn
-                && exploreSectionShouldBeLoaded &&
-                <ExploreLogin />
-              }
-              {section === EXPLORE_SECTIONS.DISCOVER &&
-                exploreSectionShouldBeLoaded &&
-                <ExploreDiscover />
-              }
-              {section === EXPLORE_SECTIONS.NEAR_REAL_TIME
-                && exploreSectionShouldBeLoaded &&
-                <ExploreNearRealTime />
-              }
-              {/* <ExploreDatasetsHeader /> */}
+  return (
+    <Layout
+      title="Explore Data Sets — Resource Watch"
+      description="Browse more than 200 global data sets on the state of our planet."
+      className="-fullscreen"
+    >
+      <div className="c-page-explore">
+        <ExploreSidebar>
+          <ExploreMenu />
+          <div
+            className="explore-sidebar-content"
+            id="sidebar-content-container"
+          >
+            {section === EXPLORE_SECTIONS.ALL_DATA &&
+              exploreSectionShouldBeLoaded &&
+              <ExploreDatasets />
+            }
+            {section === EXPLORE_SECTIONS.TOPICS &&
+              exploreSectionShouldBeLoaded &&
+              <ExploreTopics />
+            }
+            {section === EXPLORE_SECTIONS.COLLECTIONS && userIsLoggedIn
+              && exploreSectionShouldBeLoaded &&
+              <ExploreCollections />
+            }
+            {section === EXPLORE_SECTIONS.FAVORITES && userIsLoggedIn
+              && exploreSectionShouldBeLoaded &&
+              <ExploreFavorites />
+            }
+            {(section === EXPLORE_SECTIONS.COLLECTIONS ||
+              section === EXPLORE_SECTIONS.FAVORITES) && !userIsLoggedIn
+              && exploreSectionShouldBeLoaded &&
+              <ExploreLogin />
+            }
+            {section === EXPLORE_SECTIONS.DISCOVER &&
+              exploreSectionShouldBeLoaded &&
+              <ExploreDiscover />
+            }
+            {section === EXPLORE_SECTIONS.NEAR_REAL_TIME
+              && exploreSectionShouldBeLoaded &&
+              <ExploreNearRealTime />
+            }
+            {/* <ExploreDatasetsHeader /> */}
+          </div>
+          {selected && <ExploreDetail />}
+        </ExploreSidebar>
+
+        {/* Mobile warning */}
+        <MediaQuery
+          maxDeviceWidth={breakpoints.medium}
+          values={{ deviceWidth: responsive.fakeWidth }}
+        >
+          <Modal
+            isOpen={mobileWarningOpened}
+            onRequestClose={() => setMobileWarningOpened(false)}
+          >
+            <div>
+              <p>The mobile version of Explore has limited functionality,
+              please check the desktop version to have access to the
+              full list of features available.
+              </p>
             </div>
-            {selected && <ExploreDetail /> }
-          </ExploreSidebar>
+          </Modal>
+        </MediaQuery>
 
-          {/* Mobile warning */}
-          <MediaQuery
-            maxDeviceWidth={breakpoints.medium}
-            values={{ deviceWidth: responsive.fakeWidth }}
-          >
-            <Modal
-              isOpen={mobileWarningOpened}
-              onRequestClose={() => this.setState({ mobileWarningOpened: false })}
-            >
-              <div>
-                <p>The mobile version of Explore has limited functionality,
-                  please check the desktop version to have access to the
-                  full list of features available.
-                </p>
-              </div>
-            </Modal>
-          </MediaQuery>
+        {/* Desktop map */}
+        <MediaQuery
+          minDeviceWidth={breakpoints.medium}
+          values={{ deviceWidth: responsive.fakeWidth }}
+        >
+          <ExploreMap />
+        </MediaQuery>
 
-          {/* Desktop map */}
-          <MediaQuery
-            minDeviceWidth={breakpoints.medium}
-            values={{ deviceWidth: responsive.fakeWidth }}
-          >
-            <ExploreMap />
-          </MediaQuery>
-
-        </div>
-      </Layout>
-    );
-  }
+      </div>
+    </Layout>
+  );
 }
+
+Explore.propTypes = {
+  responsive: PropTypes.object.isRequired,
+  explore: PropTypes.object.isRequired,
+  userIsLoggedIn: PropTypes.bool.isRequired
+};
 
 export default Explore;

--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -41,7 +41,7 @@ function Explore(props) {
       setExploreSectionAlreadyLoaded(true);
     }
     // Scroll to top of the div 'sidebar-content-container' should go here
-  }, [exploreSectionAlreadyLoaded, selected]);
+  }, [selected]);
 
   return (
     <Layout

--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -39,8 +39,7 @@ function Explore(props) {
   useEffect(() => {
     if (!exploreSectionAlreadyLoaded) {
       setExploreSectionAlreadyLoaded(true);
-    }
-    // Scroll to top of the div 'sidebar-content-container' should go here
+    }    
   }, [selected]);
 
   return (
@@ -50,11 +49,18 @@ function Explore(props) {
       className="-fullscreen"
     >
       <div className="c-page-explore">
-        <ExploreSidebar>
+        {/*
+           We set this key so that, by rerendering the sidebar, the sections are 
+           scrolled to the top when the selected section changes. 
+        */}
+        <ExploreSidebar  
+          key={section}
+        >
           <ExploreMenu />
           <div
             className="explore-sidebar-content"
             id="sidebar-content-container"
+            key={section}
           >
             {section === EXPLORE_SECTIONS.ALL_DATA &&
               exploreSectionShouldBeLoaded &&

--- a/layout/explore/explore-sidebar/component.js
+++ b/layout/explore/explore-sidebar/component.js
@@ -7,7 +7,6 @@ import { logEvent } from 'utils/analytics';
 
 // Components
 import Icon from 'components/ui/icon';
-import Spinner from 'components/ui/Spinner';
 
 class ExploreSidebarComponent extends React.Component {
   static propTypes = {

--- a/layout/explore/explore-sidebar/index.js
+++ b/layout/explore/explore-sidebar/index.js
@@ -2,7 +2,7 @@
 import { connect } from 'react-redux';
 import * as actions from 'layout/explore/actions';
 
-import ExploreSidebarComponent from './explore-sidebar-component';
+import ExploreSidebarComponent from './component';
 
 export default connect(
   state => ({ ...state.explore.sidebar }),


### PR DESCRIPTION
## Overview
This PR fixes the issues with the scroll position when changing between explore sections.

## Testing instructions
- Go to any of the sections, change the scroll position and then click on any of the menu elements to go to another section. Verify that the interfaces scrolls to the top of the new section.
- Click on links such as `SEE ALL`, `SEE ALL DATA` from the `Discover` section and verify that the section opened scrolls to the top.

## Pivotal tasks
- https://www.pivotaltracker.com/story/show/172012514
- https://www.pivotaltracker.com/story/show/172013630
