### PR TITLE
Explore: fix legend timeline mark styles

### DIFF
--- a/layout/explore/explore-map/styles.scss
+++ b/layout/explore/explore-map/styles.scss
@@ -39,7 +39,18 @@
       }
 
       .rc-slider-mark {
-        margin-left: 0;
+        min-width: 100%;
+        margin-left: 0;  
+        display: flex;
+        justify-content: space-between;      
+
+        .rc-slider-mark-text {
+          display: none;
+
+          &:last-child, &:first-child {
+            display: block;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/545342/87921538-014f8c00-ca7b-11ea-8315-f946cbefffa8.png)

**After: **

![image](https://user-images.githubusercontent.com/545342/87921582-0f9da800-ca7b-11ea-989c-4756caba476c.png)

## Overview
This PR fixes the styles issue shown above.

## Testing instructions
Check that the timeline legend is working fine [here](http://localhost:9000/data/explore/cli023-Standard-Precipitation-Index?section=All%20data&zoom=1.7732970661501868&lat=-13.436431891129605&lng=-77.52791432671418&pitch=0&bearing=0&basemap=dark&labels=light&layers=%255B%257B%2522dataset%2522%253A%2522c0c71e67-0088-4d69-b375-85297f79ee75%2522%252C%2522opacity%2522%253A1%252C%2522layer%2522%253A%2522eb0574c3-50a8-4cd3-ba8d-4d13eb7b12ad%2522%257D%255D&page=1&sort=relevance&sortDirection=-1&search=spi)
