### PR TITLE
removes Axios' cancel token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Fixed
+- data explore: areas of interest not loading.[RW-67](https://vizzuality.atlassian.net/browse/RW-67)
 - mini-explore: USA and World boundaries.
 - warning with dashboard links.
 - fixes search place in Explore map. [RW-58](https://vizzuality.atlassian.net/browse/RW-58)
@@ -42,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Removed
+- Axios' cancelToken.
 - removes `react-responsive` and `react-responsive-redux`.
 - removes `hostname` and its action from global state.
 - removes `routes` global state. [RW-53](https://vizzuality.atlassian.net/browse/RW-53)

--- a/components/areas/card/component.jsx
+++ b/components/areas/card/component.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useState,
   useEffect,
   useCallback,
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { toastr } from 'react-redux-toastr';
 import { Tooltip } from 'vizzuality-components';
-import axios, { CancelToken } from 'axios';
+import axios from 'axios';
 
 // services
 import { fetchGeostore } from 'services/geostore';
@@ -170,9 +170,7 @@ const AreaCard = (props) => {
   }, [handleEditSubscription, refetch]);
 
   useEffect(() => {
-    const cancelToken = CancelToken.source();
-
-    fetchGeostore(geostoreId, { cancelToken: cancelToken.token })
+    fetchGeostore(geostoreId)
       .then((_geostore = {}) => {
         const { bbox, geojson } = _geostore;
 
@@ -189,8 +187,6 @@ const AreaCard = (props) => {
           toastr.error(`Something went wrong loading your area "${name}"`);
         }
       });
-
-    return () => { cancelToken.cancel('Fetching geostore: operation canceled by the user.'); };
   }, [area, geostoreId, name]);
 
   useEffect(() => {

--- a/layout/embed/map/component.jsx
+++ b/layout/embed/map/component.jsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useState,
   useCallback,
   useEffect,
@@ -15,7 +15,6 @@ import {
   LegendItemTypes,
 } from 'vizzuality-components';
 import Link from 'next/link';
-import { CancelToken } from 'axios';
 
 // components
 import LayoutEmbed from 'layout/layout/layout-embed';
@@ -233,8 +232,6 @@ const LayoutEmbedMap = (props) => {
   }, [bounds]);
 
   useEffect(() => {
-    const cancelToken = CancelToken.source();
-
     const fetchAreaOfInterest = async () => {
       try {
         const {
@@ -243,7 +240,6 @@ const LayoutEmbedMap = (props) => {
           userId: areaUserId,
         } = await fetchArea(aoi, {}, {
           Authorization: user.token,
-          cancelToken: cancelToken.token,
         });
 
         if (!isPublicArea
@@ -253,7 +249,7 @@ const LayoutEmbedMap = (props) => {
         const {
           geojson,
           bbox,
-        } = await fetchGeostore(geostoreId, { cancelToken: cancelToken.token });
+        } = await fetchGeostore(geostoreId);
 
         const aoiLayer = getUserAreaLayer(
           {
@@ -286,8 +282,6 @@ const LayoutEmbedMap = (props) => {
     if (aoi) {
       fetchAreaOfInterest();
     }
-
-    return () => { cancelToken.cancel('Fetching geostore: operation canceled by the user.'); };
   }, [aoi, user]);
 
   const {

--- a/layout/explore/explore-map/component.jsx
+++ b/layout/explore/explore-map/component.jsx
@@ -6,7 +6,6 @@ import debounce from 'lodash/debounce';
 import isEmpty from 'lodash/isEmpty';
 import { useDebouncedCallback } from 'use-debounce';
 import { Popup } from 'react-map-gl';
-import { CancelToken } from 'axios';
 import {
   Legend,
   LegendListItem,
@@ -294,8 +293,6 @@ const ExploreMap = (props) => {
   }, [activeLayers, aoi]);
 
   useEffect(() => {
-    const cancelToken = CancelToken.source();
-
     const fetchAreaOfInterest = async () => {
       try {
         const {
@@ -304,7 +301,6 @@ const ExploreMap = (props) => {
           userId: areaUserId,
         } = await fetchArea(aoi, {}, {
           Authorization: token,
-          cancelToken: cancelToken.token,
         });
 
         if (!isPublicArea
@@ -315,7 +311,7 @@ const ExploreMap = (props) => {
           id,
           geojson,
           bbox,
-        } = await fetchGeostore(geostoreId, { cancelToken: cancelToken.token });
+        } = await fetchGeostore(geostoreId);
 
         const aoiLayer = getUserAreaLayer(
           {
@@ -349,8 +345,6 @@ const ExploreMap = (props) => {
         ...prevLayers.filter(({ provider }) => provider !== 'geojson'),
       ]);
     }
-
-    return () => { cancelToken.cancel('Fetching area of interest: operation canceled by the user.'); };
   }, [aoi, token, userId, setBounds]);
 
   return (


### PR DESCRIPTION
## Overview
Fixes areas of interest load in Explore and other places removing Axios' cancel Token.

## Testing instructions
Go to Explore and turn on one of your areas of interest. It should appear in the map.

## Jira task
https://vizzuality.atlassian.net/browse/RW-67

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
