### PR TITLE
fixed issue with user areas overlapping with dataset detail view in E…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - renamed some internal folders called `pages` to `tabs` as they were giving some issues with the new Node version.
 
 ### Fixed
+- fixed issue with user areas overlapping with dataset detail view in Explore page.
 - fixed issue with Twitter card attributes in dashboards. [#177007206](https://www.pivotaltracker.com/story/show/177007206)
 
 ### Removed

--- a/layout/explore/component.jsx
+++ b/layout/explore/component.jsx
@@ -27,12 +27,14 @@ import ExploreDiscover from 'layout/explore/explore-discover';
 import ExploreNearRealTime from 'layout/explore/explore-near-real-time';
 import ExploreFavorites from 'layout/explore/explore-favorites';
 
-// constants
-import { EXPLORE_SUBSECTIONS } from 'layout/explore/constants';
-
 // utils
 import { breakpoints } from 'utils/responsive';
-import { EXPLORE_SECTIONS } from './constants';
+
+// constants
+import {
+  EXPLORE_SECTIONS,
+  EXPLORE_SUBSECTIONS,
+} from './constants';
 
 function Explore(props) {
   const {
@@ -57,7 +59,7 @@ function Explore(props) {
 
   const getSidebarLayout = () => (
     <>
-      {!subsection && (
+      {(!subsection && !selected) && (
         <>
           <ExploreMenu />
           <div
@@ -98,7 +100,9 @@ function Explore(props) {
           onDatasetLoaded={(_dataset) => setDataset(_dataset)}
         />
       )}
-      {subsection === EXPLORE_SUBSECTIONS.NEW_AREA && (<ExploreAreasOfInterestNewArea />)}
+      {(!selected && subsection === EXPLORE_SUBSECTIONS.NEW_AREA) && (
+        <ExploreAreasOfInterestNewArea />
+      )}
     </>
   );
 


### PR DESCRIPTION
## Overview
Fixes an issue with user areas overlapping with dataset detail view in Explore page.

![image](https://user-images.githubusercontent.com/999124/109647283-644ce980-7b59-11eb-981b-f42cf70bac68.png)


## Testing instructions
- Active a layer in the map,
-  go to `Areas of Interest` section,
- click on "info" button in the map legend.

## Pivotal task
–

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
