### PR TITLE
GEDC: select Global Power Plants dataset by default in map

### DIFF
--- a/layout/app/dashboard-detail/energy-country-explorer/power-generation-map/map-menu/component.js
+++ b/layout/app/dashboard-detail/energy-country-explorer/power-generation-map/map-menu/component.js
@@ -54,7 +54,7 @@ function MapMenu(props) {
         //-------------------------------------------------------
       })
       .catch(err => toastr.error('Error loading datasets', err));
-  }, [datasetsMap, groups]);
+  }, [groups]);
 
   return (
     <div className="c-map-menu">

--- a/layout/app/dashboard-detail/energy-country-explorer/power-generation-map/map-menu/component.js
+++ b/layout/app/dashboard-detail/energy-country-explorer/power-generation-map/map-menu/component.js
@@ -10,7 +10,6 @@ import { breakpoints } from 'utils/responsive';
 import { fetchDatasets } from 'services/dataset';
 
 // Components
-import Spinner from 'components/ui/Spinner';
 import DatasetList from 'layout/explore/explore-datasets/list';
 import ExploreDatasetsActions from 'layout/explore/explore-datasets/explore-datasets-actions';
 
@@ -18,9 +17,16 @@ import ExploreDatasetsActions from 'layout/explore/explore-datasets/explore-data
 import './styles.scss';
 
 function MapMenu(props) {
-  const { groups, responsive } = props;
+  const {
+    groups,
+    responsive,
+    toggleMapLayerGroup,
+    setMapLayerGroupActive,
+    resetMapLayerGroupsInteraction
+  } = props;
   const [datasetsMap, setDatasetsMap] = useState(new Map());
   const [loading, setLoading] = useState(true);
+  const powerwatchDatasetID = 'a86d906d-9862-4783-9e30-cdb68cd808b8';
 
   useEffect(() => {
     const datasetIDs = groups.reduce((acc, group) => [...acc, ...group.datasets], []);
@@ -33,6 +39,19 @@ function MapMenu(props) {
         datasets.forEach(d => datasetsMap.set(d.id, d));
         setDatasetsMap(datasetsMap);
         setLoading(false);
+
+        //----- Select Power plants dataset by default ---------
+        const powerWatchDataset = datasetsMap.get(powerwatchDatasetID);
+        toggleMapLayerGroup({ 
+          dataset: powerWatchDataset, 
+          toggle: true }
+        );
+        setMapLayerGroupActive({ 
+          dataset: { id: powerwatchDatasetID }, 
+          active: powerWatchDataset.layer.find(l => l.default).id
+        });
+        resetMapLayerGroupsInteraction();
+        //-------------------------------------------------------
       })
       .catch(err => toastr.error('Error loading datasets', err));
   }, [datasetsMap, groups]);

--- a/layout/app/dashboard-detail/energy-country-explorer/power-generation-map/map-menu/index.js
+++ b/layout/app/dashboard-detail/energy-country-explorer/power-generation-map/map-menu/index.js
@@ -1,7 +1,19 @@
 import { connect } from 'react-redux';
 
+// actions
+import {
+  toggleMapLayerGroup,
+  setMapLayerGroupActive,
+  resetMapLayerGroupsInteraction
+} from 'layout/explore/actions';
+
 import MapMenuComponent from './component';
 
 export default connect(state => (
   { responsive: state.responsive }),
-null)(MapMenuComponent);
+  {
+    toggleMapLayerGroup,
+    setMapLayerGroupActive,
+    resetMapLayerGroupsInteraction
+  }
+)(MapMenuComponent);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/82795482-5f456600-9e74-11ea-9eed-b89bf7622eda.png)

## Overview
This PR adds the logic necessary to select the Global Power Plants dataset by default in the map section.

## Testing instructions
Go to http://localhost:9000/dashboards/energy?tab=country