### PR TITLE
replaces staging API URL env variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,7 +23,7 @@ APPLICATIONS="rw"
 REDIS_URL=
 
 # URL to set the environment of Control Tower. Control Tower handles user login/registration/logout through local or third parties (Google, Facebook...).
-CONTROL_TOWER_URL=https://production-api.globalforestwatch.org
+CONTROL_TOWER_URL=https://api.resourcewatch.org
 
 # Environment the resource belongs to in the WRI API.
 # Example: inside the production WRI API the data can be cataloged in different environments, like staging or production.

--- a/.env.sample
+++ b/.env.sample
@@ -22,18 +22,12 @@ APPLICATIONS="rw"
 # Redis URL for production mode
 REDIS_URL=
 
-# URL to set the environment of Control Tower. Control Tower handles user login/registration/logout through local or third parties (Google, Facebook...).
-CONTROL_TOWER_URL=https://api.resourcewatch.org
-
 # Environment the resource belongs to in the WRI API.
 # Example: inside the production WRI API the data can be cataloged in different environments, like staging or production.
 API_ENV=production
 
 # Sets the environment of the WRI API.
-WRI_API_URL=https://api.resourcewatch.org/v1
-
-# Sets the environment of the WRI API v2.
-WRI_API_URL_V2=https://api.resourcewatch.org/v2
+WRI_API_URL=https://api.resourcewatch.org
 
 # API Key used for google maps library.
 RW_GOGGLE_API_TOKEN_SHORTENER=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,9 @@
     "react/jsx-filename-extension": "warn",
     "react/jsx-props-no-spreading": "off",
     "react-hooks/exhaustive-deps": "warn",
-    "react-hooks/rules-of-hooks": "error"
+    "react-hooks/rules-of-hooks": "error",
+    "jsx-a11y/anchor-is-valid": "off",
+    "react/button-has-type": "off"
   },
   "parser": "@babel/eslint-parser",
   "parserOptions": {

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
         node: [ '14.15', '14', '15' ]
 
     env:
-      WRI_API_URL: https://staging-api.resourcewatch.org.org/v1
+      WRI_API_URL: https://staging-api.resourcewatch.org
       PORT: 3000
       RW_NODE_ENV: development
       REDIS_URL: redis://localhost:6379
@@ -33,7 +33,6 @@ jobs:
       API_ENV: production,preproduction
       CALLBACK_URL: http://localhost:3000/auth
       APPLICATIONS: rw
-      CONTROL_TOWER_URL: https://staging-api.resourcewatch.org.org
       BLOG_API_URL: https://blog.resourcewatch.org/wp-json/wp/v2
       BASEMAP_TILE_URL: https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png
       TRANSIFEX_LIVE_API: abcdef1234567890abcdef1234567890

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
         node: [ '14.15', '14', '15' ]
 
     env:
-      WRI_API_URL: https://staging-api.globalforestwatch.org/v1
+      WRI_API_URL: https://staging-api.resourcewatch.org.org/v1
       PORT: 3000
       RW_NODE_ENV: development
       REDIS_URL: redis://localhost:6379
@@ -33,7 +33,7 @@ jobs:
       API_ENV: production,preproduction
       CALLBACK_URL: http://localhost:3000/auth
       APPLICATIONS: rw
-      CONTROL_TOWER_URL: https://staging-api.globalforestwatch.org
+      CONTROL_TOWER_URL: https://staging-api.resourcewatch.org.org
       BLOG_API_URL: https://blog.resourcewatch.org/wp-json/wp/v2
       BASEMAP_TILE_URL: https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png
       TRANSIFEX_LIVE_API: abcdef1234567890abcdef1234567890

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - added new service and entrypoint to launch Docker.
 
 ### Changed
+- replace redundant environment variables that pointed to the RW API URL with a single one.
 - replaced staging API URL: `staging-api.globalforestwatch.org` to `staging-api.resourcewatch.org`
 - replaced `better-npm-run` with `cross-env`.
 - moved `@babel/core` to devDependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.0.3] - X
+## [3.0.4] - X
 ### Added
 - added tests to verify pages are loaded successfully in `get-involved`, `about`, `data` pages.
 - added new service and entrypoint to launch Docker.
 
 ### Changed
