### PR TITLE
fixes issue populating open graph tags in dashboards pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 
 .nyc_output
 coverage
+coverage.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - renamed some internal folders called `pages` to `tabs` as they were giving some issues with the new Node version.
 
 ### Fixed
+- fixed issue with Twitter card attributes in dashboards. [#177007206](https://www.pivotaltracker.com/story/show/177007206)
 
 ### Removed
 - user token from tools endpoint.

--- a/layout/app/dashboard-detail/component.jsx
+++ b/layout/app/dashboard-detail/component.jsx
@@ -16,7 +16,6 @@ import compact from 'lodash/compact';
 import Layout from 'layout/layout/layout-app';
 import Tabs from 'components/ui/Tabs';
 import Breadcrumbs from 'components/ui/Breadcrumbs';
-import Spinner from 'components/ui/Spinner';
 import Title from 'components/ui/Title';
 import Icon from 'components/ui/icon';
 import DashboardDetail from 'components/dashboards/detail';
@@ -35,14 +34,8 @@ import { fetchCountryPowerExplorerConfig } from 'services/config';
 import { ENERGY_TABS } from './constants';
 
 const LayoutDashboardDetail = ({
-  dashboardState,
+  dashboard,
 }) => {
-  const {
-    data: dashboard,
-    isSuccess,
-    isFetching,
-    isFetchedAfterMount,
-  } = dashboardState;
   const {
     name,
     summary,
@@ -162,11 +155,10 @@ const LayoutDashboardDetail = ({
                   },
                 ]}
                 />
-                <h1>
-                  {(!isFetchedAfterMount && isFetching) && 'Loading...'}
-                  {(isFetchedAfterMount && isSuccess) && name}
-                </h1>
-                {(isFetchedAfterMount && isSuccess && headerText) && (<h3>{headerText}</h3>)}
+                <h1>{name}</h1>
+                {headerText && (
+                  <h3>{headerText}</h3>
+                )}
                 <div className="page-header-info">
                   <ul>
                     <li>
@@ -216,20 +208,9 @@ const LayoutDashboardDetail = ({
         </div>
       </header>
 
-      {!isFetchedAfterMount && (
-        <div className="l-section">
-          <div className="l-container">
-            <Spinner
-              className="-center -transparent"
-              isLoading
-            />
-          </div>
-        </div>
-      )}
+      {(isEnergyDashboard && tab === 'country') && (<EnergyCountryExplorer />)}
 
-      {((isFetchedAfterMount && isSuccess) && isEnergyDashboard && tab === 'country') && (<EnergyCountryExplorer />)}
-
-      {((isFetchedAfterMount && isSuccess) && (!isEnergyDashboard || (isEnergyDashboard && tab !== 'country'))) && (
+      {((!isEnergyDashboard || (isEnergyDashboard && tab !== 'country'))) && (
         <div className="l-section">
           <div className="l-container">
             <div className="row">
@@ -246,7 +227,7 @@ const LayoutDashboardDetail = ({
         </div>
       )}
 
-      {(isFetchedAfterMount && datasets.length > 0) && (
+      {(datasets.length > 0) && (
         <div className="l-section">
           <div className="l-container">
             <div className="row">
@@ -268,10 +249,12 @@ const LayoutDashboardDetail = ({
 };
 
 LayoutDashboardDetail.propTypes = {
-  dashboardState: PropTypes.shape({
-    data: PropTypes.shape({}).isRequired,
-    isFetchedAfterMount: PropTypes.bool.isRequired,
-    isSuccess: PropTypes.bool.isRequired,
+  dashboard: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    summary: PropTypes.string,
+    description: PropTypes.string,
+    slug: PropTypes.string.isRequired,
+    content: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/pages/app/dashboards-detail/index.jsx
+++ b/pages/app/dashboards-detail/index.jsx
@@ -1,34 +1,39 @@
 import React from 'react';
-import { useRouter } from 'next/router';
+import PropTypes from 'prop-types';
 
 // components
 import LayoutDashboardDetail from 'layout/app/dashboard-detail';
 
-// hooks
-import useFetchDashboard from 'hooks/dashboard/fetch-dashboard';
+// services
+import {
+  fetchDashboard,
+} from 'services/dashboard';
 
-const DashboardsDetailPage = () => {
+const DashboardsDetailPage = ({
+  dashboard,
+}) => (
+  <LayoutDashboardDetail
+    dashboard={dashboard}
+  />
+);
+
+// getInitialProps is used to improve SEO of these pages.
+// TO-DO: replace with getStaticProps eventually
+DashboardsDetailPage.getInitialProps = async (ctx) => {
   const {
     query: {
       slug,
     },
-  } = useRouter();
+  } = ctx;
+  const dashboard = await fetchDashboard(slug);
 
-  const dashboardState = useFetchDashboard(
-    slug,
-    {},
-    {
-      enabled: slug,
-      initialData: {},
-      initialStale: true,
-    },
-  );
+  return ({
+    dashboard,
+  });
+};
 
-  return (
-    <LayoutDashboardDetail
-      dashboardState={dashboardState}
-    />
-  );
+DashboardsDetailPage.propTypes = {
+  dashboard: PropTypes.shape({}).isRequired,
 };
 
 export default DashboardsDetailPage;


### PR DESCRIPTION
## Overview
Fixes issue populating open graph tags in dashboards pages. 
Moved dashboard load to the server to help with SEO.

## Testing instructions
–

## Pivotal task
https://www.pivotaltracker.com/story/show/177007206

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
