### PR TITLE
adds call action in areas of interest to go to all-data section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.16.7] - TBD
 ### Added
+- call action in areas of interest to go to all-data section.
 - Explore: added active state for prominent buttons in new area form.
 - Embed maps: display user areas. [#175394222](https://www.pivotaltracker.com/story/show/175394222)
 - widget-editor: WRI's colour scheme.

--- a/layout/explore/explore-areas-of-interest/component.jsx
+++ b/layout/explore/explore-areas-of-interest/component.jsx
@@ -11,6 +11,7 @@ import AreaCardList from 'components/areas/card-list';
 import Spinner from 'components/ui/Spinner';
 import Icon from 'components/ui/icon';
 import Paginator from 'components/ui/Paginator';
+import ExploreAreasOfInterestIntro from 'layout/explore/explore-areas-of-interest/intro';
 
 // constants
 import { EXPLORE_SUBSECTIONS } from 'layout/explore/constants';
@@ -96,8 +97,9 @@ const ExploreAreasOfInterest = ({
           <Icon name="icon-plus" />
           New Area
         </button>
-
       </div>
+
+      <ExploreAreasOfInterestIntro />
 
       <div className="user-areas-header">
         <h4>Your saved areas</h4>

--- a/layout/explore/explore-areas-of-interest/intro/component.jsx
+++ b/layout/explore/explore-areas-of-interest/intro/component.jsx
@@ -1,0 +1,40 @@
+import React, {
+  useCallback,
+} from 'react';
+import PropTypes from 'prop-types';
+
+// constants
+import { EXPLORE_SECTIONS } from 'layout/explore/constants';
+
+// styles
+import './styles.scss';
+
+const ExploreAreasOfInterestIntro = ({
+  setSidebarSection,
+}) => {
+  const handleClick = useCallback(() => {
+    setSidebarSection(EXPLORE_SECTIONS.ALL_DATA);
+  }, [setSidebarSection]);
+
+  return (
+    <div className="c-explore-areas-of-interest-intro">
+      <h4>Analyse local data</h4>
+      <p className="-text-center">
+        Use your areas of interest as a filter in the widget editor in any dataset
+      </p>
+      <button
+        type="button"
+        className="c-btn -primary"
+        onClick={handleClick}
+      >
+        See all datasets
+      </button>
+    </div>
+  );
+};
+
+ExploreAreasOfInterestIntro.propTypes = {
+  setSidebarSection: PropTypes.func.isRequired,
+};
+
+export default ExploreAreasOfInterestIntro;

--- a/layout/explore/explore-areas-of-interest/intro/index.js
+++ b/layout/explore/explore-areas-of-interest/intro/index.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+
+// actions
+import { setSidebarSection } from 'layout/explore/actions';
+
+// component
+import ExploreAreasOfInterestIntro from './component';
+
+export default connect(
+  null,
+  {
+    setSidebarSection,
+  },
+)(ExploreAreasOfInterestIntro);

--- a/layout/explore/explore-areas-of-interest/intro/styles.scss
+++ b/layout/explore/explore-areas-of-interest/intro/styles.scss
@@ -1,0 +1,9 @@
+@import 'css/settings';
+
+.c-explore-areas-of-interest-intro {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: ($space * 8) 0;
+}


### PR DESCRIPTION
## Overview
Adds call action in areas of interest to go to all-data section.
![image](https://user-images.githubusercontent.com/999124/98389697-b327be00-2054-11eb-9221-b85d95a7923e.png)


## Testing instructions
Go to "Areas of Interest" in Explore.

## Pivotal task
–

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
