### PR TITLE
OW-56 – ocean watch: adds new type of partners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.2.0] - X
 ### Added
+- Ocean Watch: adds new type of partners. [OW-56](https://vizzuality.atlassian.net/browse/OW-56)
 
 
 ### Changed

--- a/components/admin/partners/form/constants.js
+++ b/components/admin/partners/form/constants.js
@@ -55,4 +55,16 @@ export const PARTNER_TYPES = [{
 }, {
   label: 'Anchor Funder',
   value: 'anchor_funder',
-}];
+}, {
+  label: 'Ocean Watch – Collaborating Partner',
+  value: 'ow_collaborating-partner',
+},
+{
+  label: 'Ocean Watch – Data Provider',
+  value: 'ow_data-provider',
+},
+{
+  label: 'Ocean Watch – Funder',
+  value: 'ow_funder',
+},
+];

--- a/components/admin/partners/form/steps/Step1.js
+++ b/components/admin/partners/form/steps/Step1.js
@@ -169,14 +169,13 @@ class Step1 extends React.Component {
                 onChange={(value) => {
                   this.props.onChange({ 'white-logo': value });
                 }}
-                validations={['required']}
                 className="-fluid"
                 properties={{
                   name: 'white-logo',
                   label: 'White logo',
                   placeholder: 'Browse file',
                   default: this.state.form['white-logo'],
-                  required: true,
+                  required: false,
                 }}
               >
                 {FileImage}
@@ -189,14 +188,13 @@ class Step1 extends React.Component {
                 onChange={(value) => {
                   this.props.onChange({ cover: value });
                 }}
-                validations={['required']}
                 className="-fluid"
                 properties={{
                   name: 'cover',
                   label: 'Cover',
                   placeholder: 'Browse file',
                   default: this.state.form.cover,
-                  required: true,
+                  required: false,
                 }}
               >
                 {FileImage}
@@ -209,14 +207,13 @@ class Step1 extends React.Component {
                 onChange={(value) => {
                   this.props.onChange({ icon: value });
                 }}
-                validations={['required']}
                 className="-fluid"
                 properties={{
                   name: 'icon',
                   label: 'Icon',
                   placeholder: 'Browse file',
                   default: this.state.form.icon,
-                  required: true,
+                  required: false,
                 }}
               >
                 {FileImage}

--- a/layout/admin/partners-detail/component.jsx
+++ b/layout/admin/partners-detail/component.jsx
@@ -34,9 +34,11 @@ export default function LayoutAdminPartnersDetail({
 
   const {
     data: partner,
-  } = useFetchPartner(id, {
-    enabled: !!(id && id !== 'new'),
-  });
+  } = useFetchPartner(id,
+    {},
+    {
+      enabled: !!(id && id !== 'new'),
+    });
 
   const name = useMemo(() => {
     if (id === 'new') return `New ${singular(tab)}`;


### PR DESCRIPTION
## Overview
Adds new types of partners for Ocean Watch.

![image](https://user-images.githubusercontent.com/999124/117333560-56894c80-ae99-11eb-9e57-cad34b4d049d.png)


## Testing instructions
Go to `/admin/partners/partners/new` and click on "Partner Type". The list should display the new options available.

## Jira task
https://vizzuality.atlassian.net/browse/OW-56

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
