### PR TITLE
fixes embed powered by in external sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - renamed some internal folders called `pages` to `tabs` as they were giving some issues with the new Node version.
 
 ### Fixed
+- fixed issue where the "Powered By Resource Watch" logo in embeds didn't appear in external sites.
 - fixed issue with user areas overlapping with dataset detail view in Explore page.
 - fixed issue with Twitter card attributes in dashboards. [#177007206](https://www.pivotaltracker.com/story/show/177007206)
 

--- a/layout/embed/dataset/component.jsx
+++ b/layout/embed/dataset/component.jsx
@@ -17,42 +17,45 @@ import { fetchDataset } from 'services/dataset';
 import { isLoadedExternally } from 'utils/embed';
 
 class LayoutEmbedDataset extends PureComponent {
-  static propTypes = {
-    routes: PropTypes.object.isRequired,
-    referer: PropTypes.string.isRequired,
-    RWAdapter: PropTypes.func.isRequired,
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      dataset: null,
+      loadingDataset: true,
+    };
   }
 
-  state = {
-    dataset: null,
-    loadingWidget: true,
-    loadingDataset: true,
-  }
-
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
-    fetchDataset(this.props.routes.query.id, { includes: 'widget, metadata' })
+    const {
+      routes: {
+        query: {
+          id,
+        },
+      },
+    } = this.props;
+    fetchDataset(id, { includes: 'widget, metadata' })
       .then((data) => this.setState({
         dataset: data,
         loadingDataset: false,
       }));
   }
 
-  triggerToggleLoading = () => { this.setState({ loadingWidget: false }); }
-
   render() {
-    const { referer, RWAdapter } = this.props;
-    const { dataset, loadingDataset, loadingWidget } = this.state;
-    const widgets = dataset && dataset.attributes.widget;
-    const metadataObj = dataset && dataset.attributes.metadata[0];
-    const datasetName = metadataObj && metadataObj.attributes.info
-      ? metadataObj.attributes.info.name : dataset && dataset.attributes.name;
-    const datasetDescription = metadataObj && metadataObj.attributes
-      ? metadataObj.attributes.description : dataset && dataset.attributes.description;
-    const isExternal = isLoadedExternally(referer);
+    const { RWAdapter } = this.props;
+    const { dataset, loadingDataset } = this.state;
+    const widgets = dataset && dataset.widget;
+    const metadataObj = dataset && dataset.metadata[0];
+    const datasetName = metadataObj && metadataObj.info
+      ? metadataObj.info.name : dataset && dataset.name;
+    const datasetDescription = metadataObj && metadataObj
+      ? metadataObj.description : dataset && dataset.description;
+    const isExternal = isLoadedExternally();
     let widget = null;
 
     if (widgets) {
-      widget = widgets.find((value) => value.attributes.default === true);
+      widget = widgets.find((value) => value.default === true);
     }
 
     if (loadingDataset) {
@@ -87,7 +90,7 @@ class LayoutEmbedDataset extends PureComponent {
               </div>
             </ErrorBoundary>
           )}
-          <Spinner isLoading={loadingWidget} className="-light -relative" />
+          <Spinner isLoading={loadingDataset} className="-light -relative" />
           <div className="info">
             <div className="widget-title">
               <h2>
@@ -120,5 +123,14 @@ class LayoutEmbedDataset extends PureComponent {
     );
   }
 }
+
+LayoutEmbedDataset.propTypes = {
+  routes: PropTypes.shape({
+    query: PropTypes.shape({
+      id: PropTypes.string,
+    }),
+  }).isRequired,
+  RWAdapter: PropTypes.func.isRequired,
+};
 
 export default LayoutEmbedDataset;

