### PR TITLE
widget-editor: RW adapter changes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
   "rules": {
     "import/no-unresolved": "off",
     "react/jsx-filename-extension": "warn",
+    "react/jsx-props-no-spreading": "off",
     "react-hooks/exhaustive-deps": "warn",
     "react-hooks/rules-of-hooks": "error"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
-- maintenance: updates `eslint` and its plugins. [#174977793](https://www.pivotaltracker.com/story/show/174977793)
+- widget-editor: updated RW-adapter to accept app's params (like API url).
+- maintenance: updated `eslint` and its plugins. [#174977793](https://www.pivotaltracker.com/story/show/174977793)
 
 ### Fixed
 - widget-editor: fixed error updating fields. [#174996497](https://www.pivotaltracker.com/story/show/174996497)

--- a/components/admin/data/widgets/form/component.js
+++ b/components/admin/data/widgets/form/component.js
@@ -4,7 +4,7 @@ import { toastr } from 'react-redux-toastr';
 import { Router } from 'routes';
 
 // components
-import Step1 from 'components/admin/data/widgets/form/steps/Step1';
+import AdminWidgetForm from 'components/admin/data/widgets/form/steps';
 import Spinner from 'components/ui/Spinner';
 
 // services
@@ -308,7 +308,7 @@ class WidgetForm extends PureComponent {
       <form className="c-form c-widgets-form" noValidate>
         <Spinner isLoading={loading} className="-light" />
         {step === 1 && !loading && (
-          <Step1
+          <AdminWidgetForm
             id={id}
             form={form}
             datasets={datasets}

--- a/components/admin/data/widgets/form/steps/component.jsx
+++ b/components/admin/data/widgets/form/steps/component.jsx
@@ -1,10 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import WidgetEditor from '@widget-editor/widget-editor';
-import RwAdapter from '@widget-editor/rw-adapter';
-
-// Redux
-import { connect } from 'react-redux';
 
 // Constants
 import { FORM_ELEMENTS } from 'components/admin/data/widgets/form/constants';
@@ -17,34 +13,36 @@ import Checkbox from 'components/form/Checkbox';
 // Utils
 import DefaultTheme from 'utils/widgets/theme';
 
-class Step1 extends Component {
-  static propTypes = {
-    id: PropTypes.string,
-    user: PropTypes.object.isRequired,
-    form: PropTypes.object,
-    datasets: PropTypes.array,
-    onChange: PropTypes.func,
-    onSave: PropTypes.func,
-    query: PropTypes.object.isRequired
-  };
+class AdminWidgetForm extends Component {
+  constructor(props) {
+    super(props);
 
-  state = {
-    id: this.props.id,
-    form: this.props.form
-  };
+    this.state = {
+      form: props.form,
+    };
+  }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       form: {
         ...nextProps.form,
-        dataset: nextProps.form.dataset || nextProps.query.dataset
-      }
+        dataset: nextProps.form.dataset || nextProps.query.dataset,
+      },
     });
   }
 
   render() {
-    const { id } = this.state;
-    const { user, query } = this.props;
+    const {
+      id,
+      user,
+      query,
+      datasets,
+      onChange,
+      onSave,
+      RWAdapter,
+    } = this.props;
+    const { form } = this.state;
 
     // Reset FORM_ELEMENTS
     FORM_ELEMENTS.elements = {};
@@ -55,53 +53,54 @@ class Step1 extends Component {
           {/* DATASET */}
           <Field
             ref={(c) => { if (c) FORM_ELEMENTS.elements.dataset = c; }}
-            onChange={value => this.props.onChange({ dataset: value })}
+            onChange={(value) => onChange({ dataset: value })}
             validations={['required']}
             className="-fluid"
-            options={this.props.datasets}
+            options={datasets}
             properties={{
               name: 'dataset',
               label: 'Dataset',
               default: query.dataset,
-              value: this.state.form.dataset || query.dataset,
+              value: form.dataset || query.dataset,
               disabled: !!id,
               required: true,
-              instanceId: 'selectDataset'
+              instanceId: 'selectDataset',
             }}
           >
             {Select}
           </Field>
 
-          {(user.role === 'ADMIN') &&
+          {(user.role === 'ADMIN') && (
             <Field
               ref={(c) => { if (c) FORM_ELEMENTS.elements.env = c; }}
               hint={'Choose "preproduction" to see this dataset it only as admin, "production" option will show it in public site.'}
               className="-fluid"
               options={[{ label: 'Pre-production', value: 'preproduction' }, { label: 'Production', value: 'production' }]}
-              onChange={value => this.props.onChange({ env: value })}
+              onChange={(value) => onChange({ env: value })}
               properties={{
                 name: 'env',
                 label: 'Environment',
                 placeholder: 'Choose an environment...',
                 noResultsText: 'Please, type the name of the columns and press enter',
-                promptTextCreator: label => `The name of the column is "${label}"`,
+                promptTextCreator: (label) => `The name of the column is "${label}"`,
                 default: 'preproduction',
-                value: this.props.form.env
+                value: form.env,
               }}
             >
               {Select}
-            </Field>}
+            </Field>
+          )}
 
           {/* PUBLISHED */}
           <Field
             ref={(c) => { if (c) FORM_ELEMENTS.elements.published = c; }}
-            onChange={value => this.props.onChange({ published: value.checked })}
+            onChange={(value) => onChange({ published: value.checked })}
             properties={{
               name: 'published',
               label: 'Do you want to set this widget as published?',
               value: 'published',
               title: 'Published',
-              checked: this.props.form.published
+              checked: form.published,
             }}
           >
             {Checkbox}
@@ -110,13 +109,13 @@ class Step1 extends Component {
           {/* DEFAULT */}
           <Field
             ref={(c) => { if (c) FORM_ELEMENTS.elements.default = c; }}
-            onChange={value => this.props.onChange({ default: value.checked })}
+            onChange={(value) => onChange({ default: value.checked })}
             properties={{
               name: 'default',
               label: 'Do you want to set this widget as default?',
               value: 'default',
               title: 'Default',
-              checked: this.props.form.default
+              checked: form.default,
             }}
           >
             {Checkbox}
@@ -125,13 +124,13 @@ class Step1 extends Component {
           {/* DEFAULT EDITABLE WIDGET */}
           <Field
             ref={(c) => { if (c) FORM_ELEMENTS.elements.defaultEditableWidget = c; }}
-            onChange={value => this.props.onChange({ defaultEditableWidget: value.checked })}
+            onChange={(value) => onChange({ defaultEditableWidget: value.checked })}
             properties={{
               name: 'defaultEditableWidget',
               label: 'Do you want to set this widget as the default editable widget?',
               value: 'defaultEditableWidget',
               title: 'Default editable widget',
-              checked: this.props.form.defaultEditableWidget
+              checked: form.defaultEditableWidget,
             }}
           >
             {Checkbox}
@@ -141,47 +140,68 @@ class Step1 extends Component {
           <div className="freeze-container">
             <Field
               ref={(c) => { if (c) FORM_ELEMENTS.elements.freeze = c; }}
-              onChange={value => this.props.onChange({ freeze: value.checked })}
+              onChange={(value) => onChange({ freeze: value.checked })}
               properties={{
                 name: 'freeze',
-                label: this.props.id ? '' : 'Do you want to freeze this widget?',
+                label: id ? '' : 'Do you want to freeze this widget?',
                 value: 'freeze',
                 title: 'Freeze',
-                checked: this.props.form.freeze,
+                checked: form.freeze,
                 // Temporarily disabled --> we need to review the implementation
-                disabled: true
+                disabled: true,
               }}
             >
               {Checkbox}
             </Field>
-            {this.props.form.freeze && this.props.id &&
+            {(form.freeze && id) && (
               <div className="freeze-text">
-                This widget has been <strong>frozen</strong> and cannot be modified...
+                This widget has been&nbsp;
+                <strong>frozen</strong>
+                &nbsp;and cannot be modified...
               </div>
-            }
+            )}
           </div>
         </fieldset>
 
-        {this.state.form.dataset &&
+        {form.dataset && (
           <WidgetEditor
-            datasetId={this.state.form.dataset}
+            datasetId={form.dataset}
             {...(id && { widgetId: id })}
             application="rw"
-            onSave={this.props.onSave}
+            onSave={onSave}
             theme={DefaultTheme}
-            adapter={RwAdapter}
+            adapter={RWAdapter}
             authenticated
             compact={false}
           />
-        }
+        )}
       </fieldset>
     );
   }
 }
 
-const mapStateToProps = state => ({
-  user: state.user,
-  query: state.routes.query
-});
+AdminWidgetForm.defaultProps = {
+  id: null,
+  datasets: [],
+};
 
-export default connect(mapStateToProps, null)(Step1);
+AdminWidgetForm.propTypes = {
+  id: PropTypes.string,
+  user: PropTypes.shape({
+    role: PropTypes.string.isRequired,
+  }).isRequired,
+  form: PropTypes.shape({
+    dataset: PropTypes.string,
+  }).isRequired,
+  datasets: PropTypes.arrayOf(
+    PropTypes.shape({}),
+  ),
+  query: PropTypes.shape({
+    dataset: PropTypes.string,
+  }).isRequired,
+  onChange: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+  RWAdapter: PropTypes.func.isRequired,
+};
+
+export default AdminWidgetForm;

--- a/components/admin/data/widgets/form/steps/index.js
+++ b/components/admin/data/widgets/form/steps/index.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+
+// constants
+import { getRWAdapter } from 'constants/widget-editor';
+
+// component
+import Step1 from './component';
+
+export default connect((state) => ({
+  user: state.user,
+  query: state.routes.query,
+  RWAdapter: getRWAdapter({ locale: state.common.locale }),
+}), null)(Step1);

--- a/components/app/myrw/widgets/WidgetsTab.js
+++ b/components/app/myrw/widgets/WidgetsTab.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 
 // Components
 import WidgetsIndex from 'components/app/myrw/widgets/tabs/list';
-import WidgetsEdit from 'components/app/myrw/widgets/tabs/edit';
-import WidgetsNew from 'components/app/myrw/widgets/tabs/new';
+import MyRWWidgetEditTab from 'components/app/myrw/widgets/tabs/edit';
+import MyRWWidgetNewTab from 'components/app/myrw/widgets/tabs/new';
 
 function WidgetsTab(props) {
   const { tab, subtab, id, user, dataset } = props;
@@ -19,11 +19,11 @@ function WidgetsTab(props) {
       }
 
       {id && subtab === 'edit' && user.token &&
-        <WidgetsEdit tab={tab} subtab={subtab} id={id} dataset={dataset} />
+        <MyRWWidgetEditTab tab={tab} subtab={subtab} id={id} dataset={dataset} />
       }
 
       {id === 'new' && user.token &&
-        <WidgetsNew tab={tab} subtab={subtab} dataset={dataset === 'new' ? null : dataset} />
+        <MyRWWidgetNewTab tab={tab} subtab={subtab} dataset={dataset === 'new' ? null : dataset} />
       }
     </div>
   );

--- a/components/app/myrw/widgets/tabs/edit/component.jsx
+++ b/components/app/myrw/widgets/tabs/edit/component.jsx
@@ -1,46 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { toastr } from 'react-redux-toastr';
+import WidgetEditor from '@widget-editor/widget-editor';
 
-// Redux
-import { connect } from 'react-redux';
+// components
+import Spinner from 'components/ui/Spinner';
 
-// Services
+// cervices
 import {
   fetchWidget,
   updateWidget,
   createWidgetMetadata,
-  updateWidgetMetadata
+  updateWidgetMetadata,
 } from 'services/widget';
 
-// Widget Editor
-import WidgetEditor from '@widget-editor/widget-editor';
-import RwAdapter from '@widget-editor/rw-adapter';
-
-// Utils
+// utils
 import DefaultTheme from 'utils/widgets/theme';
 
-// Components
-import Spinner from 'components/ui/Spinner';
+class MyRWWidgetEditTab extends React.Component {
+  constructor(props) {
+    super(props);
 
-class WidgetsEdit extends React.Component {
-  state = {
-    loading: true,
-    widget: null
-  };
+    this.state = {
+      loading: true,
+      widget: null,
+    };
+  }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
     const { id } = this.props;
     fetchWidget(id, { includes: 'metadata' })
       .then((data) => {
         this.setState({
           widget: data,
-          loading: false
+          loading: false,
         });
       })
-      .catch((err) => {
+      .catch(() => {
         toastr.error('Error loading widget');
-        console.error('Error loading widget', err);
       });
   }
 
@@ -53,7 +51,7 @@ class WidgetsEdit extends React.Component {
       ...widget,
       name: widgetData.name,
       description: widgetData.description,
-      widgetConfig: widgetData.widgetConfig
+      widgetConfig: widgetData.widgetConfig,
     };
 
     updateWidget(widgetObj, user.token)
@@ -65,12 +63,12 @@ class WidgetsEdit extends React.Component {
             widget.dataset,
             {
               ...widget.metadata[0],
-              info: { 
+              info: {
                 ...widget.metadata[0].info,
-                caption: widgetData.metadata.caption 
-              }
+                caption: widgetData.metadata.caption,
+              },
             },
-            user.token
+            user.token,
           )
             .then(() => {
               this.setState({ loading: false });
@@ -82,15 +80,16 @@ class WidgetsEdit extends React.Component {
             widget.dataset,
             {
               language: 'en',
-              info: { 
-                caption: widgetData.metadata.caption 
-              }
+              info: {
+                caption: widgetData.metadata.caption,
+              },
             },
-            user.token)
-          .then(() => {
-            this.setState({ loading: false });
-            toastr.success('Success', 'Widget updated successfully!');
-          });
+            user.token,
+          )
+            .then(() => {
+              this.setState({ loading: false });
+              toastr.success('Success', 'Widget updated successfully!');
+            });
         }
       }).catch((err) => {
         this.setState({ loading: false });
@@ -99,40 +98,35 @@ class WidgetsEdit extends React.Component {
   }
 
   render() {
+    const { RWAdapter } = this.props;
     const { loading, widget } = this.state;
+
     return (
       <div className="c-myrw-widgets-edit">
         <Spinner
           className="-light"
           isLoading={loading}
         />
-        {widget &&
-          <div>
-            <WidgetEditor
-              datasetId={widget.dataset}
-              widgetId={widget.id}
-              application="rw"
-              onSave={this.onSaveWidget}
-              theme={DefaultTheme}
-              adapter={RwAdapter}
-            />
-          </div>
-        }
+        {widget && (
+          <WidgetEditor
+            datasetId={widget.dataset}
+            widgetId={widget.id}
+            onSave={this.onSaveWidget}
+            theme={DefaultTheme}
+            adapter={RWAdapter}
+          />
+        )}
       </div>
     );
   }
 }
 
-WidgetsEdit.propTypes = {
+MyRWWidgetEditTab.propTypes = {
   id: PropTypes.string.isRequired,
-  // Store
-  user: PropTypes.object.isRequired,
-  locale: PropTypes.string.isRequired
+  user: PropTypes.shape({
+    token: PropTypes.string.isRequired,
+  }).isRequired,
+  RWAdapter: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = state => ({
-  user: state.user,
-  locale: state.common.locale
-});
-
-export default connect(mapStateToProps, null)(WidgetsEdit);
+export default MyRWWidgetEditTab;

--- a/components/app/myrw/widgets/tabs/edit/index.js
+++ b/components/app/myrw/widgets/tabs/edit/index.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+
+// constants
+import { getRWAdapter } from 'constants/widget-editor';
+
+// component
+import MyRWWidgetEditTab from './component';
+
+export default connect((state) => ({
+  user: state.user,
+  locale: state.common.locale,
+  RWAdapter: getRWAdapter({ locale: state.common.locale }),
+}), null)(MyRWWidgetEditTab);

--- a/components/app/myrw/widgets/tabs/new/component.jsx
+++ b/components/app/myrw/widgets/tabs/new/component.jsx
@@ -2,53 +2,44 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { toastr } from 'react-redux-toastr';
 import { Router } from 'routes';
-
-// Redux
-import { connect } from 'react-redux';
-
-// Services
-import { createWidget, createWidgetMetadata } from 'services/widget';
-import { fetchDatasets } from 'services/dataset';
-
-// Widget Editor
 import WidgetEditor from '@widget-editor/widget-editor';
-import RwAdapter from '@widget-editor/rw-adapter';
 
-// Utils
-import { logEvent } from 'utils/analytics';
-import DefaultTheme from 'utils/widgets/theme';
-
-// Components
+// components
 import Spinner from 'components/ui/Spinner';
 import Field from 'components/form/Field';
 import Select from 'components/form/SelectInput';
 
+// services
+import { createWidget, createWidgetMetadata } from 'services/widget';
+import { fetchDatasets } from 'services/dataset';
+
 // constants
 import { WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES } from 'constants/widget-editor';
 
-class WidgetsNew extends React.Component {
-  static propTypes = {
-    dataset: PropTypes.string,
-    // Store
-    user: PropTypes.object.isRequired
-  };
+// utils
+import { logEvent } from 'utils/analytics';
+import DefaultTheme from 'utils/widgets/theme';
 
-  static defaultProps = { dataset: null };
+class MyRWWidgetNewTab extends React.Component {
+  constructor(props) {
+    super(props);
 
-  state = {
-    loading: false,
-    loadingPublishedDatasets: true,
-    loadingUserDatasets: true,
-    datasets: [],
-    selectedDataset: this.props.dataset
-  };
+    this.state = {
+      loading: false,
+      loadingPublishedDatasets: true,
+      loadingUserDatasets: true,
+      datasets: [],
+      selectedDataset: props.dataset,
+    };
+  }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
     this.loadDatasets();
   }
 
   onSaveWidget = (data) => {
-    const { selectedDataset } = this.state;
+    const { datasets, selectedDataset } = this.state;
     const { user } = this.props;
     // The widget creation endpoint expects the application property to be
     // of array type
@@ -59,10 +50,10 @@ class WidgetsNew extends React.Component {
       widgetConfig: data.widgetConfig,
       published: false,
       application: process.env.APPLICATIONS.split(','),
-      env: process.env.API_ENV
+      env: process.env.API_ENV,
     };
 
-    logEvent('My RW', 'User creates new widget', this.state.datasets.find(d => d.id === this.state.selectedDataset).label);
+    logEvent('My RW', 'User creates new widget', datasets.find((d) => d.id === selectedDataset).label);
 
     this.setState({ loading: true });
 
@@ -75,9 +66,9 @@ class WidgetsNew extends React.Component {
           widgetResult.dataset,
           {
             language: 'en',
-            info: { caption: data.metadata.caption }
+            info: { caption: data.metadata.caption },
           },
-          user.token
+          user.token,
         )
           .then(() => {
             Router.pushRoute('myrw', { tab: 'widgets', subtab: 'my_widgets' });
@@ -89,10 +80,20 @@ class WidgetsNew extends React.Component {
       });
   }
 
+  handleDatasetSelected = (value) => {
+    this.setState({ selectedDataset: value });
+  }
+
   loadDatasets() {
-    fetchDatasets({ published: true, includes: 'metadata', 'page[size]': 999999 }).then((response) => {
-      this.setState({
-        datasets: [...this.state.datasets, ...response.map((dataset) => {
+    const { user } = this.props;
+    fetchDatasets({
+      published: true,
+      includes: 'metadata',
+      sort: 'name',
+      'page[size]': 999999,
+    }).then((response) => {
+      this.setState((prevState) => ({
+        datasets: [...prevState.datasets, ...response.map((dataset) => {
           const metadata = dataset.metadata[0];
           return ({
             id: dataset.id,
@@ -102,17 +103,17 @@ class WidgetsNew extends React.Component {
             label: metadata && metadata.info
               ? metadata.info.name
               : dataset.name,
-            value: dataset.id
+            value: dataset.id,
           });
         })],
-        loadingPublishedDatasets: false
-      });
+        loadingPublishedDatasets: false,
+      }));
     });
 
-    fetchDatasets({ userId: this.props.user.id, includes: 'metadata' })
+    fetchDatasets({ userId: user.id, includes: 'metadata' })
       .then((response) => {
-        this.setState({
-          datasets: [...this.state.datasets, ...response.map((dataset) => {
+        this.setState((prevState) => ({
+          datasets: [...prevState.datasets, ...response.map((dataset) => {
             const metadata = dataset.metadata[0];
             return ({
               id: dataset.id,
@@ -122,16 +123,12 @@ class WidgetsNew extends React.Component {
               label: metadata && metadata.info
                 ? metadata.info.name
                 : dataset.name,
-              value: dataset.id
+              value: dataset.id,
             });
           })],
-          loadingUserDatasets: false
-        });
+          loadingUserDatasets: false,
+        }));
       });
-  }
-
-  handleDatasetSelected = (value) => {
-    this.setState({ selectedDataset: value });
   }
 
   render() {
@@ -140,8 +137,9 @@ class WidgetsNew extends React.Component {
       datasets,
       selectedDataset,
       loadingUserDatasets,
-      loadingPublishedDatasets
+      loadingPublishedDatasets,
     } = this.state;
+    const { RWAdapter } = this.props;
 
     return (
       <div className="c-myrw-widgets-new">
@@ -149,7 +147,7 @@ class WidgetsNew extends React.Component {
           className="-light"
           isLoading={loading || loadingPublishedDatasets || loadingUserDatasets}
         />
-        {datasets &&
+        {datasets && (
           <div className="dataset-selector">
             <Field
               onChange={this.handleDatasetSelected}
@@ -161,34 +159,42 @@ class WidgetsNew extends React.Component {
                 value: selectedDataset,
                 default: selectedDataset,
                 required: true,
-                instanceId: 'selectDataset'
+                instanceId: 'selectDataset',
               }}
             >
               {Select}
             </Field>
           </div>
-        }
-        {selectedDataset &&
-          <div>
-            <WidgetEditor
-              datasetId={selectedDataset}
-              application="rw"
-              onSave={this.onSaveWidget}
-              theme={DefaultTheme}
-              adapter={RwAdapter}
-              authenticated
-              disable={[
-                ...WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES,
-                'advanced-editor',
-              ]}
-            />
-          </div>
-        }
+        )}
+        {selectedDataset && (
+          <WidgetEditor
+            datasetId={selectedDataset}
+            onSave={this.onSaveWidget}
+            theme={DefaultTheme}
+            adapter={RWAdapter}
+            authenticated
+            disable={[
+              ...WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES,
+              'advanced-editor',
+            ]}
+          />
+        )}
       </div>
     );
   }
 }
 
-const mapStateToProps = state => ({ user: state.user });
+MyRWWidgetNewTab.defaultProps = {
+  dataset: null,
+};
 
-export default connect(mapStateToProps, null)(WidgetsNew);
+MyRWWidgetNewTab.propTypes = {
+  dataset: PropTypes.string,
+  user: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    token: PropTypes.string.isRequired,
+  }).isRequired,
+  RWAdapter: PropTypes.func.isRequired,
+};
+
+export default MyRWWidgetNewTab;

--- a/components/app/myrw/widgets/tabs/new/index.js
+++ b/components/app/myrw/widgets/tabs/new/index.js
@@ -4,12 +4,12 @@ import { connect } from 'react-redux';
 import { getRWAdapter } from 'constants/widget-editor';
 
 // component
-import VisualizationComponent from './component';
+import MyRWWidgetNewTab from './component';
 
 export default connect(
   (state) => ({
-    authorization: state.user.token,
+    user: state.user,
     RWAdapter: getRWAdapter({ locale: state.common.locale }),
   }),
   null,
-)(VisualizationComponent);
+)(MyRWWidgetNewTab);

--- a/constants/widget-editor.js
+++ b/constants/widget-editor.js
@@ -1,6 +1,16 @@
+import { AdapterModifier } from '@widget-editor/widget-editor';
+import RWAdapter from '@widget-editor/rw-adapter';
+
 export const WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES = [
   'typography',
   'end-user-filters',
 ];
 
-export default { WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES };
+export const getRWAdapter = (config = {}) => AdapterModifier(RWAdapter, {
+  endpoint: process.env.WRI_API_URL,
+  dataEndpoint: `${process.env.WRI_API_URL}/query`,
+  env: process.env.API_ENV,
+  applications: process.env.APPLICATIONS.split(','),
+  // locale: process.env.locale,
+  ...config,
+});

--- a/layout/explore/explore-detail/explore-detail-visualization/component.jsx
+++ b/layout/explore/explore-detail/explore-detail-visualization/component.jsx
@@ -2,10 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { toastr } from 'react-redux-toastr';
 import { Router } from 'routes';
-
-// Widget Editor
 import WidgetEditor from '@widget-editor/widget-editor';
-import RwAdapter from '@widget-editor/rw-adapter';
 
 // components
 import Modal from 'components/modal/modal-component';
@@ -13,18 +10,23 @@ import LoginModal from 'components/modal/login-modal';
 import Spinner from 'components/ui/Spinner';
 import ErrorBoundary from 'components/ui/error-boundary';
 
-// Utils
-import DefaultTheme from 'utils/widgets/theme';
-import { logEvent } from 'utils/analytics';
-
-// Services
+// services
 import { createWidget, createWidgetMetadata } from 'services/widget';
 
 // constants
 import { WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES } from 'constants/widget-editor';
 
+// utils
+import DefaultTheme from 'utils/widgets/theme';
+import { logEvent } from 'utils/analytics';
+
 function ExploreDetailVisualization(props) {
-  const { widgetId, datasetId, authorization } = props;
+  const {
+    widgetId,
+    datasetId,
+    authorization,
+    RWAdapter,
+  } = props;
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -42,7 +44,7 @@ function ExploreDetailVisualization(props) {
         widgetConfig: widget.widgetConfig,
         published: false,
         application: process.env.APPLICATIONS.split(','),
-        env: process.env.API_ENV
+        env: process.env.API_ENV,
       };
 
       logEvent('Explore (Detail)', 'Save Widget', datasetId);
@@ -58,9 +60,9 @@ function ExploreDetailVisualization(props) {
             newWidgetObject.dataset,
             {
               language: 'en',
-              info: { caption: widget.metadata.caption }
+              info: { caption: widget.metadata.caption },
             },
-            authorization
+            authorization,
           )
             .then(() => {
               Router.pushRoute('myrw', { tab: 'widgets', subtab: 'my_widgets' });
@@ -82,10 +84,9 @@ function ExploreDetailVisualization(props) {
           datasetId={datasetId}
           {...(widgetId && { widgetId })}
           compact
-          application="rw"
           onSave={onSaveWidget}
           theme={DefaultTheme}
-          adapter={RwAdapter}
+          adapter={RWAdapter}
           authenticated
           disable={[
             ...WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES,
@@ -105,15 +106,16 @@ function ExploreDetailVisualization(props) {
   );
 }
 
+ExploreDetailVisualization.defaultProps = {
+  widgetId: null,
+  authorization: null,
+};
+
 ExploreDetailVisualization.propTypes = {
   widgetId: PropTypes.string,
   datasetId: PropTypes.string.isRequired,
-  authorization: PropTypes.string
-};
-
-ExploreDetailVisualization.defaultProps = {
-  widgetId: null,
-  authorization: null
+  authorization: PropTypes.string,
+  RWAdapter: PropTypes.func.isRequired,
 };
 
 export default ExploreDetailVisualization;


### PR DESCRIPTION
## Overview
Modifies RW-adapter's `widget editor` to listen to app env variables and others.

## Testing instructions
Test with the API pointing to staging and production environments. `widget-editor` should point based on the environmental variables.

## Pivotal task
Related to: https://www.pivotaltracker.com/story/show/174996497

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
