### PR TITLE
fixes override widget-editor default disabled features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - maintenance: updates `eslint` and its plugins. [#174977793](https://www.pivotaltracker.com/story/show/174977793)
 
 ### Fixed
+- widget editor: override of default disabled features. [#174930015](https://www.pivotaltracker.com/story/show/174930015)
 
 ### Removed
 - widget editor: removed deprecated assets. [#174952659](https://www.pivotaltracker.com/story/show/174952659)

--- a/components/app/myrw/widgets/tabs/new.js
+++ b/components/app/myrw/widgets/tabs/new.js
@@ -15,6 +15,7 @@ import WidgetEditor from '@widget-editor/widget-editor';
 import RwAdapter from '@widget-editor/rw-adapter';
 
 // Utils
+import { logEvent } from 'utils/analytics';
 import DefaultTheme from 'utils/widgets/theme';
 
 // Components
@@ -22,8 +23,8 @@ import Spinner from 'components/ui/Spinner';
 import Field from 'components/form/Field';
 import Select from 'components/form/SelectInput';
 
-// Utils
-import { logEvent } from 'utils/analytics';
+// constants
+import { WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES } from 'constants/widget-editor';
 
 class WidgetsNew extends React.Component {
   static propTypes = {
@@ -176,7 +177,10 @@ class WidgetsNew extends React.Component {
               theme={DefaultTheme}
               adapter={RwAdapter}
               authenticated
-              disable={['advanced-editor']}
+              disable={[
+                ...WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES,
+                'advanced-editor',
+              ]}
             />
           </div>
         }

--- a/constants/widget-editor.js
+++ b/constants/widget-editor.js
@@ -1,0 +1,6 @@
+export const WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES = [
+  'typography',
+  'end-user-filters',
+];
+
+export default { WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES };

--- a/layout/explore/explore-detail/explore-detail-visualization/component.js
+++ b/layout/explore/explore-detail/explore-detail-visualization/component.js
@@ -20,6 +20,9 @@ import { logEvent } from 'utils/analytics';
 // Services
 import { createWidget, createWidgetMetadata } from 'services/widget';
 
+// constants
+import { WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES } from 'constants/widget-editor';
+
 function ExploreDetailVisualization(props) {
   const { widgetId, datasetId, authorization } = props;
   const [loginModalOpen, setLoginModalOpen] = useState(false);
@@ -84,7 +87,12 @@ function ExploreDetailVisualization(props) {
           theme={DefaultTheme}
           adapter={RwAdapter}
           authenticated
-          disable={['theme-selection', 'advanced-editor', 'map']}
+          disable={[
+            ...WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES,
+            'theme-selection',
+            'advanced-editor',
+            'map',
+          ]}
         />
       </ErrorBoundary>
       <Modal


### PR DESCRIPTION
## Overview
Disables default features `typography` and `end-user-filters` as they are not used in RW. Adding new disabled features was overriding the default ones.
![image](https://user-images.githubusercontent.com/999124/94235437-dc104b80-ff0b-11ea-973d-54f09800c6dc.png)
![image](https://user-images.githubusercontent.com/999124/94235449-e5011d00-ff0b-11ea-9b15-e7a6e8ede562.png)


## Testing instructions
- check any widget editor instance (for example in `/data/explore`) and check the default disabled features and the ones added later are not there.

## Pivotal task
https://www.pivotaltracker.com/story/show/174930015

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
