### PR TITLE
fixes widget metadata override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.20.3] - TBD
+## [2.20.4] - TBD
 ### Added
 - Explore: added spinner to area creation as it takes several seconds to finish.
 
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `widget-editor@2.5.5`
 
 ### Fixed
-- restored URL params (zoom, latitude, longitude) for map-swipe [#176121901](https://www.pivotaltracker.com/story/show/176121901)
+- admin: fixed widget metadata override when the user saved the widget via `widget-editor`. [#175408294](https://www.pivotaltracker.com/story/show/175408294/comments/220475227)
+- restored URL params (zoom, latitude, longitude) for map-swipe. [#176121901](https://www.pivotaltracker.com/story/show/176121901)
 
 ### Removed
 

--- a/components/admin/data/widgets/form/component.js
+++ b/components/admin/data/widgets/form/component.js
@@ -61,7 +61,7 @@ class WidgetForm extends PureComponent {
       })
     ];
 
-    // fetchs the widget if exists
+    // fetches the widget if exists
     if (id) promises.push(fetchWidget(id, { includes: 'metadata' }));
 
     Promise.all(promises)
@@ -178,10 +178,14 @@ class WidgetForm extends PureComponent {
       })
       .catch((error) => {
         this.setState({ loading: false });
-        toastr.error('Tnere was an error', error);
+        toastr.error('There was an error', error);
       });
   }
-
+  /**
+   *
+   * @param {Object} widget - widget object with possible changes (metadata changes not included)
+   * @param {Object} updatedMetadata - widget metadata updated by widget-editor
+   */
   updateWidget(widget, updatedMetadata) {
     const { onSubmit, authorization } = this.props;
     const { metadata } = widget;
@@ -189,15 +193,17 @@ class WidgetForm extends PureComponent {
     updateWidgetService(widget, authorization)
       .then((response) => {
         const { id, name, dataset } = response;
+        // A metadata object already exists for this widget so we have to update it
         if (metadata && metadata.length) {
-          // A metadata object already exists for this widget so we have to update it
           updateWidgetMetadata(
             id,
             dataset,
             {
-              language: 'en',
-              info: { caption: updatedMetadata.caption },
-              application: process.env.APPLICATIONS,
+              ...metadata[0] || {},
+              info: {
+                ...metadata[0]?.info || {},
+                caption: updatedMetadata.caption
+              },
             },
             authorization
           )
@@ -227,7 +233,7 @@ class WidgetForm extends PureComponent {
       })
       .catch((error) => {
         this.setState({ loading: false });
-        toastr.error('Tnere was an error', error);
+        toastr.error('There was an error', error);
       });
   }
 


### PR DESCRIPTION
## Overview
Fixes an error where the metadata of the widget was being overridden by the `widget-editor` output, as we didn't pass the whole metadata object.

## Testing instructions
Go to the admin zone and modify a `widgetLink` (in metadata tab), then save from widget-editor. The widget must contain the widgetLinks.

## Pivotal task
https://www.pivotaltracker.com/story/show/175408294

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
