### PR TITLE
Fix for "Explore metadata page map-widgets float over metadata navigation tabs"

### DIFF
--- a/layout/explore/explore-detail/explore-detail-footer/styles.scss
+++ b/layout/explore/explore-detail/explore-detail-footer/styles.scss
@@ -5,6 +5,7 @@
     bottom: 0px;
     left: 0px;
     width: 100%;
+    z-index: 2;
     padding-left: 8 * $space;
     padding-right: 8 * $space;
     display: flex;


### PR DESCRIPTION
## [Pivotal task](https://www.pivotaltracker.com/story/show/174639854)