### PR TITLE
Explore favorites: prompt when user has no favorite datasets

### DIFF
--- a/layout/explore/explore-favorites/component.js
+++ b/layout/explore/explore-favorites/component.js
@@ -10,6 +10,7 @@ import { fetchDatasets } from 'services/dataset';
 import DatasetList from 'layout/explore/explore-datasets/list';
 import Spinner from 'components/ui/Spinner';
 import ExploreDatasetsActions from 'layout/explore/explore-datasets/explore-datasets-actions';
+import Icon from 'components/ui/icon';
 
 // Styles
 import './styles.scss';
@@ -52,7 +53,23 @@ function ExploreFavoritesComponent(props) {
           list={datasets}
           actions={<ExploreDatasetsActions />}
         />
-        }
+      }
+      {!datasetsLoading && datasets.length === 0 &&
+        <div className="no-datasets">
+          <div className="empty-card" />
+          <div className="message">
+            <h5>You currently have no favorite datasets</h5>
+            <p>
+              To favorite a dataset or start a collection, click the <Icon
+                name="icon-star-full"
+                className="-star -small"
+              /> on any dataset card
+            </p>
+          </div>
+          <div className="empty-card" />
+          <div className="empty-card" />
+        </div>
+      }
     </div>
   );
 }

--- a/layout/explore/explore-favorites/styles.scss
+++ b/layout/explore/explore-favorites/styles.scss
@@ -1,6 +1,8 @@
 @import 'css/settings';
 
 .c-explore-favorites {
+    display: flex;
+    flex-direction: column;
     margin: 0px 4 * $space 2 * $space 3 * $space;
 
     &.-hidden {
@@ -9,5 +11,16 @@
 
     .c-spinner {
         top: 300px;
+    }
+
+    .empty-card {
+        height: 130px;
+        background-color: $sea-blue;
+        opacity: 0.05;
+        margin: 2 * $space 0px 2 * $space 0px;
+    }
+
+    .message {
+        text-align: center;
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/78656180-4f26f680-78c7-11ea-9dde-9a176e4beff7.png)

## Overview
This PR adds a prompt to add favorites/collections if an user is logged in, but doesn't yet have any.

## Testing instructions
Make sure that you have no favorite datasets and go to the Explore _favorites_ section.

## [Pivotal task](https://www.pivotaltracker.com/story/show/172013507)