### PR TITLE
Fix GDPR banner position

### DIFF
--- a/components/ui/gdpr-banner/styles.scss
+++ b/components/ui/gdpr-banner/styles.scss
@@ -1,6 +1,11 @@
 @import 'css/settings';
 
 .c-gdpr-banner {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  z-index: 99999999;
   display: flex;
   align-items: center;
   padding: $space-1 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/82880219-65a01480-9f3e-11ea-9594-a88b311dbfc6.png)

## Overview
This PR fixes the GDPR banner position.

## Testing instructions
Go to `localhost:9000/data/explore` after clearing the session storage and make sure the banner doesn't displace the interface to the bottom.

## [Pivotal task](https://www.pivotaltracker.com/story/show/172900641)