### PR TITLE
fixes explore search not working first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.20.4] - TBD
+## [2.20.5] - TBD
+### Added
+
+### Changed
+
+### Fixed
+- Explore: search not working first time. [#176263572](https://www.pivotaltracker.com/story/show/176263572)
+
+### Removed
+
+## [2.20.4] - 2012-12-17
 ### Added
 - Explore: added spinner to area creation as it takes several seconds to finish.
 

--- a/layout/explore/explore-menu/component.jsx
+++ b/layout/explore/explore-menu/component.jsx
@@ -67,17 +67,18 @@ const ExploreMenu = ({
   }, [setDatasetsPage, fetchDatasets]);
 
   const onChangeTextSearch = useCallback((_search) => {
-    if (!search && sortSelected === 'relevance') {
+    if (!_search && sortSelected === 'relevance') {
       resetFiltersSort();
     }
     setFiltersSearch(_search);
-    if (search && shouldAutoUpdateSortDirection) {
+    if (_search && shouldAutoUpdateSortDirection) {
       setSortSelected('relevance');
       setSortDirection(-1);
-      setSidebarSection(EXPLORE_SECTIONS.ALL_DATA);
     }
+
+    setSidebarSection(EXPLORE_SECTIONS.ALL_DATA);
     loadDatasets();
-    logEvent('Explore Menu', 'search', search);
+    logEvent('Explore Menu', 'search', _search);
   }, [
     resetFiltersSort,
     setFiltersSearch,
@@ -85,7 +86,6 @@ const ExploreMenu = ({
     setSortDirection,
     setSidebarSection,
     loadDatasets,
-    search,
     shouldAutoUpdateSortDirection,
     sortSelected,
   ]);


### PR DESCRIPTION
## Overview
Fixed an issue with the explore search when the user wasn't able to get results the first time it entered a search term.

## Testing instructions
Go to `/data/explore` and try to search for a term. The expected result is seeing the results (if any) displayed.

## Pivotal task
https://www.pivotaltracker.com/story/show/176263572

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