--- a/layout/embed/embed/component.jsx
+++ b/layout/embed/embed/component.jsx
@@ -10,26 +10,13 @@ import Icon from 'components/ui/icon';
 import { isLoadedExternally } from 'utils/embed';
 
 class LayoutEmbedEmbed extends PureComponent {
-  static propTypes = {
-    widget: PropTypes.object.isRequired,
-    loading: PropTypes.bool.isRequired,
-    error: PropTypes.string,
-    favourited: PropTypes.bool.isRequired,
-    url: PropTypes.object.isRequired,
-    user: PropTypes.object.isRequired,
-    referer: PropTypes.string,
-    getWidget: PropTypes.func.isRequired,
-    checkIfFavorited: PropTypes.func.isRequired,
-    setIfFavorited: PropTypes.func.isRequired,
-  };
+  constructor(props) {
+    super(props);
 
-  static defaultProps = {
-    referer: '',
-    error: null,
+    this.state = { modalOpened: false };
   }
 
-  state = { modalOpened: false }
-
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
     const {
       url,
@@ -68,11 +55,11 @@ class LayoutEmbedEmbed extends PureComponent {
       error,
       favourited,
       user,
-      referer,
+      setIfFavorited,
     } = this.props;
     const { modalOpened } = this.state;
     const favouriteIcon = favourited ? 'star-full' : 'star-empty';
-    const isExternal = isLoadedExternally(referer);
+    const isExternal = isLoadedExternally();
     const {
       name,
       description,
@@ -143,7 +130,7 @@ class LayoutEmbedEmbed extends PureComponent {
               {
                 user.id && (
                   <button
-                    onClick={() => this.props.setIfFavorited(id, !this.props.favourited)}
+                    onClick={() => { setIfFavorited(id, !favourited); }}
                   >
                     <Icon
                       name={`icon-${favouriteIcon}`}
@@ -194,5 +181,35 @@ class LayoutEmbedEmbed extends PureComponent {
     );
   }
 }
+
+LayoutEmbedEmbed.defaultProps = {
+  error: null,
+};
+
+LayoutEmbedEmbed.propTypes = {
+  widget: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    description: PropTypes.string,
+    dataset: PropTypes.string,
+    widgetConfig: PropTypes.shape({
+      url: PropTypes.string,
+    }),
+  }).isRequired,
+  loading: PropTypes.bool.isRequired,
+  error: PropTypes.string,
+  favourited: PropTypes.bool.isRequired,
+  url: PropTypes.shape({
+    query: PropTypes.shape({
+      id: PropTypes.string,
+    }),
+  }).isRequired,
+  user: PropTypes.shape({
+    id: PropTypes.string,
+  }).isRequired,
+  getWidget: PropTypes.func.isRequired,
+  checkIfFavorited: PropTypes.func.isRequired,
+  setIfFavorited: PropTypes.func.isRequired,
+};
 
 export default LayoutEmbedEmbed;

--- a/layout/embed/map/component.jsx
+++ b/layout/embed/map/component.jsx
@@ -297,7 +297,7 @@ const LayoutEmbedMap = (props) => {
   } = mapState;
   const { pitch, bearing } = viewport;
   const favoriteIcon = isFavorite ? 'star-full' : 'star-empty';
-  const isExternal = typeof window !== 'undefined' ? isLoadedExternally(window?.location?.href) : false;
+  const isExternal = isLoadedExternally();
   const resetViewBtnClass = classnames({
     '-with-transition': true,
     '-visible': pitch !== 0 || bearing !== 0,

--- a/layout/embed/table/component.jsx
+++ b/layout/embed/table/component.jsx
@@ -10,22 +10,16 @@ import Spinner from 'components/ui/Spinner';
 import { isLoadedExternally } from 'utils/embed';
 
 class LayoutEmbedTable extends PureComponent {
-  static propTypes = {
-    isLoading: PropTypes.bool,
-    referer: PropTypes.string,
-    routes: PropTypes.object.isRequired,
-  };
+  constructor(props) {
+    super(props);
 
-  static defaultProps = {
-    isLoading: true,
-    referer: '',
-  };
+    this.state = {
+      isLoading: props.isLoading,
+      tableData: [],
+    };
+  }
 
-  state = {
-    isLoading: this.props.isLoading,
-    tableData: [],
-  };
-
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
     const { routes: { query: { queryURL } } } = this.props;
 
@@ -41,19 +35,18 @@ class LayoutEmbedTable extends PureComponent {
           tableData: response.data,
         });
       })
-      .catch((error) => { console.error(error); })
+      .catch(() => {})
       .then(() => { this.setState({ isLoading: false }); });
   }
 
   render() {
-    const { referer } = this.props;
     const {
       isLoading,
       tableData,
     } = this.state;
 
     const header = tableData && tableData.length > 0 && Object.keys(tableData[0]);
-    const isExternal = isLoadedExternally(referer);
+    const isExternal = isLoadedExternally();
 
     if (isEmpty(tableData)) {
       return (
@@ -89,6 +82,7 @@ class LayoutEmbedTable extends PureComponent {
                   <tbody>
                     {(tableData || []).map((row, i) => (
                       <tr
+                        // eslint-disable-next-line react/no-array-index-key
                         key={`row${i}`}
                       >
                         {Object.keys(row).map((column) => (<td key={`td${column}`}>{row[column]}</td>))}
@@ -114,5 +108,18 @@ class LayoutEmbedTable extends PureComponent {
     );
   }
 }
+
+LayoutEmbedTable.defaultProps = {
+  isLoading: true,
+};
+
+LayoutEmbedTable.propTypes = {
+  isLoading: PropTypes.bool,
+  routes: PropTypes.shape({
+    query: PropTypes.shape({
+      queryURL: PropTypes.string,
+    }),
+  }).isRequired,
+};
 
 export default LayoutEmbedTable;

--- a/layout/embed/text/component.jsx
+++ b/layout/embed/text/component.jsx
@@ -10,18 +10,13 @@ import Spinner from 'components/ui/Spinner';
 import { isLoadedExternally } from 'utils/embed';
 
 class LayoutEmbedText extends PureComponent {
-  static propTypes = {
-    widget: PropTypes.object.isRequired,
-    loading: PropTypes.bool.isRequired,
-    routes: PropTypes.object.isRequired,
-    referer: PropTypes.string,
-    getWidget: PropTypes.func.isRequired,
-  };
+  constructor(props) {
+    super(props);
 
-  static defaultProps = { referer: '' }
+    this.state = { isLoading: props.loading };
+  }
 
-  state = { isLoading: this.props.loading };
-
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
     const {
       getWidget,
@@ -36,9 +31,9 @@ class LayoutEmbedText extends PureComponent {
   }
 
   render() {
-    const { widget, referer, loading } = this.props;
+    const { widget, loading } = this.props;
     const { isLoading } = this.state;
-    const isExternal = isLoadedExternally(referer);
+    const isExternal = isLoadedExternally();
     const {
       name,
       description,
@@ -92,5 +87,20 @@ class LayoutEmbedText extends PureComponent {
     );
   }
 }
+
+LayoutEmbedText.propTypes = {
+  widget: PropTypes.shape({
+    name: PropTypes.string,
+    description: PropTypes.string,
+    widgetConfig: PropTypes.shape({}),
+  }).isRequired,
+  loading: PropTypes.bool.isRequired,
+  routes: PropTypes.shape({
+    query: PropTypes.shape({
+      id: PropTypes.string,
+    }),
+  }).isRequired,
+  getWidget: PropTypes.func.isRequired,
+};
 
 export default LayoutEmbedText;

--- a/layout/embed/widget/component.jsx
+++ b/layout/embed/widget/component.jsx
@@ -15,28 +15,13 @@ import { logEvent } from 'utils/analytics';
 import { isLoadedExternally } from 'utils/embed';
 
 class LayoutEmbedWidget extends PureComponent {
-  static propTypes = {
-    widget: PropTypes.object.isRequired,
-    bandDescription: PropTypes.string,
-    bandStats: PropTypes.object.isRequired,
-    error: PropTypes.string,
-    favourited: PropTypes.bool.isRequired,
-    user: PropTypes.object.isRequired,
-    webshot: PropTypes.bool.isRequired,
-    referer: PropTypes.string,
-    setIfFavorited: PropTypes.func.isRequired,
-    RWAdapter: PropTypes.func.isRequired,
-  };
+  constructor(props) {
+    super(props);
 
-  static defaultProps = {
-    bandDescription: null,
-    error: null,
-    referer: '',
-  }
-
-  state = {
-    modalOpened: false,
-    shareWidget: null,
+    this.state = {
+      modalOpened: false,
+      shareWidget: null,
+    };
   }
 
   getModal() {
@@ -123,16 +108,19 @@ class LayoutEmbedWidget extends PureComponent {
       favourited,
       user,
       webshot,
-      referer,
       RWAdapter,
+      setIfFavorited,
     } = this.props;
-    const { modalOpened } = this.state;
+    const {
+      modalOpened,
+      shareWidget,
+    } = this.state;
     const favouriteIcon = favourited ? 'star-full' : 'star-empty';
     const widgetAtts = widget && widget;
     const widgetLinks = (widgetAtts && widgetAtts.metadata && widgetAtts.metadata.length > 0
       && widgetAtts.metadata[0].info
       && widgetAtts.metadata[0].info.widgetLinks) || [];
-    const isExternal = isLoadedExternally(referer);
+    const isExternal = isLoadedExternally();
 
     if (error) {
       return (
@@ -204,7 +192,7 @@ class LayoutEmbedWidget extends PureComponent {
                   </button>
 
                   <Modal
-                    isOpen={this.state.shareWidget === widget}
+                    isOpen={shareWidget === widget}
                     className="-medium"
                     onRequestClose={() => this.handleToggleShareModal(null)}
                   >
@@ -225,7 +213,7 @@ class LayoutEmbedWidget extends PureComponent {
                 {user.id && (
                   <li>
                     <button
-                      onClick={() => this.props.setIfFavorited(widget.id, !this.props.favourited)}
+                      onClick={() => { setIfFavorited(widget.id, !favourited); }}
                     >
                       <Icon name={`icon-${favouriteIcon}`} className="c-icon -small" />
                     </button>
@@ -276,5 +264,31 @@ class LayoutEmbedWidget extends PureComponent {
     );
   }
 }
+
+LayoutEmbedWidget.defaultProps = {
+  bandDescription: null,
+  error: null,
+};
+
+LayoutEmbedWidget.propTypes = {
+  widget: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    description: PropTypes.string,
+    thumbnailUrl: PropTypes.string,
+    dataset: PropTypes.string,
+    widgetConfig: PropTypes.shape({}),
+  }).isRequired,
+  user: PropTypes.shape({
+    id: PropTypes.string,
+  }).isRequired,
+  bandDescription: PropTypes.string,
+  bandStats: PropTypes.shape({}).isRequired,
+  error: PropTypes.string,
+  favourited: PropTypes.bool.isRequired,
+  webshot: PropTypes.bool.isRequired,
+  setIfFavorited: PropTypes.func.isRequired,
+  RWAdapter: PropTypes.func.isRequired,
+};
 
 export default LayoutEmbedWidget;

--- a/pages/app/embed/dataset/index.jsx
+++ b/pages/app/embed/dataset/index.jsx
@@ -7,12 +7,12 @@ import { setEmbed } from 'redactions/common';
 import LayoutEmbedDataset from 'layout/embed/dataset';
 
 class EmbedDatasetPage extends PureComponent {
-  static async getInitialProps({ store, isServer, req }) {
+  static async getInitialProps({ store }) {
     const { dispatch } = store;
 
     dispatch(setEmbed(true));
 
-    return { referer: isServer ? req.headers.referer : window.location.href };
+    return ({});
   }
 
   render() {

--- a/pages/app/embed/text/index.jsx
+++ b/pages/app/embed/text/index.jsx
@@ -7,15 +7,14 @@ import { setEmbed, setWebshotMode } from 'redactions/common';
 import LayoutEmbedText from 'layout/embed/text';
 
 class EmbedTextPage extends PureComponent {
-  static async getInitialProps({ store, isServer, req }) {
+  static async getInitialProps({ store }) {
     const { dispatch, getState } = store;
     const { routes: { query: { webshot } } } = getState();
-    const referer = isServer ? req.headers.referer : window.location.href;
 
     dispatch(setEmbed(true));
     if (webshot) dispatch(setWebshotMode(true));
 
-    return { referer };
+    return ({});
   }
 
   render() {

--- a/pages/app/embed/widget/index.jsx
+++ b/pages/app/embed/widget/index.jsx
@@ -8,13 +8,12 @@ import { setEmbed, setWebshotMode } from 'redactions/common';
 import LayoutEmbedWidget from 'layout/embed/widget';
 
 class EmbedWidgetPage extends PureComponent {
-  static async getInitialProps({ store, isServer, req }) {
+  static async getInitialProps({ store }) {
     const { dispatch, getState } = store;
     const {
       routes: { query: { id, webshot } },
       user,
     } = getState();
-    const referer = isServer ? req.headers.referer : window.location.href;
 
     dispatch(setEmbed(true));
     if (webshot) dispatch(setWebshotMode(true));
@@ -25,7 +24,7 @@ class EmbedWidgetPage extends PureComponent {
       if (user && user.id) dispatch(checkIfFavorited(id));
     }
 
-    return { referer };
+    return ({});
   }
 
   render() {

--- a/redactions/common.js
+++ b/redactions/common.js
@@ -3,7 +3,6 @@ import { Router } from 'routes';
 const SET_LOCALE = 'common/SET_LOCALE';
 const SET_EMBED = 'common/SET_EMBED';
 const SET_WEBSHOT = 'common/SET_WEBSHOT';
-const SET_IS_LOADED_EXTERNALY = 'common/SET_IS_LOADED_EXTERNALY';
 const SET_IS_SERVER = 'common/SET_IS_SERVER';
 const SET_HOSTNAME = 'common/SET_HOSTNAME';
 
@@ -11,12 +10,11 @@ const initialState = {
   locale: 'en',
   embed: false,
   webshot: false,
-  isLoadedExternally: false,
   isServer: true,
   hostname: 'http://www.resourcewatch.org',
 };
 
-export default function (state = initialState, action) {
+export default function commonReducer(state = initialState, action) {
   switch (action.type) {
     case SET_LOCALE:
       return { ...state, locale: action.payload };
@@ -26,9 +24,6 @@ export default function (state = initialState, action) {
 
     case SET_WEBSHOT:
       return { ...state, webshot: action.payload };
-
-    case SET_IS_LOADED_EXTERNALY:
-      return { ...state, isLoadedExternally: action.payload };
 
     case SET_IS_SERVER:
       return { ...state, isServer: action.payload };
@@ -83,17 +78,6 @@ export function setWebshotMode(webshot) {
   return {
     type: SET_WEBSHOT,
     payload: webshot,
-  };
-}
-
-/**
- * Set if we are on an embed or not
- * @param {boolean} embed Two-letter locale
- */
-export function setIsLoadedExternaly(isLoadedExternally) {
-  return {
-    type: SET_IS_LOADED_EXTERNALY,
-    payload: isLoadedExternally,
   };
 }
 

--- a/utils/embed.js
+++ b/utils/embed.js
@@ -1,3 +1,7 @@
-export const isLoadedExternally = (referer) => !/localhost|(staging\.)?resourcewatch.org/.test(referer);
+export const isLoadedExternally = () => {
+  if (typeof document === 'undefined' || document.referrer === '') return false;
+
+  return !/localhost|(staging\.)?resourcewatch.org/.test(document.referrer);
+};
 
 export default { isLoadedExternally };


### PR DESCRIPTION
## Overview
Fixes an issue where the "Powered by Resource Watch" sentence wasn't displaying on external sites. Now we use `document.referrer` instead of `window.location.href` as inside of an iframe, the URL is Resource Watch's one instead of the URL of the external site.

![image](https://user-images.githubusercontent.com/999124/110776169-09557980-8260-11eb-871c-aa91f8af34e8.png)


## Testing instructions
Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc.

## Pivotal task
–

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
