### PR TITLE
removes colors dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 ### Removed
+- maintenance: removed unused `colors` dev dependency.
 - widget editor: removed deprecated assets. [#174952659](https://www.pivotaltracker.com/story/show/174952659)
 
 ## [2.2.1] - 2020-02-03

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "babel-cli": "6.26.0",
     "babel-eslint": "^10.1.0",
     "babel-preset-env": "1.6.0",
-    "colors": "1.1.2",
     "cssnano": "^4.1.10",
     "eslint": "5.16.0",
     "eslint-config-airbnb": "^18.2.0",


### PR DESCRIPTION
## Overview
Removes unused [colors](https://www.npmjs.com/package/colors) dev dependency.

## Testing instructions
run `rm -rf node_modules && yarn`. The app should start normally.

## Pivotal task
–

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
