### PR TITLE
replaces better-npm-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - X
+## [3.0.1] - X
 ### Added
 - added new service and entrypoint to launch Docker.
 
 ### Changed
+- replaced `better-npm-run` with `cross-env`.
 - moved `@babel/core` to devDependencies.
 - updates `Node` version from `v8` to current `LTS` (`v14`).
 - `@vizzuality/wysiwyg` (former `vizz-wysiwyg`) has been updated removing a lot of unused/deprecated dependencies that were blocking the application to upgrade the Node version.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "autoprefixer": "^9.4.2",
     "axios": "^0.18.0",
     "basic-auth": "1.1.0",
-    "better-npm-run": "^0.1.1",
     "bitly": "^6.0.8",
     "body-parser": "1.16.0",
     "bourbon": "4.3.4",
@@ -125,6 +124,7 @@
     "@cypress/code-coverage": "^3.9.2",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-module-resolver": "^4.1.0",
+    "cross-env": "^7.0.3",
     "cssnano": "^4.1.10",
     "cypress": "^6.4.0",
     "eslint": "^7.19.0",
@@ -141,14 +141,14 @@
     "webpack-bundle-analyzer": "^3.3.2"
   },
   "scripts": {
-    "lint": "eslint . --ext .js,.jsx",
-    "dev": "node $NODE_DEBUG_OPTION index.js",
-    "build": "better-npm-run build",
-    "start": "better-npm-run start",
-    "bundle-analyzer": "better-npm-run bundle-analyzer",
-    "sitemap": "better-npm-run sitemap",
-    "test": "cypress run",
-    "cy:open": "cypress open"
+    "lint": "cross-env eslint . --ext .js,.jsx",
+    "dev": "cross-env node index.js",
+    "build": "cross-env NODE_OPTIONS=--max_old_space_size=4096 RW_NODE_ENV=production next build ",
+    "start": "cross-env RW_NODE_ENV=production node index.js",
+    "bundle-analyzer": "cross-env BUNDLE_ANALYZER=1 yarn build",
+    "sitemap": "cross-env node next-sitemap.js",
+    "test": "cross-env cypress run",
+    "cy:open": "cross-env cypress open"
   },
   "engines": {
     "node": ">=14.15"
@@ -163,29 +163,5 @@
       "eslint --fix",
       "git add"
     ]
-  },
-  "betterScripts": {
-    "build": {
-      "command": "next build",
-      "env": {
-        "NODE_OPTIONS": "--max_old_space_size=4096",
-        "RW_NODE_ENV": "production"
-      }
-    },
-    "start": {
-      "command": "node index.js",
-      "env": {
-        "RW_NODE_ENV": "production"
-      }
-    },
-    "bundle-analyzer": {
-      "command": "yarn build",
-      "env": {
-        "BUNDLE_ANALYZER": "1"
-      }
-    },
-    "sitemap": {
-      "command": "node next-sitemap.js"
-    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4054,15 +4054,6 @@ beeper@^1.0.0:
   resolved "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
   integrity sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=
 
-better-npm-run@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/better-npm-run/-/better-npm-run-0.1.1.tgz#6bb6008591de1b72554aa8b0cefa0da1572fd481"
-  integrity sha512-SBBYsUsb6bYcUMF9QUWy39GX5kzD4CoRBP11gx/k5jYkUr4Tr+irAokIeQX5FgfCRz0Q27rt8U0J4D2TlRgQFA==
-  dependencies:
-    commander "^2.9.0"
-    dotenv "^2.0.0"
-    object-assign "^4.0.1"
-
 bfj@^6.1.1:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.2.tgz#325c861a822bcb358a41c78a33b8e6e2086dde7f"
@@ -5113,7 +5104,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.18.0, commander@^2.20.0, commander@^2.9.0:
+commander@2, commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -5466,6 +5457,13 @@ cross-env@^6.0.3:
   dependencies:
     cross-spawn "^7.0.0"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
@@ -5484,7 +5482,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -6582,11 +6580,6 @@ dotenv@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
   integrity sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=
-
-dotenv@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-2.0.0.tgz#bd759c357aaa70365e01c96b7b0bec08a6e0d949"
-  integrity sha1-vXWcNXqqcDZeAclrewvsCKbg2Uk=
 
 double-ended-queue@^2.1.0-0:
   version "2.1.0-0"


### PR DESCRIPTION
## Overview
Replaces deprecated `better-npm-run` with [cross-env](https://github.com/kentcdodds/cross-env).

## Testing instructions
`yarn` and test any script in the `package.json`

## Pivotal task
–

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
