### PR TITLE
enforces widgetConfig attribute to be an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.15.14] - TBD
 ### Added
+- extra validation step to ensure `widgetConfig` attribute of widgets is present and valid. [#174911795](https://www.pivotaltracker.com/story/show/174911795)
 
 ### Changed
 - widget-editor: updated RW-adapter to accept app's params (like API url).

--- a/utils/widget.js
+++ b/utils/widget.js
@@ -1,30 +1,38 @@
-export const isMapWidget = (widgetConfig = {}) =>
-  'type' in widgetConfig && widgetConfig.type === 'map';
+export const isMapWidget = (widgetConfig = {}) => 'type' in widgetConfig && widgetConfig.type === 'map';
 
-export const isEmbedWidget = (widgetConfig = {}) =>
-  !!(widgetConfig
-    // Some widgets have not been created with the widget editor
-    // so the paramsConfig attribute doesn't exist
-    && (
-      (
-        widgetConfig.paramsConfig
-        && widgetConfig.paramsConfig.visualizationType === 'embed'
-      )
-      || (
-        // Case of a widget created outside of the widget editor
-        widgetConfig.type
-        && widgetConfig.type === 'embed'
-      )
+// Some widgets have not been created with the widget editor
+// so the paramsConfig attribute doesn't exist
+export const isEmbedWidget = (widgetConfig = {}) => !!(widgetConfig
+  && (
+    (
+      widgetConfig.paramsConfig
+      && widgetConfig.paramsConfig.visualizationType === 'embed'
     )
-  );
+    || (
+      // Case of a widget created outside of the widget editor
+      widgetConfig.type
+      && widgetConfig.type === 'embed'
+    )
+  )
+);
 
-export const isTextualWidget = (widgetConfig = {}) =>
-  // The widgets that are created through the widget editor
-  // don't have any "type" attribute
-  'type' in widgetConfig && widgetConfig.type === 'text';
+// The widgets that are created through the widget editor
+// don't have any "type" attribute
+export const isTextualWidget = (widgetConfig = {}) => 'type' in widgetConfig && widgetConfig.type === 'text';
 
-export default {
-  isMapWidget,
-  isEmbedWidget,
-  isTextualWidget
+export const hasValidConfiguration = (widget = {}) => {
+  // checks widgetConfig attribute is present
+  if (!Object.prototype.hasOwnProperty.call(widget, 'widgetConfig')) return false;
+
+  // checks widgetConfig is undefined or null
+  if (!widget.widgetConfig || widget.widgetConfig === null) return false;
+
+  // checks widgetConfig attribute is not an object (discards Number, String, etc...)
+  if (!(widget.widgetConfig instanceof Object)) return false;
+
+  // checks widgetConfig attribute is an array
+  // (Array type is still an Object so we need to double-check)
+  if (widget.widgetConfig instanceof Array) return false;
+
+  return true;
 };


### PR DESCRIPTION
## Overview
Enforces `widgetConfig` attribute to be an object. This way widgets who don't fulfil the validations won't be displayed in the application. This validation has to be applied eventually across the app.

## Testing instructions
_Users are experiencing a soft 404 from the dashboard editing interface. When attempting to add a visualization (chart/widget): Within the "select visualization" menu, "My visualizations" and "My favorites" tabs display widgets as expected, but selecting the "all visualizations" tab triggers the soft 404._

## Pivotal task
https://www.pivotaltracker.com/story/show/174911795

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
