### PR TITLE
Explore detail: dataset description meta tags

### DIFF
--- a/layout/explore/component.js
+++ b/layout/explore/component.js
@@ -33,6 +33,7 @@ function Explore(props) {
     userIsLoggedIn
   } = props;
   const [mobileWarningOpened, setMobileWarningOpened] = useState(true);
+  const [datasetDescription, setDatasetDescription] = useState(null);
 
   const getSidebarLayout = () => (
     <Fragment>
@@ -65,26 +66,35 @@ function Explore(props) {
           <ExploreNearRealTime />
         }
       </div>
-      {selected && <ExploreDetail key={selected} />}
+      {selected && 
+        <ExploreDetail 
+          key={selected} 
+          onDatasetLoaded={(dataset) =>
+            setDatasetDescription(dataset.metadata[0].info.functions)}
+        />
+      }
     </Fragment>
   );
+
+  const descriptionSt = selected ? datasetDescription : 
+      'Browse more than 200 global data sets on the state of our planet.';
 
   return (
     <Layout
       title="Explore Data Sets — Resource Watch"
-      description="Browse more than 200 global data sets on the state of our planet."
+      description={descriptionSt}
       className="-fullscreen"
     >
       <div className="c-page-explore">
-        {/*
-           We set this key so that, by rerendering the sidebar, the sections are
-           scrolled to the top when the selected section changes.
-        */}
         <MediaQuery
           minWidth={breakpoints.medium}
           values={{ deviceWidth: responsive.fakeWidth }}
         >
           <Fragment>
+             {/*
+              We set this key so that, by rerendering the sidebar, the sections are
+              scrolled to the top when the selected section changes.
+            */}
             <ExploreSidebar
               key={section}
             >

--- a/layout/explore/explore-detail/index.js
+++ b/layout/explore/explore-detail/index.js
@@ -26,7 +26,7 @@ import {
 
 const ExploreDetailContainer = (props) => {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const { datasetID, anchor } = props;
+  const { datasetID, anchor, onDatasetLoaded } = props;
 
   useEffect(() => {
     if (datasetID) {
@@ -37,6 +37,9 @@ const ExploreDetailContainer = (props) => {
         .then((data) => {
           dispatch(setDataset(data));
           dispatch(setDatasetLoading(false));
+
+          // Notifying the parent about the dataset load
+          onDatasetLoaded(data);
 
           // Check if there's an anchor value so that the interface scrolls
           // to that section
@@ -86,7 +89,8 @@ const ExploreDetailContainer = (props) => {
 
 ExploreDetailContainer.propTypes = {
   datasetID: PropTypes.string.isRequired,
-  anchor: PropTypes.string.isRequired
+  anchor: PropTypes.string.isRequired,
+  onDatasetLoaded: PropTypes.func.isRequired
 };
 
 export default connect(


### PR DESCRIPTION
## Overview
This PR adds the right dataset description to the meta tags when users open a dataset detail page.

## Testing instructions
Load any dataset detail page and check that the right description is included in the `<head/>` metadata tags.

## [Pivotal task](https://www.pivotaltracker.com/story/show/173136239)