### PR TITLE
Explore map update: change behavior when clicking on info button

### DIFF
--- a/layout/explore/explore-detail/component.js
+++ b/layout/explore/explore-detail/component.js
@@ -27,10 +27,17 @@ class ExploreDetailComponent extends React.Component {
   static propTypes = {
     dataset: PropTypes.object,
     datasetLoading: PropTypes.bool.isRequired,
-    tags: PropTypes.array.isRequired
+    tags: PropTypes.array.isRequired,
+    setSidebarAnchor: PropTypes.func.isRequired
   };
 
   static defaultProps = { dataset: null };
+
+  // We clear the anchor value so that next time the component is open
+  // the scroll is at the top
+  componentWillUnmount() {
+    this.props.setSidebarAnchor(null);
+  }
 
   render() {
     const { dataset, datasetLoading, tags } = this.props;

--- a/layout/explore/explore-detail/index.js
+++ b/layout/explore/explore-detail/index.js
@@ -38,6 +38,13 @@ const ExploreDetailContainer = (props) => {
           dispatch(setDataset(data));
           dispatch(setDatasetLoading(false));
 
+          // Check if there's an anchor value so that the interface scrolls
+          // to that section
+          const element = document.getElementById(anchor);
+          if (element) {
+            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }
+
           // Load tags
           const knowledgeGraphVoc = data.vocabulary && data.vocabulary.find(v => v.name === 'knowledge_graph');
           const tags = knowledgeGraphVoc && knowledgeGraphVoc.tags;
@@ -60,7 +67,7 @@ const ExploreDetailContainer = (props) => {
           toastr.error('Error loading dataset data', error);
         });
     }
-  }, [datasetID]);
+  }, [anchor, datasetID]);
 
 
   useEffect(() => {

--- a/layout/explore/explore-map/component.js
+++ b/layout/explore/explore-map/component.js
@@ -18,6 +18,8 @@ import {
 } from 'vizzuality-components';
 
 // components
+import Modal from 'components/modal/modal-component';
+import LayerInfoModal from 'components/modal/layer-info-modal';
 import Spinner from 'components/ui/Spinner';
 import Map from 'components/map';
 import LayerManager from 'components/map/layer-manager';
@@ -68,7 +70,8 @@ class ExploreMap extends PureComponent {
     setMapLayerGroupsInteractionLatLng: PropTypes.func.isRequired,
     setMapLayerGroupsInteractionSelected: PropTypes.func.isRequired,
     resetMapLayerGroupsInteraction: PropTypes.func.isRequired,
-    setSelectedDataset: PropTypes.func.isRequired
+    setSelectedDataset: PropTypes.func.isRequired,
+    setSidebarAnchor: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -77,10 +80,14 @@ class ExploreMap extends PureComponent {
     layerGroupsInteractionLatLng: null
   }
 
-  state = { loading: {} };
+  state = { layer: null, loading: {} };
 
   onChangeInfo = (layer) => {
-    this.props.setSelectedDataset(layer.dataset);
+    this.setState({ layer });
+    if (layer) {
+      this.props.setSelectedDataset(layer.dataset);
+      this.props.setSidebarAnchor('layers');
+    }
   };
 
   onChangeOpacity = debounce((l, opacity) => {
@@ -564,6 +571,15 @@ class ExploreMap extends PureComponent {
             ))}
           </Legend>
         </div>
+        {!!layer && embed && (
+          <Modal
+            isOpen={!!layer}
+            className="-medium"
+            onRequestClose={() => this.onChangeInfo(null)}
+          >
+            <LayerInfoModal layer={layer} />
+          </Modal>
+        )}
       </div>
     );
   }

--- a/layout/explore/explore-map/component.js
+++ b/layout/explore/explore-map/component.js
@@ -18,8 +18,6 @@ import {
 } from 'vizzuality-components';
 
 // components
-import Modal from 'components/modal/modal-component';
-import LayerInfoModal from 'components/modal/layer-info-modal';
 import Spinner from 'components/ui/Spinner';
 import Map from 'components/map';
 import LayerManager from 'components/map/layer-manager';
@@ -69,7 +67,8 @@ class ExploreMap extends PureComponent {
     setMapLayerGroupsInteraction: PropTypes.func.isRequired,
     setMapLayerGroupsInteractionLatLng: PropTypes.func.isRequired,
     setMapLayerGroupsInteractionSelected: PropTypes.func.isRequired,
-    resetMapLayerGroupsInteraction: PropTypes.func.isRequired
+    resetMapLayerGroupsInteraction: PropTypes.func.isRequired,
+    setSelectedDataset: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -78,13 +77,10 @@ class ExploreMap extends PureComponent {
     layerGroupsInteractionLatLng: null
   }
 
-  state = {
-    layer: null,
-    loading: {}
-  };
+  state = { loading: {} };
 
   onChangeInfo = (layer) => {
-    this.setState({ layer });
+    this.props.setSelectedDataset(layer.dataset);
   };
 
   onChangeOpacity = debounce((l, opacity) => {
@@ -568,20 +564,6 @@ class ExploreMap extends PureComponent {
             ))}
           </Legend>
         </div>
-
-
-        {!!layer && (
-          <Modal
-            isOpen={!!layer}
-            className="-medium"
-            onRequestClose={() => this.onChangeInfo(null)}
-          >
-            <LayerInfoModal
-              layer={layer}
-              onRequestClose={() => this.onChangeInfo(null)}
-            />
-          </Modal>
-        )}
       </div>
     );
   }


### PR DESCRIPTION
## Overview
This PR modifies the behavior when clicking on the layer info button from the map legend, now the explore detail section is opened and scrolled to the `Dataset layers` section instead of opening a modal. 
_NOTE: The modal is still opened when Explore is embedded_

## Testing instructions
Check the behavior when clicking on the info button both in Explore and an embedded instance of it.

## [Pivotal task](https://www.pivotaltracker.com/story/show/172050135)