### PR TITLE
removes RW_FEATURE_FLAG_AREAS_V2 feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Explore: search not working first time. [#176263572](https://www.pivotaltracker.com/story/show/176263572)
 
 ### Removed
+- RW_FEATURE_FLAG_AREAS_V2 feature flag.
 
 ## [2.20.4] - 2012-12-17
 ### Added

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,13 +20,13 @@ node {
     stage ('Build docker') {
       switch ("${env.BRANCH_NAME}") {
         case "develop":
-          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg apiUrl=https://staging.resourcewatch.org/api --build-arg wriApiUrl=https://staging-api.globalforestwatch.org/v1 --build-arg WRI_API_URL_V2=https://staging-api.globalforestwatch.org/v2 --build-arg callbackUrl=https://staging.resourcewatch.org/auth --build-arg controlTowerUrl=https://staging-api.globalforestwatch.org --build-arg RW_FEATURE_FLAG_AREAS_V2=true -t ${imageTag} .")
+          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg apiUrl=https://staging.resourcewatch.org/api --build-arg wriApiUrl=https://staging-api.globalforestwatch.org/v1 --build-arg WRI_API_URL_V2=https://staging-api.globalforestwatch.org/v2 --build-arg callbackUrl=https://staging.resourcewatch.org/auth --build-arg controlTowerUrl=https://staging-api.globalforestwatch.org -t ${imageTag} .")
           break
         case "preproduction":
-          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg callbackUrl=https://preproduction.resourcewatch.org/auth --build-arg RW_FEATURE_FLAG_AREAS_V2=true -t ${imageTag} .")
+          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg callbackUrl=https://preproduction.resourcewatch.org/auth -t ${imageTag} .")
           break
         case "master":
-          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg RW_FEATURE_FLAG_AREAS_V2=true -t ${imageTag} .")
+          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} -t ${imageTag} .")
         default:
           sh("echo NOT DEPLOYED")
           currentBuild.result = 'SUCCESS'

--- a/components/areas/card/tooltip/component.jsx
+++ b/components/areas/card/tooltip/component.jsx
@@ -68,17 +68,15 @@ const AreaActionsTooltip = (props) => {
             Rename
           </button>
         </li>
-        {process.env.RW_FEATURE_FLAG_AREAS_V2 && (
-          <li>
-            <button
-              type="button"
-              className="c-button"
-              onClick={() => handleClick('change-visibility')}
-            >
-              {`Make ${area.public ? 'Private' : 'Public'}`}
-            </button>
-          </li>
-        )}
+        <li>
+          <button
+            type="button"
+            className="c-button"
+            onClick={() => handleClick('change-visibility')}
+          >
+            {`Make ${area.public ? 'Private' : 'Public'}`}
+          </button>
+        </li>
         {
         /**
         * * Enable subscriptions unconditionally when they work properly.

--- a/layout/embed/map/component.jsx
+++ b/layout/embed/map/component.jsx
@@ -246,8 +246,7 @@ const LayoutEmbedMap = (props) => {
           cancelToken: cancelToken.token,
         });
 
-        if (process.env.RW_FEATURE_FLAG_AREAS_V2
-          && !isPublicArea
+        if (!isPublicArea
           && (areaUserId !== user.id)
         ) throw new Error('Error loading area: this area is private.');
 
@@ -285,10 +284,7 @@ const LayoutEmbedMap = (props) => {
     };
 
     if (aoi) {
-      // in 'v1/areas' areas are private.
-      if (!process.env.RW_FEATURE_FLAG_AREAS_V2 && user.token) fetchAreaOfInterest();
-      // in 'v2/areas' areas can be private or public
-      if (process.env.RW_FEATURE_FLAG_AREAS_V2) fetchAreaOfInterest();
+      fetchAreaOfInterest();
     }
 
     return () => { cancelToken.cancel('Fetching geostore: operation canceled by the user.'); };

--- a/layout/explore/explore-map/component.jsx
+++ b/layout/explore/explore-map/component.jsx
@@ -305,8 +305,7 @@ const ExploreMap = (props) => {
           cancelToken: cancelToken.token,
         });
 
-        if (process.env.RW_FEATURE_FLAG_AREAS_V2
-          && !isPublicArea
+        if (!isPublicArea
           && (areaUserId !== userId)
         ) throw new Error('This area is private.');
 
@@ -341,10 +340,7 @@ const ExploreMap = (props) => {
     };
 
     if (aoi) {
-      // in 'v1/areas' areas are private.
-      if (!process.env.RW_FEATURE_FLAG_AREAS_V2 && token) fetchAreaOfInterest();
-      // in 'v2/areas' areas can be private or public
-      if (process.env.RW_FEATURE_FLAG_AREAS_V2) fetchAreaOfInterest();
+      fetchAreaOfInterest();
     } else {
       // if the user removes the AoI, filter it to avoid display it in the map
       setDisplayedLayers((prevLayers) => [

--- a/next.config.js
+++ b/next.config.js
@@ -43,8 +43,6 @@ module.exports = withCSS(withSass({
     BITLY_TOKEN: process.env.BITLY_TOKEN,
     PARDOT_NEWSLETTER_URL: process.env.PARDOT_NEWSLETTER_URL,
     RW_MAPBOX_API_TOKEN: process.env.RW_MAPBOX_API_TOKEN,
-    // feature flags
-    RW_FEATURE_FLAG_AREAS_V2: process.env.RW_FEATURE_FLAG_AREAS_V2,
   },
 
   webpack: (config) => {

--- a/services/areas.js
+++ b/services/areas.js
@@ -2,7 +2,6 @@ import WRISerializer from 'wri-json-api-serializer';
 
 // utils
 import {
-  WRIAPI,
   WRIAPI_V2,
 } from 'utils/axios';
 import { logger } from 'utils/logs';
@@ -18,9 +17,7 @@ import { logger } from 'utils/logs';
 export const fetchArea = (id, params = {}, headers = {}) => {
   logger.info(`Fetch area ${id}`);
 
-  const API = process.env.RW_FEATURE_FLAG_AREAS_V2 ? WRIAPI_V2 : WRIAPI;
-
-  return API.get(
+  return WRIAPI_V2.get(
     `area/${id}`,
     {
       headers: {
@@ -46,9 +43,8 @@ export const fetchArea = (id, params = {}, headers = {}) => {
  */
 export const fetchUserAreas = (token, params = {}, _meta = false) => {
   logger.info('Fetch user areas');
-  const API = process.env.RW_FEATURE_FLAG_AREAS_V2 ? WRIAPI_V2 : WRIAPI;
 
-  return API.get('area', {
+  return WRIAPI_V2.get('area', {
     headers: {
       Authorization: token,
       'Upgrade-Insecure-Requests': 1,
@@ -59,7 +55,7 @@ export const fetchUserAreas = (token, params = {}, _meta = false) => {
       ...params,
     },
     transformResponse: [].concat(
-      API.defaults.transformResponse,
+      WRIAPI_V2.defaults.transformResponse,
       (({ data, meta }) => ({ areas: data, meta })),
     ),
   })
@@ -97,9 +93,8 @@ export const fetchUserAreas = (token, params = {}, _meta = false) => {
  */
 export const deleteArea = (areaId, token) => {
   logger.info(`Delete area ${areaId}`);
-  const API = process.env.RW_FEATURE_FLAG_AREAS_V2 ? WRIAPI_V2 : WRIAPI;
 
-  return API.delete(`area/${areaId}`, { headers: { Authorization: token } })
+  return WRIAPI_V2.delete(`area/${areaId}`, { headers: { Authorization: token } })
     .catch(({ response }) => {
       const { status, statusText } = response;
       logger.error(`Error deleting area ${areaId}: ${status}: ${statusText}`);
@@ -117,7 +112,6 @@ export const deleteArea = (areaId, token) => {
  */
 export const createArea = (name, geostore, token) => {
   logger.info('Create area');
-  const API = process.env.RW_FEATURE_FLAG_AREAS_V2 ? WRIAPI_V2 : WRIAPI;
 
   const bodyObj = {
     name,
@@ -126,7 +120,7 @@ export const createArea = (name, geostore, token) => {
     geostore,
   };
 
-  return API.post('area', bodyObj, { headers: { Authorization: token } })
+  return WRIAPI_V2.post('area', bodyObj, { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
     .catch(({ response }) => {
       const { status, statusText } = response;
@@ -146,9 +140,7 @@ export const createArea = (name, geostore, token) => {
 export const updateArea = (id, params, token) => {
   logger.info(`Update area ${id}`);
 
-  const API = process.env.RW_FEATURE_FLAG_AREAS_V2 ? WRIAPI_V2 : WRIAPI;
-
-  return API.patch(`area/${id}`, {
+  return WRIAPI_V2.patch(`area/${id}`, {
     application: process.env.APPLICATIONS,
     env: process.env.API_ENV,
     ...params,


### PR DESCRIPTION
## Overview
Removes `RW_FEATURE_FLAG_AREAS_V2` feature flag.

## Testing instructions
Remove `RW_FEATURE_FLAG_AREAS_V2` from `.env`. The application should work as if the env var were there.

## Pivotal task
–

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
