### PR TITLE
fixes app crash when data in map tooltip is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.19.7] - TBD
+## [2.19.8] - TBD
 ### Added
 - map-type widget embed: widget links. [#175408294](https://www.pivotaltracker.com/story/show/175408294)
 - Dashboards: added better error handling for maps instead of crashing. [#175408544](https://www.pivotaltracker.com/story/show/175408544)
@@ -50,6 +50,7 @@ This should reduce the page workload and impact. [#175408544](https://www.pivota
 - widget-editor: better separation of utils and constants.
 
 ### Fixed
+- tooltip crashing when data is undefined. [#175888099](https://www.pivotaltracker.com/story/show/175888099)
 - query not fetching country list in Energy dashboard. [#175594527](https://www.pivotaltracker.com/story/show/175594527)
 - visual glitch with top bar in explore detail.
 - collections more consistent across the app. [#175272462](https://www.pivotaltracker.com/story/show/175272462)

--- a/components/map/popup/component.js
+++ b/components/map/popup/component.js
@@ -161,12 +161,13 @@ class LayerPopup extends PureComponent {
         </header>
 
         <div className="popup-content">
-          {(interaction.data || interactionState.data) &&
+          {!isEmpty(interaction.data || interactionState.data) &&
             output.map((outputItem) => {
               const { column } = outputItem;
               const columnArray = column.split('.');
               const value = columnArray.reduce((acc, c) => acc[c],
                 interaction.data || interactionState.data);
+
                 return (
                   <div
                     className="popup-field"
@@ -199,7 +200,7 @@ class LayerPopup extends PureComponent {
               <Spinner isLoading className="-tiny -inline -pink-color" />
             </div>}
 
-          {!this.state.loading && (!interaction.data && !interactionState.data) &&
+          {!this.state.loading && (!interaction.data && !interactionState.data || isEmpty(interaction.data || interactionState.data)) &&
             interactionConfig.config && interactionConfig.config.url &&
             'No data available'}
 


### PR DESCRIPTION
## Overview
Fixes app crash when data in map tooltip is undefined.

![image](https://user-images.githubusercontent.com/999124/100229112-012d3480-2f24-11eb-93ed-e291b6c15723.png)


## Testing instructions
Go to `http://localhost:9000/data/explore/foo055b-Gridded-Livestock-Version-3?section=All%20data&zoom=3&lat=0&lng=0&pitch=0&bearing=0&basemap=dark&labels=light&layers=%255B%257B%2522dataset%2522%253A%25226b523d76-ca2d-4059-b0a6-d90a6b8ba5a6%2522%252C%2522opacity%2522%253A1%252C%2522layer%2522%253A%252210587041-b4c5-493d-ac9e-cf75bc2d58b7%2522%257D%255D&page=1&sort=most-viewed&sortDirection=-1&topics=%255B%2522livestock%2522%255D` and click on any point of the layer. Previosuly, the app would crash.

## Pivotal task
https://www.pivotaltracker.com/story/show/175888099

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
