### PR TITLE
patch map embed title href

### DIFF
--- a/layout/embed/map/component.jsx
+++ b/layout/embed/map/component.jsx
@@ -365,10 +365,10 @@ const LayoutEmbedMap = (props) => {
             {!webshot && (
               <div className="widget-title">
                 <Link
-                  href={`/explore/${dataset}`}
+                  href={`/data/explore/${dataset}`}
                 >
                   <a
-                    href={`/explore/${dataset}`}
+                    href={`/data/explore/${dataset}`}
                     target="_blank"
                     rel="noopener noreferrer"
                   >


### PR DESCRIPTION
fixes the url path constructed for the href element of embed widget titles in map-type widgets

## Overview
Please write a description. If the PR is hard to understand, provide a quick explanation of the code.

## Testing instructions
Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc.

## Pivotal task
Provide the link to the task(s), if any.

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
