### PR TITLE
Fix redirect back to RW after social login

### DIFF
--- a/server/api-router.js
+++ b/server/api-router.js
@@ -48,9 +48,9 @@ router.get('/auth/:service', (req, res) => {
   // save the current url for redirect if successful, set it to expire in 5 min
   res.cookie('authUrl', req.headers.referer, { maxAge: 3e5, httpOnly: true });
   return res.redirect(
-    `${process.env.NEXT_PUBLIC_WRI_API_URL}/auth/${service}?callbackUrl=${
+    `${process.env.NEXT_PUBLIC_WRI_API_URL}/auth/${service}?applications=rw&token=true&origin=rw&callbackUrl=${
       process.env.NEXT_PUBLIC_CALLBACK_URL
-    }&applications=rw&token=true&origin=rw`,
+    }`,
   );
 });
 


### PR DESCRIPTION
## Overview
The callbackUrl in the server was not being correctly interpreted by the authorization service. This PR changes the order of the query parameters in social logins so that the `callbackUrl` is the last one to be provided.

## Testing instructions
You should be able to log in with Facebook (or another social login) and be redirected back to the RW app.

## Jira task
Reported by Ethan Roday via Slack here: https://vizzuality.slack.com/archives/CR4GT8NFL/p1618870912001100

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
