### PR TITLE
Replace missing widget

### DIFF
--- a/public/static/data/CountryEnergyExplorer.json
+++ b/public/static/data/CountryEnergyExplorer.json
@@ -136,7 +136,7 @@
             ],
             "widgetsWorld": [
               {
-                "id": "dcb73b1b-f744-4db3-ae44-c4552b04e457",
+                "id": "64d7466b-4d33-44a4-9ecc-c437905137e5",
                 "widgetsPerRow": 2
               },
               {


### PR DESCRIPTION
Replace widget that had been deleted (API ID dcb73b1b-f744-4db3-ae44-c4552b04e457) with a new one entitled "Countries with the highest electricity consumption in 2017". This is a "world" widget in the "Power Generation and Consumption" section.

## Overview
Replace broken widget with new one.

## Testing instructions
Ensure the new widget (API ID 64d7466b-4d33-44a4-9ecc-c437905137e5) entitled "Countries with the highest electricity consumption in 2017" shows up on the page. 

## Pivotal task
Provide the link to the task(s), if any.

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
