### PR TITLE
dashboards: render while scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.19.2] - TBD
 ### Added
+- Dashboards: added better error handling for maps instead of crashing. [#175408544](https://www.pivotaltracker.com/story/show/175408544)
 - Explore detail: added `spatial_-_resolution` metadata field. [#175672826](https://www.pivotaltracker.com/story/show/175672826)
 - In area cards, now it's possible to rename the area there without navigating somewhere.
 - Explore: area of interest bounds.
@@ -18,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - widget-editor: WRI's colour scheme.
 
 ### Changed
+- Dashboards: now the blocks renders with the scroll user instead of loading everything at once.
+This should reduce the page workload and impact. [#175408544](https://www.pivotaltracker.com/story/show/175408544)
 - `widget-editor@2.5.0`
 - Enabled subscriptions for area cards regardless where the cards are displayed.
 - Unified way of working with areas of interest in map explore in energy dashboard.

--- a/components/dashboards/detail/component.js
+++ b/components/dashboards/detail/component.js
@@ -3,8 +3,30 @@ import PropTypes from 'prop-types';
 
 // components
 import Wysiwyg from 'vizz-wysiwyg';
+import InView from 'components/in-view';
 import WidgetBlock from 'components/wysiwyg/widget-block';
 import WidgetBlockEdition from 'components/wysiwyg/widget-block-edition';
+
+const WidgetBlockInView = (props) => (
+  <InView
+    triggerOnce
+    threshold={0.25}
+  >
+    {({ ref, inView }) => (
+      <div
+        ref={ref}
+        style={{
+          display: 'flex',
+          width: '100%',
+        }}
+      >
+        {inView && (
+          <WidgetBlock {...props} />
+        )}
+      </div>
+    )}
+  </InView>
+);
 
 class DashboardDetail extends PureComponent {
   static propTypes = { dashboard: PropTypes.object.isRequired }
@@ -36,24 +58,22 @@ class DashboardDetail extends PureComponent {
       items = JSON.parse(content);
     } catch (e) { console.error(e); }
 
+    if (typeof window === 'undefined' || isUpdate) return null;
+
     return (
-      <Fragment>
-        {!isUpdate && (
-          <Wysiwyg
-            readOnly
-            items={items}
-            blocks={{
-              widget: {
-                Component: WidgetBlock,
-                EditionComponent: WidgetBlockEdition,
-                icon: 'icon-widget',
-                label: 'Visualization',
-                renderer: 'modal'
-              }
-            }}
-          />
-        )}
-      </Fragment>
+      <Wysiwyg
+        readOnly
+        items={items}
+        blocks={{
+          widget: {
+            Component: WidgetBlockInView,
+            EditionComponent: WidgetBlockEdition,
+            icon: 'icon-widget',
+            label: 'Visualization',
+            renderer: 'modal',
+          },
+        }}
+      />
     );
   }
 }

--- a/components/wysiwyg/widget-block/component.js
+++ b/components/wysiwyg/widget-block/component.js
@@ -10,6 +10,7 @@ import {
   LegendListItem,
   LegendItemTypes
 } from 'vizzuality-components';
+import { toastr } from 'react-redux-toastr';
 
 // components
 import Map from 'components/map';
@@ -138,6 +139,11 @@ class WidgetBlock extends PureComponent {
         transitionDuration: 250
       }
     });
+  }
+
+  handleMapErrors = (error) => {
+    const { item: { id } } = this.props;
+    toastr.error(`There was an error loading item ${id}`, error);
   }
 
   render() {
@@ -303,6 +309,7 @@ class WidgetBlock extends PureComponent {
                     labels={this.getMapLabel(widget)}
                     scrollZoom={false}
                     bounds={this.getMapBounds(widget)}
+                    onError={this.handleMapErrors}
                   >
                     {_map => (
                       <Fragment>


### PR DESCRIPTION
## Overview
- Reduces workload and impact of the page rendering elements when they are visible.
- Improves error handling when the bbox is wrong.

## Testing instructions
Check on `/dashboards/cities` or any other dashboard in prod API.

## Pivotal task
https://www.pivotaltracker.com/story/show/175408544

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
