### PR TITLE
Explore detail: add license and date of content metadata fields

### DIFF
--- a/layout/explore/explore-detail/further-information/component.js
+++ b/layout/explore/explore-detail/further-information/component.js
@@ -20,7 +20,10 @@ function FurtherInformationComponent(props) {
         cautions, citation,
         sources,
         geographic_coverage,
-        frequency_of_updates
+        frequency_of_updates,
+        license,
+        license_link,
+        date_of_content
       },
       language
     }
@@ -69,6 +72,7 @@ function FurtherInformationComponent(props) {
           }
         </div>
       )}
+
       <div className="row" >
         <div className="column small-6">
           <div className="metadata-field">
@@ -86,6 +90,18 @@ function FurtherInformationComponent(props) {
           <div className="metadata-field">
             <h4>Published language</h4>
             <ReactMarkdown linkTarget="_blank" source={language} />
+          </div>
+        </div>
+        <div className="column small-6">
+          <div className="metadata-field">
+            <h4>License</h4>
+            <a href={license_link} target="_blank">{license}</a>
+          </div>
+        </div>
+        <div className="column small-6">
+          <div className="metadata-field">
+            <h4>Date of content</h4>
+            <ReactMarkdown linkTarget="_blank" source={date_of_content} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/545342/91165435-e8b54000-e6d0-11ea-8e93-41798079a576.png)

## Overview
This PR adds the following metadata fields to the `Further information` section of Explore detail:
- `Date of content`
- `License`

## Testing instructions
Check any given dataset that has values for these two fields.

## [Pivotal task](https://www.pivotaltracker.com/story/show/174324573)