### PR TITLE
implements mini-explore in WYSIWYG flow

### DIFF
--- a/components/dashboards/detail/component.js
+++ b/components/dashboards/detail/component.js
@@ -1,4 +1,4 @@
-import React, { PureComponent, Fragment } from 'react';
+import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 // components
@@ -6,6 +6,7 @@ import Wysiwyg from '@vizzuality/wysiwyg';
 import InView from 'components/in-view';
 import WidgetBlock from 'components/wysiwyg/widget-block';
 import WidgetBlockEdition from 'components/wysiwyg/widget-block-edition';
+import MiniExploreBlock from 'components/wysiwyg/mini-explore';
 
 const WidgetBlockInView = (props) => (
   <InView
@@ -56,6 +57,39 @@ class DashboardDetail extends PureComponent {
     // TO-DO: review this error handling
     try {
       items = JSON.parse(content);
+      // todo: remove the following lines once
+      // todo: the MiniExplore is implemented in the dashboard via API.
+      // items.unshift({
+      //   id: Math.floor(Math.random() * 999999999999),
+      //   type: 'mini-explore',
+      //   content: JSON.stringify({
+      //     title: 'Lorem ipsum',
+      //     areaOfInterest: '972c24e1da2c2baacc7572ee9501abdc',
+      //     datasetGroups: [
+      //       {
+      //         title: 'Power Infrastructure',
+      //         datasets: [
+      //           'a86d906d-9862-4783-9e30-cdb68cd808b8',
+      //           'b75d8398-34f2-447d-832d-ea570451995a',
+      //           '4919be3a-c543-4964-a224-83ef801370de',
+      //         ],
+      //         default: [
+      //           'a86d906d-9862-4783-9e30-cdb68cd808b8',
+      //         ],
+      //       },
+      //       {
+      //         title: 'Natural hazards',
+      //         datasets: [
+      //           '484f10d3-a30b-4466-8052-c48d47cfb4a1',
+      //           'c5a62289-bdc8-4821-83f0-6f05e3d36bdc',
+      //         ],
+      //         default: [
+      //           '484f10d3-a30b-4466-8052-c48d47cfb4a1',
+      //         ],
+      //       },
+      //     ],
+      //   }),
+      // });
     } catch (e) { console.error(e); }
 
     if (typeof window === 'undefined' || isUpdate) return null;
@@ -71,6 +105,9 @@ class DashboardDetail extends PureComponent {
             icon: 'icon-widget',
             label: 'Visualization',
             renderer: 'modal',
+          },
+          'mini-explore': {
+            Component: MiniExploreBlock,
           },
         }}
       />

--- a/components/error-fallback/component.jsx
+++ b/components/error-fallback/component.jsx
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types';
+
+// styles
+import './styles.scss';
+
+export default function ErrorFallback({
+  title,
+  resetErrorBoundary,
+}) {
+  return (
+    <div
+      role="alert"
+      className="c-error-fallback"
+    >
+      <p>
+        {title}
+      </p>
+      <button
+        type="button"
+        className="c-button -primary"
+        onClick={resetErrorBoundary}
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+
+ErrorFallback.defaultProps = {
+  title: 'Something went wrong.',
+};
+
+ErrorFallback.propTypes = {
+  title: PropTypes.string,
+  // https://github.com/bvaughn/react-error-boundary#usage
+  resetErrorBoundary: PropTypes.func.isRequired,
+};

--- a/components/error-fallback/index.js
+++ b/components/error-fallback/index.js
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/components/error-fallback/styles.scss
+++ b/components/error-fallback/styles.scss
@@ -1,0 +1,13 @@
+@import 'css/settings';
+
+.c-error-fallback {
+  width: 100%;
+  padding: 15px;
+  border: 1px solid rgba($black, .1);
+  border-radius: 4px;
+  text-align: center;
+
+  > button {
+    margin: 20px 0 0;
+  }
+}

--- a/components/mini-explore/styles.scss
+++ b/components/mini-explore/styles.scss
@@ -1,6 +1,7 @@
 @import 'css/settings';
 
 .c-mini-explore {
+  width: 100%;
   border: 1px solid rgba($black ,.1);
   border-radius: 4px;
 

--- a/components/wysiwyg/mini-explore/component.jsx
+++ b/components/wysiwyg/mini-explore/component.jsx
@@ -1,0 +1,52 @@
+import {
+  useMemo,
+  useCallback,
+} from 'react';
+import PropTypes from 'prop-types';
+import { ErrorBoundary } from 'react-error-boundary';
+
+// components
+import ErrorFallback from 'components/error-fallback';
+import MiniExplore from 'components/mini-explore';
+
+function MiniExploreBlock({
+  item,
+}) {
+  const config = useMemo(() => {
+    try {
+      return JSON.parse(item.content);
+    } catch (e) {
+      throw new Error('Mini Explore: error parsing content.');
+    }
+  }, [item]);
+
+  return (
+    <MiniExplore
+      config={config}
+    />
+  );
+}
+
+export default function MiniExploreBlockWithErrorBoundary(props) {
+  const CustomErrorFallback = useCallback((_props) => (
+    <ErrorFallback
+      {..._props}
+      title="Something went wrong loading Mini Explore."
+    />
+  ), []);
+
+  return (
+    <ErrorBoundary
+      FallbackComponent={CustomErrorFallback}
+      onError={((error) => { console.error(error.message); })}
+    >
+      <MiniExploreBlock {...props} />
+    </ErrorBoundary>
+  );
+}
+
+MiniExploreBlock.propTypes = {
+  item: PropTypes.shape({
+    content: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/components/wysiwyg/mini-explore/index.js
+++ b/components/wysiwyg/mini-explore/index.js
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-dom": "^17.0.2",
     "react-dropdown-tree-select": "1.9.2",
     "react-dropzone": "4.2.9",
+    "react-error-boundary": "^3.1.3",
     "react-fast-compare": "^2.0.4",
     "react-ga": "^2.3.5",
     "react-geosuggest": "^2.12.0",

--- a/pages/dashboards/[slug].jsx
+++ b/pages/dashboards/[slug].jsx
@@ -17,7 +17,7 @@ const DashboardsDetailPage = ({
 );
 
 // getInitialProps is used to improve SEO of these pages.
-// TO-DO: replace with getStaticProps eventually
+// todo: replace with getStaticProps eventually
 DashboardsDetailPage.getInitialProps = async (ctx) => {
   const {
     query: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11901,6 +11901,13 @@ react-dropzone@^4.2.3:
     attr-accept "^1.1.3"
     prop-types "^15.5.7"
 
+react-error-boundary@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.3.tgz#276bfa05de8ac17b863587c9e0647522c25e2a0b"
+  integrity sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-fast-compare@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"


### PR DESCRIPTION
## Overview
This PR implements the needed code to read and render the mini Explore following the WYSIWYG flow.

This PR **does not** add the MiniExplore component to Coral Reef dashboard. The configuration needs to be read via API.

![image](https://user-images.githubusercontent.com/999124/119484166-07c32a00-bd56-11eb-87a8-0d83f6bf0a1d.png)

![image](https://user-images.githubusercontent.com/999124/119484327-304b2400-bd56-11eb-8ebe-8eb9fc136f71.png)


## Testing instructions
–

## Jira task
https://vizzuality.atlassian.net/browse/RW-59

---

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