+- replaced staging API URL: `staging-api.globalforestwatch.org` to `staging-api.resourcewatch.org`
 - replaced `better-npm-run` with `cross-env`.
 - moved `@babel/core` to devDependencies.
 - updates `Node` version from `v8` to current `LTS` (`v14`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ARG wriApiUrl=https://api.resourcewatch.org
 ARG callbackUrl=https://resourcewatch.org/auth
 ARG RW_GOGGLE_API_TOKEN_SHORTENER=not_valid
 ARG RW_MAPBOX_API_TOKEN=not_valid
-ARG RW_FEATURE_FLAG_AREAS_V2=
 
 ENV NODE_ENV $NODE_ENV
 ENV WRI_API_URL $wriApiUrl
@@ -24,7 +23,6 @@ ENV RW_GOGGLE_API_TOKEN_SHORTENER $RW_GOGGLE_API_TOKEN_SHORTENER
 ENV BITLY_TOKEN e3076fc3bfeee976efb9966f49383e1a8fb71c5f
 ENV PARDOT_NEWSLETTER_URL https://go.pardot.com/l/120942/2018-01-25/3nzl13
 ENV RW_MAPBOX_API_TOKEN $RW_MAPBOX_API_TOKEN
-ENV RW_FEATURE_FLAG_AREAS_V2 $RW_FEATURE_FLAG_AREAS_V2
 
 RUN apk update && apk add --no-cache \
     build-base gcc bash git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,14 @@ LABEL maintainer="hello@vizzuality.com"
 
 ARG apiEnv=production
 ARG NODE_ENV=production
-ARG apiUrl=https://api.resourcewatch.org
-ARG wriApiUrl=https://api.resourcewatch.org/v1
-ARG WRI_API_URL_V2=https://api.resourcewatch.org/v2
+ARG wriApiUrl=https://api.resourcewatch.org
 ARG callbackUrl=https://resourcewatch.org/auth
-ARG controlTowerUrl=https://api.resourcewatch.org
 ARG RW_GOGGLE_API_TOKEN_SHORTENER=not_valid
 ARG RW_MAPBOX_API_TOKEN=not_valid
 ARG RW_FEATURE_FLAG_AREAS_V2=
 
 ENV NODE_ENV $NODE_ENV
 ENV WRI_API_URL $wriApiUrl
-ENV CONTROL_TOWER_URL $controlTowerUrl
 ENV CALLBACK_URL $callbackUrl
 ENV STATIC_SERVER_URL=
 ENV APPLICATIONS rw
@@ -28,7 +24,6 @@ ENV RW_GOGGLE_API_TOKEN_SHORTENER $RW_GOGGLE_API_TOKEN_SHORTENER
 ENV BITLY_TOKEN e3076fc3bfeee976efb9966f49383e1a8fb71c5f
 ENV PARDOT_NEWSLETTER_URL https://go.pardot.com/l/120942/2018-01-25/3nzl13
 ENV RW_MAPBOX_API_TOKEN $RW_MAPBOX_API_TOKEN
-ENV WRI_API_URL_V2 $WRI_API_URL_V2
 ENV RW_FEATURE_FLAG_AREAS_V2 $RW_FEATURE_FLAG_AREAS_V2
 
 RUN apk update && apk add --no-cache \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,10 +20,10 @@ node {
     stage ('Build docker') {
       switch ("${env.BRANCH_NAME}") {
         case "develop":
-          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg --build-arg wriApiUrl=https://staging-api.resourcewatch.org --build-arg --build-arg callbackUrl=https://staging.resourcewatch.org/auth --build-arg -t ${imageTag} .")
+          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg wriApiUrl=https://staging-api.resourcewatch.org --build-arg callbackUrl=https://staging.resourcewatch.org/auth -t ${imageTag} .")
           break
         case "preproduction":
-          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg callbackUrl=https://preproduction.resourcewatch.org/auth -t ${imageTag} .")
+          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg callbackUrl=https://preproduction.resourcewatch.org/auth -t ${imageTag} .")
           break
         case "master":
           sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} -t ${imageTag} -t ${dockerUsername}/${appName}:latest .")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ node {
     stage ('Build docker') {
       switch ("${env.BRANCH_NAME}") {
         case "develop":
-          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg apiUrl=https://staging.resourcewatch.org/api --build-arg wriApiUrl=https://staging-api.globalforestwatch.org/v1 --build-arg WRI_API_URL_V2=https://staging-api.globalforestwatch.org/v2 --build-arg callbackUrl=https://staging.resourcewatch.org/auth --build-arg controlTowerUrl=https://staging-api.globalforestwatch.org -t ${imageTag} .")
+          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg apiUrl=https://staging.resourcewatch.org/api --build-arg wriApiUrl=https://staging-api.resourcewatch.org/v1 --build-arg WRI_API_URL_V2=https://staging-api.resourcewatch.org/v2 --build-arg callbackUrl=https://staging.resourcewatch.org/auth --build-arg controlTowerUrl=https://staging-api.resourcewatch.org -t ${imageTag} .")
           break
         case "preproduction":
           sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg callbackUrl=https://preproduction.resourcewatch.org/auth -t ${imageTag} .")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ node {
     stage ('Build docker') {
       switch ("${env.BRANCH_NAME}") {
         case "develop":
-          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg apiUrl=https://staging.resourcewatch.org/api --build-arg wriApiUrl=https://staging-api.resourcewatch.org/v1 --build-arg WRI_API_URL_V2=https://staging-api.resourcewatch.org/v2 --build-arg callbackUrl=https://staging.resourcewatch.org/auth --build-arg controlTowerUrl=https://staging-api.resourcewatch.org -t ${imageTag} .")
+          sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg --build-arg wriApiUrl=https://staging-api.resourcewatch.org --build-arg --build-arg callbackUrl=https://staging.resourcewatch.org/auth --build-arg -t ${imageTag} .")
           break
         case "preproduction":
           sh("docker -H :2375 build --build-arg secretKey=${secretKey} --build-arg RW_GOGGLE_API_TOKEN_SHORTENER=${env.RW_GOGGLE_API_TOKEN_SHORTENER} --build-arg RW_MAPBOX_API_TOKEN=${env.RW_MAPBOX_API_TOKEN} --build-arg apiEnv=production --build-arg callbackUrl=https://preproduction.resourcewatch.org/auth -t ${imageTag} .")

--- a/auth.js
+++ b/auth.js
@@ -17,7 +17,7 @@ passport.deserializeUser((obj, done) => {
 
 module.exports = (() => {
   const strategy = new Strategy({
-    controlTowerUrl: process.env.CONTROL_TOWER_URL,
+    controlTowerUrl: process.env.WRI_API_URL,
     callbackUrl: process.env.CALLBACK_URL,
     applications: process.env.APPLICATIONS || 'rw',
   });
@@ -31,7 +31,7 @@ module.exports = (() => {
         origin: 'rw',
       });
 
-      fetch(`${process.env.CONTROL_TOWER_URL}/auth/login?${queryParams}`, {
+      fetch(`${process.env.WRI_API_URL}/auth/login?${queryParams}`, {
         method: 'POST',
         body: JSON.stringify({ email, password }),
         headers: { 'Content-Type': 'application/json' },
@@ -75,7 +75,7 @@ module.exports = (() => {
       const { body } = req;
       const { userObj, token } = body;
 
-      fetch(`${process.env.CONTROL_TOWER_URL}/auth/user/me`, {
+      fetch(`${process.env.WRI_API_URL}/auth/user/me`, {
         method: 'PATCH',
         body: JSON.stringify(userObj),
         headers: {

--- a/components/dashboards/form/steps/step-1/component.jsx
+++ b/components/dashboards/form/steps/step-1/component.jsx
@@ -21,42 +21,33 @@ import { FORM_ELEMENTS } from 'components/dashboards/form/constants';
 import { TEMPLATES } from 'components/dashboards/template-selector/constants';
 
 class Step1 extends PureComponent {
-  static propTypes = {
-    form: PropTypes.object,
-    basic: PropTypes.bool,
-    user: PropTypes.object.isRequired,
-    mode: PropTypes.string,
-    onChange: PropTypes.func.isRequired,
+  constructor(props) {
+    super(props);
+    this.state = {
+      form: {
+        ...props.form,
+        content: TEMPLATES[0].content,
+      },
+    };
   }
-
-  static defaultProps = {
-    form: {},
-    basic: false,
-    mode: 'new',
-  }
-
-  state = {
-    form: {
-      ...this.props.form,
-      content: TEMPLATES[0].content,
-    },
-  };
 
   componentDidMount() {
     const { child: wysiwyg } = FORM_ELEMENTS.elements.content;
+    const { form } = this.props;
 
-    if (!isEmpty(this.props.form.content)) {
-      wysiwyg.setValue(this.props.form.content);
+    if (!isEmpty(form.content)) {
+      wysiwyg.setValue(form.content);
     } else {
       wysiwyg.setValue(JSON.stringify(TEMPLATES[0].content));
     }
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ form: nextProps.form });
   }
 
-  onChangeTemplate(nextTemplate) {
+  static onChangeTemplate(nextTemplate) {
     const { child: wysiwyg } = FORM_ELEMENTS.elements.content;
     const { content } = nextTemplate;
 
@@ -64,7 +55,11 @@ class Step1 extends PureComponent {
   }
 
   render() {
-    const { mode } = this.props;
+    const {
+      mode, onChange, form, basic, user,
+    } = this.props;
+    const { form: stateForm } = this.state;
+
     // Reset FORM_ELEMENTS
     FORM_ELEMENTS.elements = {};
 
@@ -73,8 +68,10 @@ class Step1 extends PureComponent {
         <fieldset className="c-field-container">
           {/* NAME */}
           <Field
-            ref={(c) => { if (c) FORM_ELEMENTS.elements.name = c; }}
-            onChange={(value) => this.props.onChange({ name: value })}
+            ref={(c) => {
+              if (c) FORM_ELEMENTS.elements.name = c;
+            }}
+            onChange={(value) => onChange({ name: value })}
             validations={['required']}
             className="-fluid"
             properties={{
@@ -82,7 +79,7 @@ class Step1 extends PureComponent {
               label: 'Name',
               type: 'text',
               required: true,
-              default: this.state.form.name,
+              default: stateForm.name,
             }}
           >
             {Input}
@@ -90,14 +87,16 @@ class Step1 extends PureComponent {
 
           {/* SUMMARY */}
           <Field
-            ref={(c) => { if (c) FORM_ELEMENTS.elements.summary = c; }}
-            onChange={(value) => this.props.onChange({ summary: value })}
+            ref={(c) => {
+              if (c) FORM_ELEMENTS.elements.summary = c;
+            }}
+            onChange={(value) => onChange({ summary: value })}
             className="-fluid"
             properties={{
               name: 'summary',
               label: 'Summary',
               rows: '6',
-              default: this.state.form.summary,
+              default: stateForm.summary,
             }}
           >
             {TextArea}
@@ -105,14 +104,16 @@ class Step1 extends PureComponent {
 
           {/* DESCRIPTION */}
           <Field
-            ref={(c) => { if (c) FORM_ELEMENTS.elements.description = c; }}
-            onChange={(value) => this.props.onChange({ description: value })}
+            ref={(c) => {
+              if (c) FORM_ELEMENTS.elements.description = c;
+            }}
+            onChange={(value) => onChange({ description: value })}
             className="-fluid"
             properties={{
               name: 'description',
               label: 'Description',
               rows: '6',
-              default: this.state.form.description,
+              default: stateForm.description,
             }}
           >
             {TextArea}
@@ -123,12 +124,14 @@ class Step1 extends PureComponent {
             <div className="row l-row">
               <div className="column small-12 medium-6">
                 <Field
-                  ref={(c) => { if (c) FORM_ELEMENTS.elements.photo = c; }}
+                  ref={(c) => {
+                    if (c) FORM_ELEMENTS.elements.photo = c;
+                  }}
                   onChange={(value) => {
                     if (value) {
-                      this.props.onChange({ photo: value });
+                      onChange({ photo: value });
                     } else {
-                      this.props.onChange({ photo: null });
+                      onChange({ photo: null });
                     }
                   }}
                   className="-fluid"
@@ -137,7 +140,7 @@ class Step1 extends PureComponent {
                     label: 'Photo',
                     placeholder: 'Browse file',
                     baseUrl: process.env.STATIC_SERVER_URL,
-                    default: this.state.form.photo,
+                    default: stateForm.photo,
                   }}
                 >
                   {FileImage}
@@ -147,11 +150,13 @@ class Step1 extends PureComponent {
           </div>
 
           {/* PUBLISHED */}
-          {!this.props.basic
-            && (
+          {!basic
+          && (
             <Field
-              ref={(c) => { if (c) FORM_ELEMENTS.elements.published = c; }}
-              onChange={(value) => this.props.onChange({
+              ref={(c) => {
+                if (c) FORM_ELEMENTS.elements.published = c;
+              }}
+              onChange={(value) => onChange({
                 published: value.checked,
                 private: !value.checked,
               })}
@@ -160,105 +165,115 @@ class Step1 extends PureComponent {
                 label: 'Do you want to set this dasboard as published?',
                 value: 'published',
                 title: 'Published',
-                defaultChecked: this.props.form.published,
-                checked: this.props.form.published,
+                defaultChecked: form.published,
+                checked: form.published,
               }}
             >
               {Checkbox}
             </Field>
-            )}
+          )}
 
-          {!this.props.basic
-            && (
+          {!basic
+          && (
             <Field
-              ref={(c) => { if (c) FORM_ELEMENTS.elements.preproduction = c; }}
-              onChange={(value) => this.props.onChange({ preproduction: value.checked })}
+              ref={(c) => {
+                if (c) FORM_ELEMENTS.elements.preproduction = c;
+              }}
+              onChange={(value) => onChange({ preproduction: value.checked })}
               properties={{
                 name: 'preproduction',
                 label: 'Do you want to set this dashboard as pre-production?',
                 value: 'preproduction',
                 title: 'Pre-production',
-                defaultChecked: this.props.form.preproduction,
-                checked: this.props.form.preproduction,
+                defaultChecked: form.preproduction,
+                checked: form.preproduction,
               }}
             >
               {Checkbox}
             </Field>
-            )}
+          )}
 
-          {!this.props.basic
-            && (
+          {!basic
+          && (
             <Field
-              ref={(c) => { if (c) FORM_ELEMENTS.elements.production = c; }}
-              onChange={(value) => this.props.onChange({ production: value.checked })}
+              ref={(c) => {
+                if (c) FORM_ELEMENTS.elements.production = c;
+              }}
+              onChange={(value) => onChange({ production: value.checked })}
               properties={{
                 name: 'production',
                 label: 'Do you want to set this dashboard as production?',
                 value: 'production',
                 title: 'Production',
-                defaultChecked: this.props.form.production,
-                checked: this.props.form.production,
+                defaultChecked: form.production,
+                checked: form.production,
               }}
             >
               {Checkbox}
             </Field>
-            )}
+          )}
 
           {/* IS-HIGHLIGHTED */}
-          {!this.props.basic
-            && (
+          {!basic
+          && (
             <Field
-              ref={(c) => { if (c) FORM_ELEMENTS.elements['is-highlighted'] = c; }}
-              onChange={(value) => this.props.onChange({ 'is-highlighted': value.checked })}
+              ref={(c) => {
+                if (c) FORM_ELEMENTS.elements['is-highlighted'] = c;
+              }}
+              onChange={(value) => onChange({ 'is-highlighted': value.checked })}
               properties={{
                 name: 'is-highlighted',
                 label: 'Highlight in Dashboards gallery',
                 value: 'is-highlighted',
                 title: 'Is highlighted',
-                defaultChecked: this.props.form['is-highlighted'],
-                checked: this.props.form['is-highlighted'],
+                defaultChecked: form['is-highlighted'],
+                checked: form['is-highlighted'],
               }}
             >
               {Checkbox}
             </Field>
-            )}
+          )}
 
           {/* IS-FEATURED */}
-          {!this.props.basic
-            && (
+          {!basic
+          && (
             <Field
-              ref={(c) => { if (c) FORM_ELEMENTS.elements['is-featured'] = c; }}
-              onChange={(value) => this.props.onChange({ 'is-featured': value.checked })}
+              ref={(c) => {
+                if (c) FORM_ELEMENTS.elements['is-featured'] = c;
+              }}
+              onChange={(value) => onChange({ 'is-featured': value.checked })}
               properties={{
                 name: 'is-featured',
                 label: 'Add to Featured dashboards',
                 value: 'is-featured',
                 title: 'Featured',
-                defaultChecked: this.props.form['is-featured'],
-                checked: this.props.form['is-featured'],
+                defaultChecked: form['is-featured'],
+                checked: form['is-featured'],
               }}
             >
               {Checkbox}
             </Field>
-            )}
+          )}
         </fieldset>
 
         <fieldset className="c-field-container">
           {/* templates */}
           {mode === 'new' && (
-            <TemplateSelector onChange={this.onChangeTemplate} />)}
+            <TemplateSelector onChange={Step1.onChangeTemplate} />)}
 
           {/* CONTENT */}
           <Field
-            ref={(c) => { if (c) FORM_ELEMENTS.elements.content = c; }}
-            onChange={(value) => this.props.onChange({ content: value })}
+            ref={(c) => {
+              if (c) FORM_ELEMENTS.elements.content = c;
+            }}
+            onChange={(value) => onChange({ content: value })}
             validations={['required']}
             className="-fluid"
             properties={{
               name: 'content',
               label: 'Content',
               required: true,
-              default: this.state.form.content,
+              default: stateForm.content,
               blocks: {
                 widget: {
                   Component: WidgetBlock,
@@ -273,9 +288,9 @@ class Step1 extends PureComponent {
                 const formData = new FormData();
                 formData.append('image', file);
 
-                fetch(`${process.env.WRI_API_URL}/temporary_content_image`, {
+                fetch(`${process.env.WRI_API_URL}/v1/temporary_content_image`, {
                   method: 'POST',
-                  headers: { Authorization: this.props.user.token },
+                  headers: { Authorization: user.token },
                   body: formData,
                 })
                   .then((response) => response.json())
@@ -296,5 +311,29 @@ class Step1 extends PureComponent {
     );
   }
 }
+
+Step1.defaultProps = {
+  form: {},
+  basic: false,
+  mode: 'new',
+};
+Step1.propTypes = {
+  form: PropTypes.shape({
+    content: PropTypes.string,
+    'is-featured': PropTypes.bool,
+    'is-highlighted': PropTypes.bool,
+    production: PropTypes.string,
+    preproduction: PropTypes.string,
+    published: PropTypes.bool,
+    photo: PropTypes.string,
+    description: PropTypes.string,
+  }),
+  basic: PropTypes.bool,
+  user: PropTypes.shape({
+    token: PropTypes.string,
+  }).isRequired,
+  mode: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+};
 
 export default Step1;

--- a/components/datasets/form/try-subscription-modal/try-subscription-modal-actions.js
+++ b/components/datasets/form/try-subscription-modal/try-subscription-modal-actions.js
@@ -10,7 +10,7 @@ export const resetTrySubscriptionModal = createAction('try-subscription-modal/re
 export const getTrySubscriptionModal = createThunkAction('try-subscription-modal/getTrySubscriptionModal', ({ query }) => (dispatch) => {
   dispatch(setTrySubscriptionModalLoading(true));
 
-  return fetch(`${process.env.WRI_API_URL}/query?sql=${query}`)
+  return fetch(`${process.env.WRI_API_URL}/V1/query?sql=${query}`)
     .then((response) => response.json())
     .then(({ data, errors }) => {
       if (errors) {

--- a/components/datasets/form/try-subscription-modal/try-subscription-modal-actions.js
+++ b/components/datasets/form/try-subscription-modal/try-subscription-modal-actions.js
@@ -10,7 +10,7 @@ export const resetTrySubscriptionModal = createAction('try-subscription-modal/re
 export const getTrySubscriptionModal = createThunkAction('try-subscription-modal/getTrySubscriptionModal', ({ query }) => (dispatch) => {
   dispatch(setTrySubscriptionModalLoading(true));
 
-  return fetch(`${process.env.WRI_API_URL}/V1/query?sql=${query}`)
+  return fetch(`${process.env.WRI_API_URL}/v1/query?sql=${query}`)
     .then((response) => response.json())
     .then(({ data, errors }) => {
       if (errors) {

--- a/components/datasets/form/try-subscription-modal/try-subscription-modal-component.jsx
+++ b/components/datasets/form/try-subscription-modal/try-subscription-modal-component.jsx
@@ -7,24 +7,14 @@ import Code from 'components/form/Code';
 import Spinner from 'components/ui/Spinner';
 
 class TrySubscriptionModal extends PureComponent {
-  static propTypes = {
-    query: PropTypes.string,
-
-    data: PropTypes.any,
-    loading: PropTypes.bool,
-    error: PropTypes.any,
-
-    getTrySubscriptionModal: PropTypes.func,
-    resetTrySubscriptionModal: PropTypes.func,
-  };
-
   componentDidMount() {
-    const { query } = this.props;
-    this.props.getTrySubscriptionModal({ query });
+    const { query, getTrySubscriptionModal } = this.props;
+    getTrySubscriptionModal({ query });
   }
 
   componentWillUnmount() {
-    this.props.resetTrySubscriptionModal();
+    const { resetTrySubscriptionModal } = this.props;
+    resetTrySubscriptionModal();
   }
 
   getValue() {
@@ -43,7 +33,7 @@ class TrySubscriptionModal extends PureComponent {
         {loading && <Spinner isLoading className="-light -tiny" />}
 
         <Field
-          hint={`${process.env.WRI_API_URL}/query?sql=${encodeURIComponent(query)}`}
+          hint={`${process.env.WRI_API_URL}/v1/query?sql=${encodeURIComponent(query)}`}
           properties={{
             name: 'query-result',
             label: 'Query result',
@@ -58,5 +48,27 @@ class TrySubscriptionModal extends PureComponent {
     );
   }
 }
+
+TrySubscriptionModal.defaultProps = {
+  query: null,
+  data: null,
+  loading: null,
+  error: null,
+  getTrySubscriptionModal: null,
+  resetTrySubscriptionModal: null,
+};
+
+TrySubscriptionModal.propTypes = {
+  query: PropTypes.string,
+
+  // eslint-disable-next-line react/forbid-prop-types
+  data: PropTypes.any,
+  loading: PropTypes.bool,
+  // eslint-disable-next-line react/forbid-prop-types
+  error: PropTypes.any,
+
+  getTrySubscriptionModal: PropTypes.func,
+  resetTrySubscriptionModal: PropTypes.func,
+};
 
 export default TrySubscriptionModal;

--- a/components/datasets/list/list-item/actions.js
+++ b/components/datasets/list/list-item/actions.js
@@ -11,10 +11,10 @@ export const setTagsError = createAction('DATASET_LIST_ITEM/setTagsError');
 export const resetTags = createAction('DATASET_LIST_ITEM/resetTags');
 
 // Async actions
-export const fetchTags = createThunkAction('DATASET_LIST_ITEM/fetchTags', (tags) => (dispatch) => {
+export const fetchTags = createThunkAction('DATASET_LIST_ITEM/fetchTags', () => (dispatch) => {
   dispatch(setTagsLoading(true));
 
-  return fetch(`${process.env.WRI_API_URL}//dataset/${this.datasetId}?application=${process.env.APPLICATIONS}&language=${this.opts.language}&includes="metadata"&page[size]=999`)
+  return fetch(`${process.env.WRI_API_URL}/v1/dataset/${this.datasetId}?application=${process.env.APPLICATIONS}&language=${this.opts.language}&includes="metadata"&page[size]=999`)
     .then((response) => {
       if (response.status >= 400) throw Error(response.statusText);
       return response.json();

--- a/components/form/File.jsx
+++ b/components/form/File.jsx
@@ -135,7 +135,7 @@ class File extends FormElement {
 
     post({
       type: 'POST',
-      url: `${process.env.WRI_API_URL}/dataset/upload`,
+      url: `${process.env.WRI_API_URL}/v1/dataset/upload`,
       headers: [{
         key: 'Authorization', value: this.props.properties.authorization,
       }],
@@ -221,7 +221,9 @@ class File extends FormElement {
 }
 
 File.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
   properties: PropTypes.object.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
   validations: PropTypes.array,
   onChange: PropTypes.func,
 };

--- a/components/tools/related-tools/actions.js
+++ b/components/tools/related-tools/actions.js
@@ -10,7 +10,7 @@ export const fetchTools = createThunkAction('WIDGET-DETAIL/fetchTools', () => (d
   dispatch(setToolsLoading(true));
   dispatch(setToolsError(null));
 
-  return fetch(new Request(`${process.env.WRI_API_URL}/tool`))
+  return fetch(new Request(`${process.env.WRI_API_URL}/v1/tool`))
     .then((response) => {
       if (response.ok) return response.json();
       throw new Error(response.statusText);

--- a/components/ui/map/map-thumbnail/helper.js
+++ b/components/ui/map/map-thumbnail/helper.js
@@ -90,7 +90,7 @@ export const getImageForGEE = ({ layerSpec }) => {
   if (!layerConfig) throw Error('layerConfig param is required');
   if (!layerConfig.body) throw Error('layerConfig does not have body param');
 
-  const tile = `${process.env.WRI_API_URL}/layer/${layerSpec.id}/tile/gee/0/0/0`;
+  const tile = `${process.env.WRI_API_URL}/v1/layer/${layerSpec.id}/tile/gee/0/0/0`;
 
   return tile;
 };
@@ -121,7 +121,7 @@ export const getLayerImage = async ({
 }) => {
   if (!layerSpec) throw Error('No layerSpec specified.');
 
-  const { id, layerConfig, provider } = layerSpec;
+  const { layerConfig, provider } = layerSpec;
   let result;
 
   switch (provider) {

--- a/components/widgets/card/component.js
+++ b/components/widgets/card/component.js
@@ -140,7 +140,7 @@ const WidgetCard = (props) => {
 
     const link = document.createElement('a');
     link.setAttribute('download', '');
-    link.href = `${process.env.CONTROL_TOWER_URL}/v1/webshot/pdf?filename=${filename}&width=790&height=580&waitFor=8000&url=${origin}/embed/${type}/${id}`;
+    link.href = `${process.env.WRI_API_URL}/v1/webshot/pdf?filename=${filename}&width=790&height=580&waitFor=8000&url=${origin}/embed/${type}/${id}`;
 
     // link.click() doesn't work on Firefox for some reasons
     // so we have to create an event manually
@@ -400,6 +400,7 @@ const WidgetCard = (props) => {
 };
 
 WidgetCard.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
   widget: PropTypes.object.isRequired,
   showActions: PropTypes.bool,
   showRemove: PropTypes.bool,
@@ -409,6 +410,7 @@ WidgetCard.propTypes = {
   onWidgetRemove: PropTypes.func.isRequired,
   onWidgetClick: PropTypes.func,
   limitChar: PropTypes.number,
+  // eslint-disable-next-line react/forbid-prop-types
   user: PropTypes.object.isRequired,
   toggleModal: PropTypes.func.isRequired,
   setModalOptions: PropTypes.func.isRequired,

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -4,7 +4,7 @@ services:
     build: .
     command: start
     environment:
-      WRI_API_URL: https://staging-api.globalforestwatch.org/v1
+      WRI_API_URL: https://staging-api.resourcewatch.org/v1
       PORT: 3000
       RW_NODE_ENV: test
       REDIS_URL: redis://redis:6379
@@ -14,7 +14,7 @@ services:
       API_ENV: production,preproduction
       CALLBACK_URL: http://localhost:3000/auth
       APPLICATIONS: rw
-      CONTROL_TOWER_URL: https://staging-api.globalforestwatch.org
+      CONTROL_TOWER_URL: https://staging-api.resourcewatch.org
       BLOG_API_URL: https://blog.resourcewatch.org/wp-json/wp/v2
       BASEMAP_TILE_URL: https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png
       TRANSIFEX_LIVE_API: fca0343bce994bf8ba3dcdeaab389136

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -4,7 +4,7 @@ services:
     build: .
     command: start
     environment:
-      WRI_API_URL: https://staging-api.resourcewatch.org/v1
+      WRI_API_URL: https://staging-api.resourcewatch.org
       PORT: 3000
       RW_NODE_ENV: test
       REDIS_URL: redis://redis:6379
@@ -14,7 +14,6 @@ services:
       API_ENV: production,preproduction
       CALLBACK_URL: http://localhost:3000/auth
       APPLICATIONS: rw
-      CONTROL_TOWER_URL: https://staging-api.resourcewatch.org
       BLOG_API_URL: https://blog.resourcewatch.org/wp-json/wp/v2
       BASEMAP_TILE_URL: https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png
       TRANSIFEX_LIVE_API: fca0343bce994bf8ba3dcdeaab389136

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ app.prepare().then(() => {
     // save the current url for redirect if successfull, set it to expire in 5 min
     res.cookie('authUrl', req.headers.referer, { maxAge: 3e5, httpOnly: true });
     return res.redirect(
-      `${process.env.CONTROL_TOWER_URL}/auth/${service}?callbackUrl=${
+      `${process.env.WRI_API_URL}/auth/${service}?callbackUrl=${
         process.env.CALLBACK_URL
       }&applications=rw&token=true&origin=rw`,
     );

--- a/layout/explore/explore-datasets/list/list-item/actions.js
+++ b/layout/explore/explore-datasets/list/list-item/actions.js
@@ -11,10 +11,10 @@ export const setTagsError = createAction('DATASET_LIST_ITEM/setTagsError');
 export const resetTags = createAction('DATASET_LIST_ITEM/resetTags');
 
 // Async actions
-export const fetchTags = createThunkAction('DATASET_LIST_ITEM/fetchTags', (tags) => (dispatch) => {
+export const fetchTags = createThunkAction('DATASET_LIST_ITEM/fetchTags', () => (dispatch) => {
   dispatch(setTagsLoading(true));
 
-  return fetch(`${process.env.WRI_API_URL}//dataset/${this.datasetId}?application=${process.env.APPLICATIONS}&language=${this.opts.language}&includes="metadata"&page[size]=999`)
+  return fetch(`${process.env.WRI_API_URL}/v1/dataset/${this.datasetId}?application=${process.env.APPLICATIONS}&language=${this.opts.language}&includes="metadata"&page[size]=999`)
     .then((response) => {
       if (response.status >= 400) throw Error(response.statusText);
       return response.json();

--- a/layout/get-involved-detail/get-involved-detail-actions.js
+++ b/layout/get-involved-detail/get-involved-detail-actions.js
@@ -25,7 +25,7 @@ export const fetchStaticData = createThunkAction(
     dispatch(setStaticDataLoading(true));
     dispatch(setStaticDataError(null));
 
-    return fetch(new Request(`${process.env.WRI_API_URL}/static_page/${lookup[payload]}`))
+    return fetch(new Request(`${process.env.WRI_API_URL}/V1/static_page/${lookup[payload]}`))
       .then((response) => {
         if (response.ok) return response.json();
         throw new Error(response.statusText);

--- a/layout/get-involved/get-involved-actions.js
+++ b/layout/get-involved/get-involved-actions.js
@@ -11,7 +11,7 @@ export const fetchStaticData = createThunkAction('GET-INVOLVED-INDEX/fetchStatic
   dispatch(setStaticDataLoading(true));
   dispatch(setStaticDataError(null));
 
-  return fetch(new Request(`${process.env.WRI_API_URL}/static_page/${payload}`))
+  return fetch(new Request(`${process.env.WRI_API_URL}/v1/static_page/${payload}`))
     .then((response) => {
       if (response.ok) return response.json();
       throw new Error(response.statusText);

--- a/layout/header-admin/header-admin-user/component.js
+++ b/layout/header-admin/header-admin-user/component.js
@@ -12,18 +12,12 @@ import Icon from 'components/ui/icon';
 import { get } from 'utils/request';
 
 class AdminHeaderUser extends PureComponent {
-  static propTypes = {
-    user: PropTypes.object.isRequired,
-    header: PropTypes.object.isRequired,
-    setDropdownOpened: PropTypes.func.isRequired,
-  }
-
-  logout(e) {
+  static logout(e) {
     if (e) e.preventDefault();
 
     // TO-DO: move this to an action
     get({
-      url: `${process.env.CONTROL_TOWER_URL}/auth/logout`,
+      url: `${process.env.WRI_API_URL}/auth/logout`,
       withCredentials: true,
       onSuccess: () => {
         window.location.href = `/logout?callbackUrl=${window.location.href}`;
@@ -35,11 +29,12 @@ class AdminHeaderUser extends PureComponent {
   }
 
   toggleDropdown = debounce((bool) => {
-    this.props.setDropdownOpened({ myrw: bool });
+    const { setDropdownOpened } = this.props;
+    setDropdownOpened({ myrw: bool });
   }, 50)
 
   render() {
-    const { user } = this.props;
+    const { user, header } = this.props;
 
     if (user.token) {
       const photo = (user.photo) ? `url(${user.photo})` : 'none';
@@ -59,16 +54,16 @@ class AdminHeaderUser extends PureComponent {
                 onMouseLeave={() => this.toggleDropdown(false)}
               >
                 {(!user.photo && user.email)
-                  && (
+                && (
                   <span className="avatar-letter">
                     {user.email.split('')[0]}
                   </span>
-                  )}
+                )}
               </a>
             </Link>
             {/* Second child: If present, this item will be tethered to the the first child */}
-            {this.props.header.dropdownOpened.myrw
-              && (
+            {header.dropdownOpened.myrw
+            && (
               <ul
                 className="header-dropdown-list"
                 onMouseEnter={() => this.toggleDropdown(true)}
@@ -80,18 +75,18 @@ class AdminHeaderUser extends PureComponent {
                   </Link>
                 </li>
                 {user.role === 'ADMIN'
-                  && (
+                && (
                   <li className="header-dropdown-list-item">
                     <Link route="admin_home">
                       <a>Admin</a>
                     </Link>
                   </li>
-                  )}
+                )}
                 <li className="header-dropdown-list-item">
-                  <a onClick={this.logout} href="/logout">Logout</a>
+                  <a onClick={AdminHeaderUser.logout} href="/logout">Logout</a>
                 </li>
               </ul>
-              )}
+            )}
           </TetherComponent>
         </div>
       );
@@ -115,8 +110,8 @@ class AdminHeaderUser extends PureComponent {
           </span>
 
           {/* Second child: If present, this item will be tethered to the the first child */}
-          {this.props.header.dropdownOpened.myrw
-            && (
+          {header.dropdownOpened.myrw
+          && (
             <ul
               className="header-dropdown-list"
               onMouseEnter={() => this.toggleDropdown(true)}
@@ -138,12 +133,20 @@ class AdminHeaderUser extends PureComponent {
                 </a>
               </li>
             </ul>
-            )}
+          )}
         </TetherComponent>
       );
     }
     return null;
   }
 }
+
+AdminHeaderUser.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  user: PropTypes.object.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  header: PropTypes.object.isRequired,
+  setDropdownOpened: PropTypes.func.isRequired,
+};
 
 export default AdminHeaderUser;

--- a/layout/header/header-menu-mobile/component.js
+++ b/layout/header/header-menu-mobile/component.js
@@ -15,30 +15,23 @@ import { APP_HEADER_ITEMS } from 'layout/header/constants';
 import './styles.scss';
 
 class HeaderMenuMobile extends PureComponent {
-  static propTypes = {
-    header: PropTypes.object.isRequired,
-    routes: PropTypes.object.isRequired,
-    user: PropTypes.object.isRequired,
-    setMobileOpened: PropTypes.func.isRequired,
+  /**
+   * UI EVENTS
+   * - logout
+  */
+  static logout(e) {
+    if (e) e.preventDefault();
+
+    // Get to logout
+    fetch(`${process.env.WRI_API_URL}/auth/logout`, { credentials: 'include' })
+      .then(() => { window.location.href = `/logout?callbackUrl=${window.location.href}`; })
+      .catch((err) => { toastr.error('Error', err); });
   }
 
   componentDidUpdate() {
     const { header: { mobileOpened } } = this.props;
 
     document.body.classList.toggle('no-scroll', mobileOpened);
-  }
-
-  /**
-   * UI EVENTS
-   * - logout
-  */
-  logout(e) {
-    if (e) e.preventDefault();
-
-    // Get to logout
-    fetch(`${process.env.CONTROL_TOWER_URL}/auth/logout`, { credentials: 'include' })
-      .then(() => { window.location.href = `/logout?callbackUrl=${window.location.href}`; })
-      .catch((err) => { toastr.error('Error', err); });
   }
 
   render() {
@@ -61,6 +54,7 @@ class HeaderMenuMobile extends PureComponent {
 
         <div className={`header-menu-mobile-content ${classNames}`}>
           {/* Backdrop */}
+          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
           <button
             className={`c-button -clean header-menu-mobile-backdrop ${classNames}`}
             onClick={() => setMobileOpened(false)}
@@ -156,7 +150,7 @@ class HeaderMenuMobile extends PureComponent {
                               {c.id === 'logout'
                                 && (
                                 <a
-                                  onClick={this.logout}
+                                  onClick={HeaderMenuMobile.logout}
                                   href={c.href}
                                 >
                                   {c.label}
@@ -177,5 +171,15 @@ class HeaderMenuMobile extends PureComponent {
     );
   }
 }
+
+HeaderMenuMobile.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  header: PropTypes.object.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  routes: PropTypes.object.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  user: PropTypes.object.isRequired,
+  setMobileOpened: PropTypes.func.isRequired,
+};
 
 export default HeaderMenuMobile;

--- a/layout/header/header-user/component.jsx
+++ b/layout/header/header-user/component.jsx
@@ -9,17 +9,11 @@ import debounce from 'lodash/debounce';
 import Icon from 'components/ui/icon';
 
 class HeaderUser extends PureComponent {
-  static propTypes = {
-    user: PropTypes.object.isRequired,
-    header: PropTypes.object.isRequired,
-    setDropdownOpened: PropTypes.func.isRequired,
-  }
-
-  logout(e) {
+  static logout(e) {
     if (e) e.preventDefault();
 
     // TO-DO: move this to an action
-    fetch(`${process.env.CONTROL_TOWER_URL}/auth/logout`, { credentials: 'include' })
+    fetch(`${process.env.WRI_API_URL}/auth/logout`, { credentials: 'include' })
       .then(() => {
         window.location.href = `/logout?callbackUrl=${window.location.href}`;
       })
@@ -29,7 +23,8 @@ class HeaderUser extends PureComponent {
   }
 
   toggleDropdown = debounce((bool) => {
-    this.props.setDropdownOpened({ myrw: bool });
+    const { setDropdownOpened } = this.props;
+    setDropdownOpened({ myrw: bool });
   }, 50)
 
   render() {
@@ -135,7 +130,7 @@ class HeaderUser extends PureComponent {
                     </li>
                     )}
                   <li className="header-dropdown-list-item">
-                    <a onClick={this.logout} href="/logout">Logout</a>
+                    <a onClick={HeaderUser.logout} href="/logout">Logout</a>
                   </li>
                 </ul>
               </div>
@@ -157,5 +152,13 @@ class HeaderUser extends PureComponent {
     );
   }
 }
+
+HeaderUser.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  user: PropTypes.object.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  header: PropTypes.object.isRequired,
+  setDropdownOpened: PropTypes.func.isRequired,
+};
 
 export default HeaderUser;

--- a/next.config.js
+++ b/next.config.js
@@ -3,8 +3,10 @@ require('dotenv').load();
 const withSass = require('@zeit/next-sass');
 const withCSS = require('@zeit/next-css');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+// eslint-disable-next-line import/no-extraneous-dependencies
 const cssnano = require('cssnano');
 const { BundleAnalyzerPlugin } = (process.env.RW_NODE_ENV === 'production' && process.env.BUNDLE_ANALYZER)
+  // eslint-disable-next-line import/no-extraneous-dependencies
   ? require('webpack-bundle-analyzer') : {};
 
 module.exports = withCSS(withSass({
@@ -29,9 +31,7 @@ module.exports = withCSS(withSass({
     RW_NODE_ENV: process.env.RW_NODE_ENV || 'development',
     APPLICATIONS: process.env.APPLICATIONS,
     CALLBACK_URL: process.env.CALLBACK_URL,
-    CONTROL_TOWER_URL: process.env.CONTROL_TOWER_URL,
     WRI_API_URL: process.env.WRI_API_URL,
-    WRI_API_URL_V2: process.env.WRI_API_URL_V2,
     BLOG_API_URL: process.env.BLOG_API_URL,
     STATIC_SERVER_URL: process.env.STATIC_SERVER_URL,
     ADD_SEARCH_KEY: process.env.ADD_SEARCH_KEY,
@@ -46,6 +46,7 @@ module.exports = withCSS(withSass({
   },
 
   webpack: (config) => {
+    // eslint-disable-next-line no-underscore-dangle
     const _config = { ...config };
 
     _config.node = {

--- a/pages/app/webshot/index.js
+++ b/pages/app/webshot/index.js
@@ -9,7 +9,7 @@ class Webshot extends PureComponent {
     const { query, res } = props;
     const { id } = query;
 
-    await WRIAPI.get(`/widget/${id}`, {
+    await WRIAPI.get(`/v1/widget/${id}`, {
       headers: { 'Upgrade-Insecure-Requests': 1 },
       params: { application: process.env.APPLICATIONS },
       transformResponse: [].concat(

--- a/redactions/insights.js
+++ b/redactions/insights.js
@@ -123,7 +123,7 @@ export function getInsights() {
       type: GET_INSIGHTS_SUCCESS,
       payload: INSIGHTS_DATA,
     });
-    // fetch(new Request(`${process.env.WRI_API_URL}/partner`))
+    // fetch(new Request(`${process.env.WRI_API_URL}/v1/partner`))
     //   .then((response) => {
     //     if (response.ok) return response.json();
     //     throw new Error(response.statusText);

--- a/services/areas.js
+++ b/services/areas.js
@@ -2,7 +2,7 @@ import WRISerializer from 'wri-json-api-serializer';
 
 // utils
 import {
-  WRIAPI_V2,
+  WRIAPI,
 } from 'utils/axios';
 import { logger } from 'utils/logs';
 
@@ -17,8 +17,8 @@ import { logger } from 'utils/logs';
 export const fetchArea = (id, params = {}, headers = {}) => {
   logger.info(`Fetch area ${id}`);
 
-  return WRIAPI_V2.get(
-    `area/${id}`,
+  return WRIAPI.get(
+    `/v2/area/${id}`,
     {
       headers: {
         ...headers,
@@ -44,7 +44,7 @@ export const fetchArea = (id, params = {}, headers = {}) => {
 export const fetchUserAreas = (token, params = {}, _meta = false) => {
   logger.info('Fetch user areas');
 
-  return WRIAPI_V2.get('area', {
+  return WRIAPI.get('/v2/area', {
     headers: {
       Authorization: token,
       'Upgrade-Insecure-Requests': 1,
@@ -55,7 +55,7 @@ export const fetchUserAreas = (token, params = {}, _meta = false) => {
       ...params,
     },
     transformResponse: [].concat(
-      WRIAPI_V2.defaults.transformResponse,
+      WRIAPI.defaults.transformResponse,
       (({ data, meta }) => ({ areas: data, meta })),
     ),
   })
@@ -94,7 +94,7 @@ export const fetchUserAreas = (token, params = {}, _meta = false) => {
 export const deleteArea = (areaId, token) => {
   logger.info(`Delete area ${areaId}`);
 
-  return WRIAPI_V2.delete(`area/${areaId}`, { headers: { Authorization: token } })
+  return WRIAPI.delete(`/v2/area/${areaId}`, { headers: { Authorization: token } })
     .catch(({ response }) => {
       const { status, statusText } = response;
       logger.error(`Error deleting area ${areaId}: ${status}: ${statusText}`);
@@ -120,7 +120,7 @@ export const createArea = (name, geostore, token) => {
     geostore,
   };
 
-  return WRIAPI_V2.post('area', bodyObj, { headers: { Authorization: token } })
+  return WRIAPI.post('/v2/area', bodyObj, { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
     .catch(({ response }) => {
       const { status, statusText } = response;
@@ -140,7 +140,7 @@ export const createArea = (name, geostore, token) => {
 export const updateArea = (id, params, token) => {
   logger.info(`Update area ${id}`);
 
-  return WRIAPI_V2.patch(`area/${id}`, {
+  return WRIAPI.patch(`/v2/area/${id}`, {
     application: process.env.APPLICATIONS,
     env: process.env.API_ENV,
     ...params,

--- a/services/collections.js
+++ b/services/collections.js
@@ -16,7 +16,7 @@ export const fetchAllCollections = (
   _meta = false,
 ) => {
   logger.info('Fetch all collections');
-  return WRIAPI.get('collection', {
+  return WRIAPI.get('/v1/collection', {
     headers: {
       Authorization: token,
       'Upgrade-Insecure-Requests': 1,
@@ -72,7 +72,7 @@ export const fetchCollection = (
   params = {},
 ) => {
   logger.info(`Fetch collection ${collectionId}`);
-  return WRIAPI.get(`collection/${collectionId}`, {
+  return WRIAPI.get(`/v1/collection/${collectionId}`, {
     headers: {
       Authorization: token,
       'Upgrade-Insecure-Requests': 1,
@@ -99,7 +99,7 @@ export const fetchCollection = (
  */
 export const createCollection = (token, data = {}) => {
   logger.info('Create collection');
-  return WRIAPI.post(`${process.env.WRI_API_URL}/collection`, data, {
+  return WRIAPI.post('v1/collection', data, {
     headers: {
       'Content-Type': 'application/json',
       Authorization: token,
@@ -127,7 +127,7 @@ export const createCollection = (token, data = {}) => {
  */
 export const deleteCollection = (token, collectionId) => {
   logger.info(`Delete collection ${collectionId}`);
-  return WRIAPI.delete(`collection/${collectionId}`, { headers: { Authorization: token } })
+  return WRIAPI.delete(`/v1/collection/${collectionId}`, { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
     .catch(({ response }) => {
       const { status, statusText } = response;
@@ -145,7 +145,7 @@ export const deleteCollection = (token, collectionId) => {
  */
 export const updateCollection = (token, collectionId, data) => {
   logger.info(`Update collection ${collectionId}`);
-  return WRIAPI.patch(`collection/${collectionId}`, data, {
+  return WRIAPI.patch(`/v1/collection/${collectionId}`, data, {
     headers: {
       'content-type': 'application/json',
       Authorization: token,
@@ -171,7 +171,7 @@ export const updateCollection = (token, collectionId, data) => {
 export const addResourceToCollection = (token, collectionId, resource = {}) => {
   logger.info(`Add resource to collection ${collectionId}`);
   return WRIAPI.post(
-    `collection/${collectionId}/resource`,
+    `/v1/collection/${collectionId}/resource`,
     { ...resource },
     {
       headers: {
@@ -200,7 +200,7 @@ export const addResourceToCollection = (token, collectionId, resource = {}) => {
 export const removeResourceFromCollection = (token, collectionId, resource = {}) => {
   logger.info(`Remove resource from collection ${collectionId}`);
   const { type, id } = resource;
-  return WRIAPI.delete(`collection/${collectionId}/resource/${type}/${id}`, { headers: { Authorization: token } })
+  return WRIAPI.delete(`/v1/collection/${collectionId}/resource/${type}/${id}`, { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
     .catch(({ response }) => {
       const { status, statusText } = response;

--- a/services/contact-us.js
+++ b/services/contact-us.js
@@ -10,7 +10,7 @@ import { logger } from 'utils/logs';
  */
 export const contactUs = (params) => {
   logger.info('Contact us');
-  return WRIAPI.post('contact-us', params)
+  return WRIAPI.post('/v1/contact-us', params)
     .catch(({ response }) => {
       const { status, statusText } = response;
       logger.error(`Error with contact us endpoint: ${status}: ${statusText}`);

--- a/services/dashboard.js
+++ b/services/dashboard.js
@@ -18,7 +18,7 @@ export const fetchDashboards = (params = {
   application: process.env.APPLICATIONS,
 }, headers = {}, _meta = false) => {
   logger.info('Fetch dashboards');
-  return WRIAPI.get('dashboard', {
+  return WRIAPI.get('/v1/dashboard', {
     headers: {
       ...WRIAPI.defaults.headers,
       ...headers,
@@ -54,7 +54,7 @@ export const fetchDashboards = (params = {
  */
 export const fetchDashboard = (id, params = {}) => {
   logger.info(`Fetch dashboard ${id}`);
-  return WRIAPI.get(`dashboard/${id}`, {
+  return WRIAPI.get(`/v1/dashboard/${id}`, {
     headers: {
       ...WRIAPI.defaults.headers,
       // TO-DO: forces the API to not cache, this should be removed at some point
@@ -91,7 +91,7 @@ export const fetchDashboard = (id, params = {}) => {
  */
 export const createDashboard = (body, token) => {
   logger.info('Create dashboard');
-  return WRIAPI.post('dashboard', {
+  return WRIAPI.post('/v1/dashboard', {
     data: {
       attributes: { ...body },
       application: [process.env.APPLICATIONS],
@@ -129,7 +129,7 @@ export const createDashboard = (body, token) => {
  */
 export const updateDashboard = (id, body, token) => {
   logger.info(`Updates dashboard ${id}`);
-  return WRIAPI.patch(`dashboard/${id}`,
+  return WRIAPI.patch(`/v1/dashboard/${id}`,
     { data: { attributes: { ...body } } },
     {
       headers: {
@@ -162,7 +162,7 @@ export const updateDashboard = (id, body, token) => {
  */
 export const deleteDashboard = (id, token) => {
   logger.info(`Deletes dashboard ${id}`);
-  return WRIAPI.delete(`dashboard/${id}`, {
+  return WRIAPI.delete(`/v1/dashboard/${id}`, {
     headers: {
       ...WRIAPI.defaults.headers,
       Authorization: token,
@@ -190,7 +190,7 @@ export const cloneDashboard = (dashboard, user) => {
   } = dashboard;
   logger.info(`Clones dashboard from dashboard ${id}`);
   const { token, id: userId } = user;
-  const url = `dashboard/${id}/clone`;
+  const url = `/v1/dashboard/${id}/clone`;
   const params = {
     'user-id': userId,
     data: {

--- a/services/dataset.js
+++ b/services/dataset.js
@@ -22,7 +22,7 @@ export const fetchDatasets = (params = {}, headers = {}, _meta = false) => {
     application: process.env.APPLICATIONS,
     ...params,
   };
-  return WRIAPI.get('/dataset', {
+  return WRIAPI.get('/v1/dataset', {
     headers: {
       ...WRIAPI.defaults.headers,
       // TO-DO: forces the API to not cache, this should be removed at some point
@@ -72,7 +72,7 @@ export const fetchDataset = (id, params = {}) => {
   if (!id) throw Error('dataset id is mandatory to perform this fetching.');
   logger.info(`Fetch dataset: ${id}`);
 
-  return WRIAPI.get(`/dataset/${id}`, {
+  return WRIAPI.get(`/v1/dataset/${id}`, {
     headers: {
       ...WRIAPI.defaults.headers,
       // TO-DO: forces the API to not cache, this should be removed at some point
@@ -110,7 +110,7 @@ export const fetchDataset = (id, params = {}) => {
  */
 export const fetchDatasetTags = (datasetId, params = {}) => {
   logger.info(`Fetch dataset tags: ${datasetId}`);
-  return WRIAPI.get(`dataset/${datasetId}/vocabulary`,
+  return WRIAPI.get(`/v1/dataset/${datasetId}/vocabulary`,
     {
       headers: { 'Upgrade-Insecure-Requests': 1 },
       params: { ...params },
@@ -134,7 +134,7 @@ export const fetchDatasetTags = (datasetId, params = {}) => {
 export const deleteDataset = (id, token) => {
   logger.info(`Delete dataset: ${id}`);
 
-  return WRIAPI.delete(`/dataset/${id}`, {
+  return WRIAPI.delete(`/v1/dataset/${id}`, {
     headers: {
       ...WRIAPI.defaults.headers,
       Authorization: token,
@@ -172,7 +172,7 @@ export const deleteDataset = (id, token) => {
 export const createDataset = (token, params = {}, headers) => {
   logger.info('Create dataset');
 
-  return WRIAPI.post('dataset',
+  return WRIAPI.post('/v1/dataset',
     params,
     { headers: { Authorization: token, ...headers } })
     .then((response) => WRISerializer(response.data))
@@ -195,7 +195,7 @@ export const createDataset = (token, params = {}, headers) => {
 export const updateDataset = (id, token, params = {}) => {
   logger.info(`Update dataset: ${id}`);
 
-  return WRIAPI.patch(`dataset/${id}`, params, { headers: { Authorization: token } })
+  return WRIAPI.patch(`/v1/dataset/${id}`, params, { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
     .catch(({ response }) => {
       const { status, statusText } = response;
@@ -218,7 +218,7 @@ export const updateDatasetTags = (datasetId, tags, token, usePatch = false) => {
   logger.info(`Update dataset tags: ${datasetId}`);
 
   if (usePatch) {
-    return WRIAPI.patch(`dataset/${datasetId}/vocabulary/knowledge_graph`,
+    return WRIAPI.patch(`/v1/dataset/${datasetId}/vocabulary/knowledge_graph`,
       {
         tags,
         application: process.env.APPLICATIONS,
@@ -233,7 +233,7 @@ export const updateDatasetTags = (datasetId, tags, token, usePatch = false) => {
       });
   }
   if (tags.length > 0) {
-    return WRIAPI.post(`dataset/${datasetId}/vocabulary`,
+    return WRIAPI.post(`/v1/dataset/${datasetId}/vocabulary`,
       {
         knowledge_graph: {
           tags,
@@ -249,7 +249,7 @@ export const updateDatasetTags = (datasetId, tags, token, usePatch = false) => {
         throw new Error(`Error updating dataset tags ${datasetId}: ${status}: ${statusText}`);
       });
   }
-  return WRIAPI.delete(`dataset/${datasetId}/vocabulary/knowledge_graph`,
+  return WRIAPI.delete(`/v1/dataset/${datasetId}/vocabulary/knowledge_graph`,
     {
       headers: { Authorization: token },
       params: {
@@ -277,7 +277,7 @@ export const updateDatasetTags = (datasetId, tags, token, usePatch = false) => {
 export const createMetadata = (datasetId, params = {}, token, headers = {}) => {
   logger.info(`Create metadata for dataset ${datasetId}`);
 
-  return WRIAPI.post(`dataset/${datasetId}/metadata`,
+  return WRIAPI.post(`/v1/dataset/${datasetId}/metadata`,
     params,
     {
       headers: {
@@ -306,7 +306,7 @@ export const createMetadata = (datasetId, params = {}, token, headers = {}) => {
 export const updateMetadata = (datasetId, params = {}, token, headers = {}) => {
   logger.info(`Update metadata for dataset ${datasetId}`);
 
-  return WRIAPI.patch(`dataset/${datasetId}/metadata`,
+  return WRIAPI.patch(`/v1/dataset/${datasetId}/metadata`,
     params,
     {
       headers: {

--- a/services/faqs.js
+++ b/services/faqs.js
@@ -14,7 +14,7 @@ import { logger } from 'utils/logs';
 export const fetchFaqs = (params = {}, headers = {}) => {
   logger.info('Fetch FAQs');
   return WRIAPI.get(
-    'faq',
+    '/v1/faq',
     {
       params: {
         env: process.env.API_ENV,
@@ -44,7 +44,7 @@ export const fetchFaqs = (params = {}, headers = {}) => {
 export const fetchFaq = (id, params = {}, headers = {}) => {
   logger.info(`Fetch FAQ - ${id}`);
   return WRIAPI.get(
-    `faq/${id}`,
+    `/v1/faq/${id}`,
     {
       params: {
         env: process.env.API_ENV,
@@ -73,7 +73,7 @@ export const fetchFaq = (id, params = {}, headers = {}) => {
 export const deleteFaq = (id, token, params = {}, headers = {}) => {
   logger.info(`Delete FAQ ${id}`);
   return WRIAPI.delete(
-    `faq/${id}`,
+    `/v1/faq/${id}`,
     {
       headers: {
         ...headers,
@@ -102,7 +102,7 @@ export const deleteFaq = (id, token, params = {}, headers = {}) => {
 export const updateFaq = (id, faq, token, params = {}, headers = {}) => {
   logger.info(`Update FAQ ${id}`);
   return WRIAPI.patch(
-    `faq/${id}`,
+    `/v1/faq/${id}`,
     { ...faq },
     {
       headers: {
@@ -132,7 +132,7 @@ export const updateFaq = (id, faq, token, params = {}, headers = {}) => {
 export const createFaq = (faq, token, params = {}, headers = {}) => {
   logger.info('Create FAQ');
   return WRIAPI.post(
-    'faq',
+    '/v1/faq',
     { ...faq },
     {
       headers: {
@@ -162,7 +162,7 @@ export const createFaq = (faq, token, params = {}, headers = {}) => {
 export const updateFaqOrder = (order, token, params = {}, headers = {}) => {
   logger.info('Reorder FAQ');
   return WRIAPI.post(
-    'faq/reorder',
+    '/v1/faq/reorder',
     { ...order },
     {
       headers: {

--- a/services/favourites.js
+++ b/services/favourites.js
@@ -11,7 +11,7 @@ import { logger } from 'utils/logs';
  */
 export const fetchFavourites = (token) => {
   logger.info('Fetch favorites');
-  return WRIAPI.get('favourite',
+  return WRIAPI.get('/v1/favourite',
     {
       headers: {
         Authorization: token,
@@ -39,7 +39,7 @@ export const fetchFavourites = (token) => {
  */
 export const createFavourite = (token, { resourceId, resourceType }) => {
   logger.info('Create favourite');
-  return WRIAPI.post('favourite',
+  return WRIAPI.post('/v1/favourite',
     {
       application: process.env.APPLICATIONS,
       resourceId,
@@ -62,7 +62,7 @@ export const createFavourite = (token, { resourceId, resourceType }) => {
  */
 export const deleteFavourite = (token, resourceId) => {
   logger.info(`Delete favourite ${resourceId}`);
-  return WRIAPI.delete(`/favourite/${resourceId}`,
+  return WRIAPI.delete(`/v1/favourite/${resourceId}`,
     { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
     .catch(({ response }) => {

--- a/services/geostore.js
+++ b/services/geostore.js
@@ -13,7 +13,7 @@ import { logger } from 'utils/logs';
 export const fetchGeostore = (id, params = {}) => {
   logger.info(`Fetch geostore ${id}`);
 
-  return WRIAPI.get(`geostore/${id}`, { ...params })
+  return WRIAPI.get(`/v1/geostore/${id}`, { ...params })
     .then((response) => {
       const { status, statusText, data } = response;
 
@@ -33,7 +33,7 @@ export const fetchGeostore = (id, params = {}) => {
  */
 export const createGeostore = (geojson) => {
   logger.info('Create geostore');
-  return WRIAPI.post('geostore', { geojson }, {
+  return WRIAPI.post('/v1/geostore', { geojson }, {
     transformResponse: [].concat(
       WRIAPI.defaults.transformResponse,
       (({ data }) => ({ geostore: data })),
@@ -63,7 +63,7 @@ export const createGeostore = (geojson) => {
  */
 export const fetchCountries = () => {
   logger.info('Fetch countries');
-  return WRIAPI.get('geostore/admin/list')
+  return WRIAPI.get('/v1/geostore/admin/list')
     .then((array) => array.data.data.sort((a, b) => {
       if (a.name < b.name) {
         return -1;
@@ -85,7 +85,7 @@ export const fetchCountries = () => {
  */
 export const fetchCountry = (iso) => {
   logger.info(`Fetch country: ${iso}`);
-  return WRIAPI.get(`query/134caa0a-21f7-451d-a7fe-30db31a424aa?sql=SELECT name_engli as label, st_asgeojson(the_geom_simple) as geojson, bbox as bounds from gadm28_countries WHERE iso = '${iso}'`)
+  return WRIAPI.get(`/v1/query/134caa0a-21f7-451d-a7fe-30db31a424aa?sql=SELECT name_engli as label, st_asgeojson(the_geom_simple) as geojson, bbox as bounds from gadm28_countries WHERE iso = '${iso}'`)
     .catch((response) => {
       const { status, statusText } = response;
       logger.error(`Error fetching country ${iso}: ${status}: ${statusText}`);

--- a/services/graph.js
+++ b/services/graph.js
@@ -11,7 +11,7 @@ import { logger } from 'utils/logs';
  */
 export const fetchAllTags = (params = {}) => {
   logger.info('Fetch all tags');
-  return WRIAPI.get('graph/query/list-concepts',
+  return WRIAPI.get('/v1/graph/query/list-concepts',
     {
       headers: { 'Upgrade-Insecure-Requests': 1 },
       params: {
@@ -35,7 +35,7 @@ export const fetchAllTags = (params = {}) => {
  */
 export const fetchInferredTags = (params = {}) => {
   logger.info('Fetch inferred tags');
-  return WRIAPI.get('graph/query/concepts-inferred',
+  return WRIAPI.get('/v1/graph/query/concepts-inferred',
     {
       headers: { 'Upgrade-Insecure-Requests': 1 },
       params: {
@@ -61,7 +61,7 @@ export const fetchInferredTags = (params = {}) => {
  */
 export const countDatasetView = (datasetId, token, params = {}) => {
   logger.info('Count dataset view');
-  return WRIAPI.post(`graph/dataset/${datasetId}/visited`,
+  return WRIAPI.post(`/v1/graph/dataset/${datasetId}/visited`,
     {},
     {
       headers: { Authorization: token },
@@ -86,7 +86,7 @@ export const countDatasetView = (datasetId, token, params = {}) => {
  */
 export const fetchMostViewedDatasets = (params = {}) => {
   logger.info('Fetch most viewed datasets');
-  return WRIAPI.get('graph/query/most-viewed',
+  return WRIAPI.get('/v1/graph/query/most-viewed',
     {
       params: {
         env: process.env.API_ENV,
@@ -110,7 +110,7 @@ export const fetchMostViewedDatasets = (params = {}) => {
  */
 export const fetchMostFavoritedDatasets = (params = {}) => {
   logger.info('Fetch most favorited datasets');
-  return WRIAPI.get('graph/query/most-liked-datasets',
+  return WRIAPI.get('/v1/graph/query/most-liked-datasets',
     {
       params: {
         env: process.env.API_ENV,

--- a/services/layer.js
+++ b/services/layer.js
@@ -15,7 +15,7 @@ import { logger } from 'utils/logs';
 export const fetchLayers = (params = {}, headers = {}, _meta = false) => {
   logger.info('Fetch layers');
 
-  return WRIAPI.get('/layer', {
+  return WRIAPI.get('/v1/layer', {
     headers: {
       ...WRIAPI.defaults.headers,
       // TO-DO: forces the API to not cache, this should be removed at some point
@@ -69,7 +69,7 @@ export const fetchLayer = (id, params = {}) => {
   if (!id) throw Error('layer id is mandatory to perform this fetching.');
   logger.info(`Fetches layer: ${id}`);
 
-  return WRIAPI.get(`/layer/${id}`, {
+  return WRIAPI.get(`/v1/layer/${id}`, {
     headers: {
       ...WRIAPI.defaults.headers,
       // TO-DO: forces the API to not cache, this should be removed at some point
@@ -115,7 +115,7 @@ export const fetchLayer = (id, params = {}) => {
 export const deleteLayer = (layerId, datasetId, token) => {
   logger.info(`deletes layer: ${layerId}`);
 
-  return WRIAPI.delete(`/dataset/${datasetId}/layer/${layerId}`, {
+  return WRIAPI.delete(`/v1/dataset/${datasetId}/layer/${layerId}`, {
     headers: {
       ...WRIAPI.defaults.headers,
       Authorization: token,
@@ -150,7 +150,7 @@ export const deleteLayer = (layerId, datasetId, token) => {
  */
 export const updateLayer = (layer, datasetId, token) => {
   logger.info(`Update layer: ${layer.id}`);
-  return WRIAPI.patch(`dataset/${datasetId}/layer/${layer.id}`, layer, { headers: { Authorization: token } })
+  return WRIAPI.patch(`/v1/dataset/${datasetId}/layer/${layer.id}`, layer, { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
     .catch(({ response }) => {
       const { status, statusText } = response;
@@ -169,7 +169,7 @@ export const updateLayer = (layer, datasetId, token) => {
  */
 export const createLayer = (layer, datasetId, token) => {
   logger.info('Create layer');
-  return WRIAPI.post(`dataset/${datasetId}/layer`,
+  return WRIAPI.post(`/v1/dataset/${datasetId}/layer`,
     {
       application: process.env.APPLICATIONS.split(','),
       env: process.env.API_ENV,

--- a/services/pages.js
+++ b/services/pages.js
@@ -13,7 +13,7 @@ import { logger } from 'utils/logs';
 export const fetchPages = (token, params = {}, headers = {}) => {
   logger.info('Fetch pages');
   return WRIAPI.get(
-    'static_page',
+    '/v1/static_page',
     {
       headers: {
         ...headers,
@@ -46,7 +46,7 @@ export const fetchPages = (token, params = {}, headers = {}) => {
 export const fetchPage = (id, token, params = {}, headers = {}) => {
   logger.info(`Fetch page ${id}`);
   return WRIAPI.get(
-    `static_page/${id}`,
+    `/v1/static_page/${id}`,
     {
       headers: {
         ...headers,
@@ -71,7 +71,7 @@ export const fetchPage = (id, token, params = {}, headers = {}) => {
  */
 export const updatePage = (page, token) => {
   logger.info(`Update page ${page.id}`);
-  return WRIAPI.patch(`static_page/${page.id}`,
+  return WRIAPI.patch(`/v1/static_page/${page.id}`,
     { data: { attributes: { ...page } } },
     { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
@@ -90,7 +90,7 @@ export const updatePage = (page, token) => {
  */
 export const createPage = (page, token) => {
   logger.info('Create page');
-  return WRIAPI.post('static_page',
+  return WRIAPI.post('/v1/static_page',
     {
       data: {
         application: process.env.APPLICATIONS,

--- a/services/partners.js
+++ b/services/partners.js
@@ -13,7 +13,7 @@ import { logger } from 'utils/logs';
  */
 export const fetchPartners = (params = {}, headers = {}) => {
   logger.info('Fetch partners');
-  return WRIAPI.get('partner', {
+  return WRIAPI.get('/v1/partner', {
     params: {
       ...params,
       env: process.env.API_ENV,
@@ -44,7 +44,7 @@ export const fetchPartners = (params = {}, headers = {}) => {
 export const fetchPartner = (id, params = {}, headers = {}) => {
   logger.info(`Fetch partner ${id}`);
   return WRIAPI.get(
-    `partner/${id}`,
+    `/v1/partner/${id}`,
     {
       headers: { ...headers },
       params: {
@@ -74,7 +74,7 @@ export const fetchPartner = (id, params = {}, headers = {}) => {
  */
 export const updatePartner = (id, partner, token, params = {}, headers = {}) => {
   logger.info(`Update partner ${id}`);
-  return WRIAPI.patch(`partner/${id}`,
+  return WRIAPI.patch(`/v1/partner/${id}`,
     { ...partner },
     {
       params: { ...params },
@@ -99,7 +99,7 @@ export const updatePartner = (id, partner, token, params = {}, headers = {}) => 
  */
 export const createPartner = (partner, token, params = {}, headers = {}) => {
   logger.info('Create partner');
-  return WRIAPI.post('partner',
+  return WRIAPI.post('/v1/partner',
     { ...partner },
     {
       params: {
@@ -128,7 +128,7 @@ export const createPartner = (partner, token, params = {}, headers = {}) => {
 export const deletePartner = (id, token, params = {}, headers = {}) => {
   logger.info(`Delete partner ${id}`);
   return WRIAPI.delete(
-    `partner/${id}`,
+    `/v1/partner/${id}`,
     {
       params: {
         ...params,

--- a/services/query.js
+++ b/services/query.js
@@ -17,7 +17,7 @@ export const fetchQuery = (token, sql, params = {}) => {
     return null;
   }
 
-  return WRIAPI.get('query', {
+  return WRIAPI.get('/v1/query', {
     headers: {
       ...WRIAPI.defaults.headers,
       Authorization: token,

--- a/services/raster.js
+++ b/services/raster.js
@@ -26,9 +26,8 @@ export default class RasterService {
     }
 
     return fetch(
-      `${process.env.WRI_API_URL}/query/${this.dataset}?sql=${query}`,
+      `${process.env.WRI_API_URL}/v1/query/${this.dataset}?sql=${query}`,
       { headers: { 'Upgrade-Insecure-Requests': 1 } },
-
     )
       .then((response) => {
         if (!response.ok) throw new Error('Unable to fetch the band names');
@@ -37,7 +36,8 @@ export default class RasterService {
       .then(({ data }) => {
         if (this.provider === 'gee') {
           return data[0].bands.map((b) => b.id);
-        } if (this.provider === 'cartodb') {
+        }
+        if (this.provider === 'cartodb') {
           return Array.from({ length: data[0].numbands }, (_, i) => `${i + 1}`);
         }
 
@@ -73,7 +73,6 @@ export default class RasterService {
       return fetch(
         `https://api.resourcewatch.org/v1/query/${this.dataset}?sql=${query}`,
         { headers: { 'Upgrade-Insecure-Requests': 1 } },
-
       )
         .then((res) => {
           if (!res.ok) reject();
@@ -83,6 +82,8 @@ export default class RasterService {
           if (this.provider === 'gee') {
             // We cache the data because the information of all the
             // bands comes at once
+
+            // eslint-disable-next-line prefer-destructuring
             this.geeBandStatInfo = data.data[0];
 
             resolve(this.geeBandStatInfo[bandName]);

--- a/services/static-page.js
+++ b/services/static-page.js
@@ -10,7 +10,7 @@ import WRISerializer from 'wri-json-api-serializer';
  * @returns {Object[]} page content serialized.
  */
 
-export const fetchStaticPage = (id) => WRIAPI.get(`/static_page/${id}`)
+export const fetchStaticPage = (id) => WRIAPI.get(`/v1/static_page/${id}`)
   .then((response) => {
     const { status, statusText, data } = response;
     if (status >= 400) throw new Error(statusText);

--- a/services/subscriptions.js
+++ b/services/subscriptions.js
@@ -12,7 +12,7 @@ import { logger } from 'utils/logs';
  */
 export const fetchSubscriptions = (token, params) => {
   logger.info('Fetch subscriptions');
-  return WRIAPI.get('subscriptions', {
+  return WRIAPI.get('/v1/subscriptions', {
     headers: {
       ...WRIAPI.defaults.headers,
       Authorization: token,
@@ -68,7 +68,7 @@ export const createSubscriptionToArea = ({
     params: { area: areaId },
   };
 
-  return WRIAPI.post('subscriptions',
+  return WRIAPI.post('/v1/subscriptions',
     bodyObj,
     { headers: { Authorization: user.token } })
     .catch(({ response }) => {
@@ -110,7 +110,7 @@ export const updateSubscriptionToArea = (
     params: { area: areaId },
   };
 
-  return WRIAPI.patch(`subscriptions/${subscriptionId}`,
+  return WRIAPI.patch(`/v1/subscriptions/${subscriptionId}`,
     bodyObj,
     { headers: { Authorization: user.token } })
     .catch(({ response }) => {
@@ -128,7 +128,7 @@ export const updateSubscriptionToArea = (
  */
 export const fetchSubscription = (subscriptionId, token) => {
   logger.info(`Fetch subscription: ${subscriptionId}`);
-  return WRIAPI.get(`subscriptions/${subscriptionId}?application=${process.env.APPLICATIONS}&env=${process.env.API_ENV}`,
+  return WRIAPI.get(`/v1/subscriptions/${subscriptionId}?application=${process.env.APPLICATIONS}&env=${process.env.API_ENV}`,
     { headers: { Authorization: token } })
     .then((response) => response.data)
     .catch(({ response }) => {
@@ -147,7 +147,7 @@ export const fetchSubscription = (subscriptionId, token) => {
  */
 export const deleteSubscription = (subscriptionId, token) => {
   logger.info(`Delete subscription: ${subscriptionId}`);
-  return WRIAPI.delete(`subscriptions/${subscriptionId}`,
+  return WRIAPI.delete(`/v1/subscriptions/${subscriptionId}`,
     { headers: { Authorization: token } })
     .catch(({ response }) => {
       const { status, statusText } = response;

--- a/services/tools.js
+++ b/services/tools.js
@@ -13,7 +13,7 @@ import { logger } from 'utils/logs';
 export const fetchTools = (token, params = {}, headers = {}) => {
   logger.info('Fetch tools');
   return WRIAPI.get(
-    'tool',
+    '/v1/tool',
     {
       headers: {
         ...headers,
@@ -46,7 +46,7 @@ export const fetchTools = (token, params = {}, headers = {}) => {
 export const fetchTool = (id, token, params = {}, headers = {}) => {
   logger.info(`Fetch tool ${id}`);
   return WRIAPI.get(
-    `tool/${id}`,
+    `/v1/tool/${id}`,
     {
       headers: {
         ...headers,
@@ -71,7 +71,7 @@ export const fetchTool = (id, token, params = {}, headers = {}) => {
  */
 export const updateTool = (tool, token) => {
   logger.info(`Update tool ${tool.id}`);
-  return WRIAPI.patch(`tool/${tool.id}`,
+  return WRIAPI.patch(`/v1/tool/${tool.id}`,
     { data: { attributes: { ...tool } } },
     { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
@@ -90,7 +90,7 @@ export const updateTool = (tool, token) => {
  */
 export const createTool = (tool, token) => {
   logger.info('Create tool');
-  return WRIAPI.post('tool',
+  return WRIAPI.post('/v1/tool',
     {
       data: {
         application: process.env.APPLICATIONS,
@@ -118,7 +118,7 @@ export const createTool = (tool, token) => {
 export const deleteTool = (id, token, params = {}, headers = {}) => {
   logger.info(`Delete tool ${id}`);
   return WRIAPI.delete(
-    `tool/${id}`,
+    `/v1/tool/${id}`,
     {
       headers: {
         ...headers,

--- a/services/user.js
+++ b/services/user.js
@@ -106,7 +106,7 @@ export const uploadPhoto = (file, user) => new Promise((resolve, reject) => {
       },
     };
 
-    return fetch(`${process.env.WRI_API_URL}/profile`, {
+    return fetch(`${process.env.WRI_API_URL}/v1/profile`, {
       method: 'POST',
       body: JSON.stringify(bodyObj),
       headers: {

--- a/services/widget.js
+++ b/services/widget.js
@@ -14,7 +14,7 @@ import { logger } from 'utils/logs';
  */
 export const fetchWidgets = (params = {}, headers = {}, _meta = false) => {
   logger.info('fetches widgets');
-  return WRIAPI.get('widget', {
+  return WRIAPI.get('/v1/widget', {
     headers: {
       ...WRIAPI.defaults.headers,
       // TO-DO: forces the API to not cache, this should be removed at some point
@@ -66,7 +66,7 @@ export const fetchWidget = (id, params = {}) => {
   if (!id) throw Error('The widget id is mandatory to perform this request (fetchWidget).');
   logger.info(`Fetch widget: ${id}`);
 
-  return WRIAPI.get(`widget/${id}`, {
+  return WRIAPI.get(`/v1/widget/${id}`, {
     headers: {
       ...WRIAPI.defaults.headers,
       // TO-DO: forces the API to not cache, this should be removed at some point
@@ -110,7 +110,7 @@ export const fetchWidget = (id, params = {}) => {
 export const deleteWidget = (widgetId, datasetId, token) => {
   logger.info(`Delete widget: ${widgetId}`);
 
-  return WRIAPI.delete(`dataset/${datasetId}/widget/${widgetId}`, {
+  return WRIAPI.delete(`/v1/dataset/${datasetId}/widget/${widgetId}`, {
     headers: {
       ...WRIAPI.defaults.headers,
       Authorization: token,
@@ -145,7 +145,7 @@ export const deleteWidget = (widgetId, datasetId, token) => {
  */
 export const updateWidget = (widget, token) => {
   logger.info(`Update widget: ${widget.id}`);
-  return WRIAPI.patch(`widget/${widget.id}`, widget, { headers: { Authorization: token } })
+  return WRIAPI.patch(`/v1/widget/${widget.id}`, widget, { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
     .catch(({ response }) => {
       const { status, statusText } = response;
@@ -163,7 +163,7 @@ export const updateWidget = (widget, token) => {
  */
 export const createWidget = (widget, datasetId, token) => {
   logger.info('Create widget');
-  return WRIAPI.post(`dataset/${datasetId}/widget`,
+  return WRIAPI.post(`/v1/dataset/${datasetId}/widget`,
     {
       application: process.env.APPLICATIONS.split(','),
       env: process.env.API_ENV,
@@ -188,7 +188,7 @@ export const createWidget = (widget, datasetId, token) => {
  */
 export const fetchWidgetMetadata = (widgetId, datasetId, token, params = {}) => {
   logger.info(`Update widget metadata: ${widgetId}`);
-  return WRIAPI.fetch(`dataset/${datasetId}/widget/${widgetId}/metadata`,
+  return WRIAPI.fetch(`/v1/dataset/${datasetId}/widget/${widgetId}/metadata`,
     {
       headers: { Authorization: token },
       params: {
@@ -215,7 +215,7 @@ export const fetchWidgetMetadata = (widgetId, datasetId, token, params = {}) => 
  */
 export const updateWidgetMetadata = (widgetId, datasetId, metadata, token) => {
   logger.info(`Update widget metadata: ${widgetId}`);
-  return WRIAPI.patch(`dataset/${datasetId}/widget/${widgetId}/metadata`,
+  return WRIAPI.patch(`/v1/dataset/${datasetId}/widget/${widgetId}/metadata`,
     metadata,
     { headers: { Authorization: token } })
     .then((response) => WRISerializer(response.data))
@@ -236,7 +236,7 @@ export const updateWidgetMetadata = (widgetId, datasetId, metadata, token) => {
  */
 export const createWidgetMetadata = (widgetId, datasetId, metadata, token) => {
   logger.info(`Update widget metadata: ${widgetId}`);
-  return WRIAPI.post(`dataset/${datasetId}/widget/${widgetId}/metadata`,
+  return WRIAPI.post(`/v1/dataset/${datasetId}/widget/${widgetId}/metadata`,
     {
       ...metadata,
       application: process.env.APPLICATIONS,

--- a/utils/areas.js
+++ b/utils/areas.js
@@ -2,7 +2,7 @@ export const convertToJSON = (file) => {
   const formData = new FormData();
   formData.append('file', file);
 
-  return fetch(`${process.env.WRI_API_URL}/ogr/convert`, {
+  return fetch(`${process.env.WRI_API_URL}/v1/ogr/convert`, {
     method: 'POST',
     body: formData,
     multipart: true,
@@ -51,7 +51,7 @@ export const processFile = async (file) => new Promise((resolve, reject) => {
   }
 })
   // Second: we store it in the geostore
-  .then((geojson) => fetch(`${process.env.WRI_API_URL}/geostore`, {
+  .then((geojson) => fetch(`${process.env.WRI_API_URL}/v1/geostore`, {
     method: 'POST',
     headers: new Headers({ 'content-type': 'application/json' }),
     body: JSON.stringify({ geojson }),

--- a/utils/axios.js
+++ b/utils/axios.js
@@ -5,11 +5,6 @@ export const WRIAPI = axios.create({
   headers: { 'Content-Type': 'application/json' },
 });
 
-export const WRIAPI_V2 = axios.create({
-  baseURL: process.env.WRI_API_URL_V2,
-  headers: { 'Content-Type': 'application/json' },
-});
-
 export const blogAPI = axios.create({
   baseURL: process.env.BLOG_API_URL,
   headers: { 'Content-Type': 'application/json' },

--- a/utils/fields.js
+++ b/utils/fields.js
@@ -8,14 +8,14 @@ export const getFieldUrl = ({
 
   switch (`${provider}-${type}`) {
     case 'cartodb-raster':
-      url = `${process.env.WRI_API_URL}/query/${id}?sql=select (ST_METADATA(st_union(the_raster_webmercator))).* from ${tableName}`;
+      url = `${process.env.WRI_API_URL}/v1/query/${id}?sql=select (ST_METADATA(st_union(the_raster_webmercator))).* from ${tableName}`;
       break;
     case 'gee-raster': {
-      url = `${process.env.WRI_API_URL}/query/${id}?sql=select ST_METADATA(rast) from "${tableName}"`;
+      url = `${process.env.WRI_API_URL}/v1/query/${id}?sql=select ST_METADATA(rast) from "${tableName}"`;
       break;
     }
     default:
-      url = `${process.env.WRI_API_URL}/fields/${id}`;
+      url = `${process.env.WRI_API_URL}/v1/fields/${id}`;
   }
 
   return url;

--- a/utils/layers/LayerGlobeManager.js
+++ b/utils/layers/LayerGlobeManager.js
@@ -12,8 +12,8 @@ export default class LayerGlobeManager {
   addLayer(layer, opts = {}, awaitMode = false) {
     const method = {
       cartodb: this.addCartoLayer,
-      leaflet: this.addLeafletLayer,
-      gee: this.addGeeLayer,
+      leaflet: LayerGlobeManager.addLeafletLayer,
+      gee: LayerGlobeManager.addGeeLayer,
     }[layer.provider];
 
     // Check for active request to prevent adding more than one layer at a time
@@ -37,7 +37,7 @@ export default class LayerGlobeManager {
     }
   }
 
-  addLeafletLayer(layerSpec, opts) {
+  static addLeafletLayer(layerSpec, opts) {
     opts.onLayerAddedSuccess({
       attributes: { ...layerSpec },
       url: layerSpec.layerConfig.url,
@@ -45,10 +45,10 @@ export default class LayerGlobeManager {
     });
   }
 
-  addGeeLayer(layerSpec, opts) {
+  static addGeeLayer(layerSpec, opts) {
     opts.onLayerAddedSuccess({
       attributes: { ...layerSpec },
-      url: `${process.env.WRI_API_URL}/layer/${layerSpec.id}/tile/gee/{z}/{x}/{y}`,
+      url: `${process.env.WRI_API_URL}/v1/layer/${layerSpec.id}/tile/gee/{z}/{x}/{y}`,
       active: false,
     });
   }

--- a/utils/layers/LayerManager.js
+++ b/utils/layers/LayerManager.js
@@ -131,7 +131,7 @@ export default class LayerManager {
   }
 
   addNexGDDPLayer(layer) {
-    const tileUrl = `${process.env.WRI_API_URL}/layer/${layer.id}/tile/nexgddp/{z}/{x}/{y}`;
+    const tileUrl = `${process.env.WRI_API_URL}/v1/layer/${layer.id}/tile/nexgddp/{z}/{x}/{y}`;
     const tileLayer = L.tileLayer(tileUrl).addTo(this.map);
     this.mapLayers[layer.id] = tileLayer;
 
@@ -141,7 +141,7 @@ export default class LayerManager {
   }
 
   addGeeLayer(layer) {
-    const tileUrl = `${process.env.WRI_API_URL}/layer/${layer.id}/tile/gee/{z}/{x}/{y}`;
+    const tileUrl = `${process.env.WRI_API_URL}/v1/layer/${layer.id}/tile/gee/{z}/{x}/{y}`;
     const tileLayer = L.tileLayer(tileUrl).addTo(this.map);
     this.mapLayers[layer.id] = tileLayer;
 

--- a/utils/widget-editor.js
+++ b/utils/widget-editor.js
@@ -8,7 +8,7 @@ const getUserToken = (state) => state.user.token;
 export const getRWAdapter = createSelector(
   [getLocale, getUserToken],
   (locale, userToken) => AdapterModifier(RWAdapter, {
-    endpoint: process.env.WRI_API_URL,
+    endpoint: `${process.env.WRI_API_URL}/v1`,
     env: process.env.API_ENV,
     applications: process.env.APPLICATIONS.split(','),
     locale,


### PR DESCRIPTION
## Overview
Replaces staging API URL: `staging-api.globalforestwatch.org` to `staging-api.resourcewatch.org`

## Testing instructions
–

## Pivotal task
–

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
