### PR TITLE
replaces import `sass` files with `css`

### DIFF
--- a/css/components/datasets/list-item.scss
+++ b/css/components/datasets/list-item.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .c-dataset-list-item {
   display: flex;
   position: relative;
@@ -21,7 +23,7 @@
       padding: $margin-size-extra-small;
 
       h4 {
-        margin: 0 0 $space-1/2;
+        margin: 0 0 math.div($margin-size-extra-small, 2);
         padding-right: $space-1 * 4;
         position: relative;
       }

--- a/css/components/datasets/search.scss
+++ b/css/components/datasets/search.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .c-dataset-search {
   position: relative;
 
@@ -9,10 +11,8 @@
       height: 45px;
       box-shadow: none;
       outline: none;
-      font-size: $font-size-medium;
-      padding: $margin-size-extra-small/2 40px;
+      padding: math.div($margin-size-extra-small, 2) 40px;
       margin: 0;
-      width: 100%;
 
       font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans;
       font-size: $font-size-normal;

--- a/css/components/form/field.scss
+++ b/css/components/form/field.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .c-field {
   margin-bottom: 20px;
 
@@ -75,7 +77,7 @@
       box-shadow: none;
       outline: none;
       font-size: $font-size-medium;
-      padding: $margin-size-extra-small/2 10px;
+      padding: math.div($margin-size-extra-small, 2) 10px;
       margin: 0;
       width: 100%;
 

--- a/css/components/form/toggle-search.scss
+++ b/css/components/form/toggle-search.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .toggle-search {
 
   .c-field-search {
@@ -8,7 +10,7 @@
 
   input {
     display: inline-block;
-    padding: $margin-size-extra-small/2 $margin-size-extra-small;
+    padding: math.div($margin-size-extra-small, 2) $margin-size-extra-small;
     padding-right: 25px;
     margin: 0;
     width: 95px;

--- a/css/components/map/map.scss
+++ b/css/components/map/map.scss
@@ -1,8 +1,10 @@
+@use "sass:math";
+
 @mixin drawMarker($important : '', $margins : 'false', $width: 10) {
 
   @if $margins == 'true' {
-    margin-left: -#{$width/2}px$important;
-    margin-top: -#{$width/2}px$important;
+    margin-left: -#{math.div($width, 2)}px$important;
+    margin-top: -#{math.div($width, 2)}px$important;
   }
 
   width: #{$width}px$important;

--- a/css/components/ui/related-content.scss
+++ b/css/components/ui/related-content.scss
@@ -26,7 +26,7 @@
         cursor: pointer;
 
         > * {
-          margin: 0 0 0 $space-1/2;
+          margin: 0 0 0 math.div($space-1, 2);
           &:first-child { margin: 0; }
         }
 

--- a/css/components/ui/search-input.scss
+++ b/css/components/ui/search-input.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $this: 'c-search-input';
 
 .#{$this} {
@@ -22,7 +24,7 @@ $this: 'c-search-input';
 
   .c-field .field-container .#{$this}--header {
     display: block;
-    padding: $margin-size-extra-small/2 $margin-size-extra-small;
+    padding: math.div($margin-size-extra-small, 2) $margin-size-extra-small;
     padding-right: 25px;
     margin: 0;
     width: 100%;

--- a/css/components/ui/switch-options.scss
+++ b/css/components/ui/switch-options.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $switch-width: 28px;
 
 .c-switch-options {
@@ -30,15 +32,15 @@ $switch-width: 28px;
 
   .switch-element {
     width: $switch-width;
-    height: $switch-width/2;
+    height: math.div($switch-width, 2);
     border-radius: 20px;
     background: $color-dark-grey;
 
     span {
       display: block;
       position: absolute;
-      width: $switch-width/2 - 4px;
-      height: $switch-width/2 - 4px;
+      width: math.div($switch-width, 2) - 4px;
+      height: math.div($switch-width, 2) - 4px;
       background: $color-primary;
       border-radius: 50%;
       margin: 2px;
@@ -47,6 +49,6 @@ $switch-width: 28px;
 
     // Switch position
     &.-left > span { transform: translate(0,0); }
-    &.-right > span { transform: translate($switch-width/2,0); }
+    &.-right > span { transform: translate(math.div($switch-width, 2),0); }
   }
 }

--- a/css/components/ui/table_tooltip.scss
+++ b/css/components/ui/table_tooltip.scss
@@ -1,3 +1,6 @@
+
+@use "sass:math";
+
 /* Filters */
 $_arrow-width: 12px;
 $_footer-height: 40px;
@@ -37,7 +40,7 @@ $_footer-height: 40px;
       top: 0;
       width: $_arrow-width;
       height: $_arrow-width;
-      margin: -#{$_arrow-width/2} 0px 0px -#{$_arrow-width/2};
+      margin: -#{math.div($-arrow-width, 2)} 0px 0px -#{math.div($-arrow-width, 2)};
       background: $color-white;
       border-top: 1px solid $color-grey;
       border-left: 1px solid $color-grey;

--- a/css/components/ui/tooltip-global.scss
+++ b/css/components/ui/tooltip-global.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $tooltip-arrow-size: 10px;
 .c-tooltip-global {
   position: fixed;
@@ -23,6 +25,6 @@ $tooltip-arrow-size: 10px;
     height: $tooltip-arrow-size;
     border-right: 1px solid $border-color-2;
     border-bottom: 1px solid $border-color-2;
-    transform: translate(-50%, $tooltip-arrow-size/2) rotate(45deg);
+    transform: translate(-50%, math.div($tooltip-arrow-size, 2)) rotate(45deg);
   }
 }

--- a/css/components/widgets/widget-tooltip-list.scss
+++ b/css/components/widgets/widget-tooltip-list.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .c-widget-tooltip-list {
   margin: 0 -$margin-size-extra-small;
 
@@ -15,7 +17,7 @@
     list-style: none;
 
     > li {
-      padding: $margin-size-extra-small/2 $margin-size-extra-small;
+      padding: math.div($margin-size-extra-small, 2) $margin-size-extra-small;
       cursor: pointer;
 
       &:hover {

--- a/css/index.scss
+++ b/css/index.scss
@@ -2,17 +2,17 @@
 // Project settings (it doesn't include Grid system)
 @import "settings";
 
-@import "../node_modules/normalize.css/normalize";
+@import "~normalize.css/normalize";
 
 // Libraries
-@import '../node_modules/react-progress-2/main';
-@import '../node_modules/react-redux-toastr/src/styles/index';
-@import '../node_modules/react-input-range/src/scss/index.scss';
-@import '../node_modules/vizzuality-components/dist/bundle';
+@import '~react-progress-2/main';
+@import '~react-redux-toastr/lib/css/react-redux-toastr.min';
+@import '~react-input-range/lib/css/index';
+@import '~vizzuality-components/dist/bundle';
 
 
 // Editor
-@import '../node_modules/react-quill/dist/quill.snow';
+@import '~react-quill/dist/quill.snow';
 
 
 // Common files
@@ -118,7 +118,7 @@
 @import './components/map/map-side-by-side-range';
 
 // Form
-@import '../node_modules/@vizzuality/wysiwyg/build/rw';
+@import '~@vizzuality/wysiwyg/build/rw';
 @import "./components/form/form";
 @import "./components/form/field";
 @import "./components/form/field-container";
@@ -244,7 +244,7 @@
 
 // Foundation:
 // We are using this library only for grid system
-@import '../node_modules/foundation-sites/scss/foundation';
+@import '~foundation-sites/scss/foundation';
 @include foundation-flex-classes;
 @include foundation-flex-grid;
 @include foundation-responsive-embed;

--- a/css/layouts/_container.scss
+++ b/css/layouts/_container.scss
@@ -1,20 +1,22 @@
+@use "sass:math";
+
 .l-container {
   width: 100%;
   position: relative;
   max-width: $grid-row-width;
   margin: 0 auto;
   box-sizing: border-box;
-  padding: 0 (map-get($grid-column-gutter, small)/2);
+  padding: 0 math.div(map-get($grid-column-gutter, medium), 2);
 
 
   @media screen and (min-width: map-get($breakpoints, medium)) {
     max-width: map-get($breakpoints, medium);
-    padding: 0 (map-get($grid-column-gutter, small)/2);
+    padding: 0 math.div(map-get($grid-column-gutter, small), 2);
   }
 
   @media screen and (min-width: map-get($breakpoints, large)) {
     max-width: map-get($breakpoints, large);
-    padding: 0 (map-get($grid-column-gutter, medium)/2);
+    padding: 0 math.div(map-get($grid-column-gutter, medium), 2);
   }
 
   @media screen and (min-width: map-get($breakpoints, xlarge)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6329,20 +6329,10 @@ cancelable-promise@^3.2.3:
   resolved "https://registry.yarnpkg.com/cancelable-promise/-/cancelable-promise-3.2.3.tgz#7bc579c003fa05147d942ca9f6c4e39217d832e4"
   integrity sha512-P0yW/pq7ZEx4znOnDd4PqA5l+I/INpo32BE4Rg3QQxVBhKk7g9hAbmJt7oYbffo1q8j+1QfSZHGmjHMqj8RoJw==
 
-caniuse-lite@^1.0.30001006, caniuse-lite@^1.0.30001181:
-  version "1.0.30001183"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001183.tgz"
-  integrity sha512-7JkwTEE1hlRKETbCFd8HDZeLiQIUcl8rC6JgNjvHCNaxOeNmQ9V4LvQXRUsKIV2CC73qKxljwVhToaA3kLRqTw==
-
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001219:
-  version "1.0.30001233"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001233.tgz#b7cb4a377a4b12ed240d2fa5c792951a06e5f2c4"
-  integrity sha512-BmkbxLfStqiPA7IEzQpIk0UFZFf3A4E6fzjPJ6OR+bFC2L8ES9J8zGA/asoi47p8XDVkev+WJo2I2Nc8c/34Yg==
-
-caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001179:
-  version "1.0.30001191"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz#bacb432b6701f690c8c5f7c680166b9a9f0843d9"
-  integrity sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==
+caniuse-lite@^1.0.30001006, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001181, caniuse-lite@^1.0.30001219:
+  version "1.0.30001248"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz"
+  integrity sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Overview
- replaces importing sass files and uses `css`files. This skips `sass` compilation of files coming from libraries with `css` alternatives ready to use.
- replaces deprecated `/` for division, uses `math.div` instead.
- updates browserlist.



## Testing instructions
Run the application, styles should not be affected. Warnings in the console should be reduced considerably.

## Jira task
None.

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
