### PR TITLE
improve styles and scroll behavior for related content

### DIFF
--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -39,8 +39,8 @@ function Explore(props) {
   useEffect(() => {
     if (!exploreSectionAlreadyLoaded) {
       setExploreSectionAlreadyLoaded(true);
-    }    
-  }, [selected]);
+    }
+  }, [exploreSectionAlreadyLoaded, selected]);
 
   return (
     <Layout
@@ -50,10 +50,10 @@ function Explore(props) {
     >
       <div className="c-page-explore">
         {/*
-           We set this key so that, by rerendering the sidebar, the sections are 
-           scrolled to the top when the selected section changes. 
+           We set this key so that, by rerendering the sidebar, the sections are
+           scrolled to the top when the selected section changes.
         */}
-        <ExploreSidebar  
+        <ExploreSidebar
           key={section}
         >
           <ExploreMenu />
@@ -93,7 +93,7 @@ function Explore(props) {
             }
             {/* <ExploreDatasetsHeader /> */}
           </div>
-          {selected && <ExploreDetail />}
+          {selected && <ExploreDetail key={selected} />}
         </ExploreSidebar>
 
         {/* Mobile warning */}

--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -40,7 +40,7 @@ function Explore(props) {
     if (!exploreSectionAlreadyLoaded) {
       setExploreSectionAlreadyLoaded(true);
     }
-  }, [exploreSectionAlreadyLoaded, selected]);
+  }, [selected]);
 
   return (
     <Layout

--- a/layout/explore/explore-detail/related-content/component.js
+++ b/layout/explore/explore-detail/related-content/component.js
@@ -9,12 +9,14 @@ import ExploreDatasetsActions from 'layout/explore/explore-datasets/explore-data
 import './styles.scss';
 
 function RelatedContent(props) {
-  const { datasets, setSelectedDataset } = props;
+  const { datasets: { list, loading }, setSelectedDataset } = props;
   return (
     <div className="c-related-content">
       <h3>Related content</h3>
       <DatasetList
-        list={datasets}
+        list={list}
+        loading={loading}
+        numberOfPlaceholders={3}
         actions={<ExploreDatasetsActions />}
         expandedChart
       />

--- a/layout/explore/explore-detail/related-content/index.js
+++ b/layout/explore/explore-detail/related-content/index.js
@@ -13,10 +13,14 @@ import RelatedContentComponent from './component';
 
 const RelatedContentContainer = (props) => {
   const { datasetID } = props;
-  const [datasets, setDatasets] = useState([]);
+  const [datasets, setDatasets] = useState({
+    list: [],
+    loading: false
+  });
 
   useEffect(() => {
     if (datasetID) {
+      setDatasets({ list: [], loading: true });
       fetchSimilarDatasets({
         dataset: datasetID,
         published: true,
@@ -27,7 +31,12 @@ const RelatedContentContainer = (props) => {
             ids: data.map(d => d.dataset).join(','),
             includes: 'widget,metadata,layer,vocabulary'
           })
-            .then(similarDatasets => setDatasets(similarDatasets));
+            .then((similarDatasets) => {
+              setDatasets({
+                list: similarDatasets,
+                loading: false
+              });
+            });
         }
       })
         .catch(error => toastr.error('Error loading related content', error));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/78341829-9bf19100-7598-11ea-858b-c4be6e86c036.png)

## Overview
This PR includes the following two improvements for the related datasets section in the metadata page:
1. Loader and placeholder while the datasets are being fetched
2. Scroll to the top of the section when selecting one of them

## Testing instructions
Check the related content section of any given dataset.

## [Pivotal task](https://www.pivotaltracker.com/story/show/172050135)