### PR TITLE
RW-35 favorite spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 500 static page.
 
 ### Changed
+- consistent spelling of `favorite`. [RW-35](https://vizzuality.atlassian.net/browse/RW-35)
 - refactor: uses dynamic import for loading scripts without SSR.
 - `next@10.1.3`
 

--- a/components/app/myrw/datasets/pages/index.js
+++ b/components/app/myrw/datasets/pages/index.js
@@ -16,10 +16,10 @@ const DATASET_SUBTABS = [{
   route: 'myrw',
   params: { tab: 'datasets', subtab: 'my_datasets' },
 }, {
-  label: 'Favourites',
+  label: 'Favorites',
   value: 'favourites',
   route: 'myrw',
-  params: { tab: 'datasets', subtab: 'favourites' },
+  params: { tab: 'datasets', subtab: 'favorites' },
 }];
 
 class DatasetIndex extends PureComponent {

--- a/components/app/myrw/widgets/tabs/list/constants.js
+++ b/components/app/myrw/widgets/tabs/list/constants.js
@@ -6,10 +6,10 @@ export const WIDGET_LIST_SUBTABS = [
     params: { tab: 'widgets', subtab: 'my_widgets' },
   },
   {
-    label: 'Favourites',
+    label: 'Favorites',
     value: 'favourites',
     route: 'myrw',
-    params: { tab: 'widgets', subtab: 'favourites' },
+    params: { tab: 'widgets', subtab: 'favorites' },
   },
 ];
 

--- a/components/app/myrw/widgets/tabs/list/helpers.js
+++ b/components/app/myrw/widgets/tabs/list/helpers.js
@@ -9,7 +9,7 @@ export const getQueryParams = (state = {}, props) => {
     subtab,
   } = props;
   const { page, limit } = pagination;
-  const isCollection = !['my_widgets', 'favourites'].includes(subtab);
+  const isCollection = !['my_widgets', 'favorites'].includes(subtab);
 
   return ({
     application: process.env.NEXT_PUBLIC_APPLICATIONS,
@@ -17,8 +17,8 @@ export const getQueryParams = (state = {}, props) => {
     'page[number]': page,
     sort: sort === 'asc' ? 'updatedAt' : '-updatedAt',
     ...search && search.length && { name: search },
-    ...subtab === 'favourites' && { favourite: true },
-    ...(subtab !== 'favourites' && !isCollection) && { userId: id },
+    ...subtab === 'favorites' && { favourite: true },
+    ...(subtab !== 'favorites' && !isCollection) && { userId: id },
     ...isCollection && { collection: subtab },
   });
 };

--- a/components/collections-panel/collections-panel-constants.js
+++ b/components/collections-panel/collections-panel-constants.js
@@ -1,6 +1,6 @@
 export const FAVOURITES_COLLECTION = {
   id: 0,
-  name: 'Favourites',
+  name: 'Favorites',
   resources: [],
 };
 

--- a/components/wysiwyg/widget-block-edition/component.js
+++ b/components/wysiwyg/widget-block-edition/component.js
@@ -53,7 +53,7 @@ class WidgetBlockEdition extends PureComponent {
                     <Tabs
                       options={[
                         { label: 'My visualizations', value: 'my-widgets' },
-                        { label: 'My favourites', value: 'my-favourites' },
+                        { label: 'My favorites', value: 'my-favorites' },
                         { label: 'All visualizations', value: 'all-widgets' },
                       ]}
                       defaultSelected={tab}

--- a/components/wysiwyg/widget-block-edition/index.jsx
+++ b/components/wysiwyg/widget-block-edition/index.jsx
@@ -39,7 +39,7 @@ const WidgetBlockEdition = (props) => {
     fetchWidgets(
       {
         ...(tab === 'my-widgets' && { userId: user.id }),
-        ...(tab === 'my-favourites' && { favourite: true }),
+        ...(tab === 'my-favorites' && { favourite: true }),
         ...(!!search && { name: search }),
         'page[number]': page,
       },

--- a/cypress/integration/components/share-modal.spec.js
+++ b/cypress/integration/components/share-modal.spec.js
@@ -51,7 +51,7 @@ describe('a user wants to share the page with a shortened link', () => {
 
     cy.get('.page-header-content').find('button[data-cy="share-button"]').click();
 
-    cy.wait(500);
+    cy.wait('@getBitlyLink');
 
     cy.get('.c-share-modal').find('#share-link').then(($btn) => {
       expect($btn.val()).to.eq(`${Cypress.config().baseUrl}/dashboards/forests`);

--- a/hooks/favorite/fetch-favorites.js
+++ b/hooks/favorite/fetch-favorites.js
@@ -1,11 +1,11 @@
 import { useQuery } from 'react-query';
 
 // services
-import { fetchFavourites } from 'services/favourites';
+import { fetchFavorites } from 'services/favourites';
 
 const useFetchUserFavorites = (token, queryConfig = {}) => useQuery(
   ['fetch-user-favorites', token],
-  () => fetchFavourites(token),
+  () => fetchFavorites(token),
   { ...queryConfig },
 );
 

--- a/redactions/admin/datasets.js
+++ b/redactions/admin/datasets.js
@@ -203,8 +203,8 @@ export const getDatasetsByTab = createThunkAction(
 
         break;
 
-      // when the user asks for its favourites datasets...
-      case 'favourites':
+      // when the user asks for its favorites datasets...
+      case 'favorites':
         options = {
           ...options,
           filters: {

--- a/redactions/widget.js
+++ b/redactions/widget.js
@@ -5,7 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 import { fetchDataset } from 'services/dataset';
 import RasterService from 'services/raster';
 import { fetchLayer } from 'services/layer';
-import { deleteFavourite, createFavourite, fetchFavourites } from 'services/favourites';
+import { deleteFavourite, createFavourite, fetchFavorites } from 'services/favourites';
 import { fetchWidget } from 'services/widget';
 
 /**
@@ -274,7 +274,7 @@ export function checkIfFavorited(widgetId) {
     if (!user.id) {
       dispatch({ type: GET_WIDGET_FAVORITE, payload: { id: null, favourited: false } });
     } else {
-      fetchFavourites(user.token)
+      fetchFavorites(user.token)
         .then((res) => {
           const favourite = res.find && res.find((elem) => elem.attributes.resourceId === widgetId);
 

--- a/services/favourites.js
+++ b/services/favourites.js
@@ -9,7 +9,7 @@ import { logger } from 'utils/logs';
  * Check out the API docs for this endpoint {@link https://resource-watch.github.io/doc-api/index-rw.html#get-favorites|here}
  * @param {String} token User's token
  */
-export const fetchFavourites = (token) => {
+export const fetchFavorites = (token) => {
   logger.info('Fetch favorites');
   return WRIAPI.get('/v1/favourite',
     {


### PR DESCRIPTION
## Overview
Updated the spelling of `favourite` in the following places:

- MyRW dashboards (creation/edition): add new block → visualization → “My favorites”
- MyRW datasets (collections aside).
- MyRW widgets (collections aside).

Also URLs:

`/myrw/widgets/favourites` → `/myrw/widgets/favorites`

`/myrw/datasets/favourites` → `/myrw/datasets/favorites`

## Testing instructions
Go to `/myrw/widgets/favorites` and check the spelling is correct in the collection list aside. Also, clicking on "Favorites" should load the user's favorites widgets.

For datasets, follow the same instructions as for widgets but go to `/myrw/datasets/favorites`.

For dashboards, go to dashboard creation/edition, click on a new block, select type `Visualization`, the second tab should be spelt `My favorites` and should load the user's favorites widgets.

## Jira task
https://vizzuality.atlassian.net/browse/RW-35

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
