### PR TITLE
fixes WE crash with map widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - maintenance: updated `eslint` and its plugins. [#174977793](https://www.pivotaltracker.com/story/show/174977793)
 
 ### Fixed
+- widget-editor: fixed a WE crash when the user changes the visualization type in a map-only widget. [#175165737](https://www.pivotaltracker.com/story/show/175165737)
 - admin: in layer edition, the interactivity wasn't being applied on first load until the user modifies it for first time. Now it does.
 - widget-editor: fixed error updating fields. [#174996497](https://www.pivotaltracker.com/story/show/174996497)
 - widget-editor: override of default disabled features. [#174930015](https://www.pivotaltracker.com/story/show/174930015)

--- a/layout/explore/explore-detail/explore-detail-visualization/component.jsx
+++ b/layout/explore/explore-detail/explore-detail-visualization/component.jsx
@@ -92,7 +92,6 @@ function ExploreDetailVisualization(props) {
             ...WIDGET_EDITOR_DEFAULT_DISABLED_FEATURES,
             'theme-selection',
             'advanced-editor',
-            'map',
           ]}
         />
       </ErrorBoundary>


### PR DESCRIPTION
## Overview
Fixes a widget-editor crash with map widgets. The `map` option in the visualization type selector wasn't there because we disabled the `map` feature preventing the WE to select the current or new types and crashing.

## Testing instructions
In data explore, click on a map widget and try to change the type. The widget-editor shouldn't crash anymore.

## Pivotal task
https://www.pivotaltracker.com/story/show/175165737

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
