### PR TITLE
adds widget links to map-type widget embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.19.3] - TBD
 ### Added
+- map-type widget embed: widget links. [#175408294](https://www.pivotaltracker.com/story/show/175408294)
 - Dashboards: added better error handling for maps instead of crashing. [#175408544](https://www.pivotaltracker.com/story/show/175408544)
 - Explore detail: added `spatial_-_resolution` metadata field. [#175672826](https://www.pivotaltracker.com/story/show/175672826)
 - In area cards, now it's possible to rename the area there without navigating somewhere.

--- a/components/wysiwyg/widget-block/styles.scss
+++ b/components/wysiwyg/widget-block/styles.scss
@@ -129,9 +129,9 @@
   }
 
   .caption-container {
-    font-style: italic;
-    padding: 8px 15px;
+    padding: ($space * 1) ($space * 3);
     font-size: $font-size-small;
+    font-style: italic;
   }
 
   &.-embed {

--- a/css/components/app/pages/embed/embed_widget.scss
+++ b/css/components/app/pages/embed/embed_widget.scss
@@ -99,23 +99,6 @@
       }
     }
 
-    // .c-map {
-    //   // Do not change the positionning of this
-    //   // element without testing it on Chrome and Firefox
-    //   // in the dashboards AND as a standalone widget
-    //   position: absolute;
-    //   top: 0;
-    //   left: 0;
-    //   height: 100%;
-    //   width: 100%;
-
-    //   // Without this property, the legend is hidden behind
-    //   // the map
-    //   .leaflet-pane {
-    //     z-index: 1;
-    //   }
-    // }
-
     .widget-modal {
       position: absolute;
       top: 0;
@@ -141,10 +124,10 @@
         ul {
           list-style-type: circle;
 
-          li {
-            margin-left: 35px;
+          > li {
+            margin-left: ($space * 7);
 
-            a {
+            > a {
               color: $link-font-color;
             }
           }
@@ -156,6 +139,12 @@
   .widget-content-row {
     display: flex;
     justify-content: space-between;
+  }
+
+  .caption-container {
+    padding: ($space * 1) ($space * 3);
+    font-size: $font-size-small;
+    font-style: italic;
   }
 
   .widget-footer {

--- a/layout/embed/map/component.jsx
+++ b/layout/embed/map/component.jsx
@@ -410,30 +410,30 @@ const LayoutEmbedMap = (props) => {
                     {!isEmpty(interaction.point)
                       && activeLayers.length
                       && !isEmpty(interaction.data) && (
-                        <Popup
-                          {...interaction.point}
-                          closeButton
-                          closeOnClick={false}
-                          onClose={handleClosePopup}
-                          className="rw-popup-layer"
-                          maxWidth="250px"
-                        >
-                          <LayerPopup
-                            data={{
-                              // data available in certain point
-                              layersInteraction: interaction.data,
-                              // ID of the layer will display data (defaults into the first layer)
-                              layersInteractionSelected: interaction.selected,
-                              // current active layers to get their layerConfig attributes
-                              layers: activeLayers,
-                            }}
-                            latlng={{
-                              lat: interaction.point.latitude,
-                              lng: interaction.point.longitude,
-                            }}
-                            onChangeInteractiveLayer={onChangeInteractiveLayer}
-                          />
-                        </Popup>
+                      <Popup
+                        {...interaction.point}
+                        closeButton
+                        closeOnClick={false}
+                        onClose={handleClosePopup}
+                        className="rw-popup-layer"
+                        maxWidth="250px"
+                      >
+                        <LayerPopup
+                          data={{
+                            // data available in certain point
+                            layersInteraction: interaction.data,
+                            // ID of the layer will display data (defaults into the first layer)
+                            layersInteractionSelected: interaction.selected,
+                            // current active layers to get their layerConfig attributes
+                            layers: activeLayers,
+                          }}
+                          latlng={{
+                            lat: interaction.point.latitude,
+                            lng: interaction.point.longitude,
+                          }}
+                          onChangeInteractiveLayer={onChangeInteractiveLayer}
+                        />
+                      </Popup>
                     )}
                   </>
                 )}
@@ -473,7 +473,7 @@ const LayoutEmbedMap = (props) => {
               </div>
               {modalVisibility && (
                 <div className="widget-modal">
-                  {!description && (
+                  {(!description && !widget?.metadata[0]) && (
                     <p>No additional information is available</p>
                   )}
                   {description && (
@@ -482,9 +482,32 @@ const LayoutEmbedMap = (props) => {
                       <p>{description}</p>
                     </>
                   )}
+                  {widget?.metadata && widget?.metadata[0]?.info?.widgetLinks && (
+                    <div className="widget-links-container">
+                      <h4>Links</h4>
+                      <ul>
+                        {widget.metadata[0].info.widgetLinks.map(({ name: linkName, link }) => (
+                          <li key={link}>
+                            <a
+                              href={link}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {linkName}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
                 </div>
               )}
             </div>
+            {(widget?.metadata && widget?.metadata[0]?.info?.caption && !modalVisibility) && (
+              <div className="caption-container">
+                {widget.metadata[0].info.caption}
+              </div>
+            )}
             {(isExternal && !webshot) && (
               <div className="widget-footer -map">
                 Powered by
@@ -519,6 +542,19 @@ LayoutEmbedMap.propTypes = {
     description: PropTypes.string,
     dataset: PropTypes.string,
     thumbnailUrl: PropTypes.string,
+    metadata: PropTypes.arrayOf(
+      PropTypes.shape({
+        info: PropTypes.shape({
+          caption: PropTypes.string,
+          widgetLinks: PropTypes.arrayOf(
+            PropTypes.shape({
+              name: PropTypes.string,
+              link: PropTypes.string,
+            }),
+          ),
+        }),
+      }),
+    ).isRequired,
   }).isRequired,
   isLoading: PropTypes.bool.isRequired,
   isError: PropTypes.bool.isRequired,


### PR DESCRIPTION
## Overview
Adds widget links to map-type widget embed.
![image](https://user-images.githubusercontent.com/999124/99513173-a0818300-298a-11eb-9327-4cf46953bc35.png)


## Testing instructions
Go to `http://localhost:9000/embed/map/f14e47f1-fefb-412a-aa40-05a566a13667` (production API) and click on (i) button to display the modal info.

## Pivotal task
https://www.pivotaltracker.com/story/show/175408294

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
