### PR TITLE
removes authorization header from GET `/static_pages` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `next@10.1.3`
 
 ### Fixed
+- `/static-page` endpoint. [RW-19](https://vizzuality.atlassian.net/browse/RW-19?focusedCommentId=10534)
 
 ### Removed
 

--- a/redactions/admin/pages.js
+++ b/redactions/admin/pages.js
@@ -78,15 +78,10 @@ export default function Pages(state = initialState, action) {
  * @param {string[]} applications Name of the applications to load the pages from
  */
 export function getPages() {
-  return (dispatch, getState) => {
-    const {
-      user: {
-        token,
-      },
-    } = getState();
+  return (dispatch) => {
     dispatch({ type: GET_PAGES_LOADING });
 
-    fetchPages(token)
+    fetchPages()
       .then((data) => {
         dispatch({ type: GET_PAGES_SUCCESS, payload: data });
       })

--- a/services/pages.js
+++ b/services/pages.js
@@ -11,13 +11,12 @@ import { logger } from 'utils/logs';
  * @param {Object} headers Request headers.
  */
 export const fetchPages = (token, params = {}, headers = {}) => {
-  logger.info('Fetch pages');
+  logger.info('fetches static pages');
   return WRIAPI.get(
     '/v1/static_page',
     {
       headers: {
         ...headers,
-        Authorization: token,
       },
       params: {
         published: 'all',
@@ -50,7 +49,6 @@ export const fetchPage = (id, token, params = {}, headers = {}) => {
     {
       headers: {
         ...headers,
-        Authorization: token,
       },
       params: { ...params },
     },


### PR DESCRIPTION
## Overview
Removes `authorization` header from GET `/static_page` endpoints.

## Testing instructions
–

## Jira task
https://vizzuality.atlassian.net/browse/RW-19?focusedCommentId=10534

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
