### PR TITLE
fixes visual bug with dataset navigation bar in explore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `next@10.1.3`
 
 ### Fixed
+- visual bug where the dataset navigation bar in the explore sidebar would remain after closing the sidebar. [RW-37](https://vizzuality.atlassian.net/browse/RW-37)
 - wrong deserialization of the user object when an user updated its profile. [RW-21](https://vizzuality.atlassian.net/browse/RW-21)
 - `/static-page` endpoint. [RW-19](https://vizzuality.atlassian.net/browse/RW-19?focusedCommentId=10534)
 

--- a/layout/explore/explore-detail/explore-detail-header/component.jsx
+++ b/layout/explore/explore-detail/explore-detail-header/component.jsx
@@ -1,16 +1,14 @@
-import React, {
+import {
   useState,
   useCallback,
 } from 'react';
 import PropTypes from 'prop-types';
 
-// Components
+// components
 import Icon from 'components/ui/icon';
 import LoginRequired from 'components/ui/login-required';
 import Modal from 'components/modal/modal-component';
 import ShareModal from 'components/modal/share-modal';
-
-// Tooltip
 import { Tooltip } from 'vizzuality-components';
 import CollectionsPanel from 'components/collections-panel';
 import { getTooltipContainer } from 'utils/tooltip';
@@ -18,11 +16,15 @@ import { getTooltipContainer } from 'utils/tooltip';
 // utils
 import { logEvent } from 'utils/analytics';
 
-// Styles
+// styles
 import './styles.scss';
 
-function ExploreDetailHeaderComponent(props) {
-  const { dataset, setSelectedDataset, userIsLoggedIn } = props;
+export default function ExploreDetailHeader({
+  dataset,
+  setSelectedDataset,
+  userIsLoggedIn,
+  isSidebarOpen,
+}) {
   const [showShareModal, setShowShareModal] = useState(false);
   const handleToggleFavorite = useCallback((isFavorite, resource) => {
     const datasetName = resource?.metadata[0]?.info?.name;
@@ -47,7 +49,12 @@ function ExploreDetailHeaderComponent(props) {
       && dataset.metadata[0].info && dataset.metadata[0].info.name;
 
   return (
-    <div className="c-explore-detail-header">
+    <div
+      className="c-explore-detail-header"
+      style={{
+        ...!isSidebarOpen && { position: 'absolute' },
+      }}
+    >
       <button
         className="c-btn -primary -compressed -fs-tiny all-datasets-button"
         onClick={() => setSelectedDataset(null)}
@@ -123,11 +130,17 @@ function ExploreDetailHeaderComponent(props) {
   );
 }
 
-ExploreDetailHeaderComponent.propTypes = {
-  dataset: PropTypes.object.isRequired,
+ExploreDetailHeader.propTypes = {
+  dataset: PropTypes.shape({
+    metadata: PropTypes.arrayOf(
+      PropTypes.shape({
+        info: PropTypes.shape({
+          name: PropTypes.string,
+        }),
+      }),
+    ),
+  }).isRequired,
   userIsLoggedIn: PropTypes.bool.isRequired,
-  // Store
+  isSidebarOpen: PropTypes.bool.isRequired,
   setSelectedDataset: PropTypes.func.isRequired,
 };
-
-export default ExploreDetailHeaderComponent;

--- a/layout/explore/explore-detail/explore-detail-header/index.js
+++ b/layout/explore/explore-detail/explore-detail-header/index.js
@@ -7,6 +7,7 @@ import ExploreDetailHeaderComponent from './component';
 export default connect(
   (state) => ({
     userIsLoggedIn: !!state.user.token,
+    isSidebarOpen: state.explore.sidebar.open,
   }),
   actions,
 )(ExploreDetailHeaderComponent);


### PR DESCRIPTION
## Overview
Fixes visual bug with dataset navigation bar in Explore when a dataset is selected and the sidebar is closed.

## Testing instructions
- Go to `/data/explore` and click on any dataset.
- Close the sidebar.
- The navigation bar should hide along with the sidebar content.

## Jira task
https://vizzuality.atlassian.net/browse/RW-37

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
