### PR TITLE
fixes opacity 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Fixed
+- opacity 0 couldn't be applied to layer. [OW-94](https://vizzuality.atlassian.net/browse/OW-94)
 - data explore: areas of interest not loading.[RW-67](https://vizzuality.atlassian.net/browse/RW-67)
 - mini-explore: USA and World boundaries.
 - warning with dashboard links.

--- a/utils/layers/index.js
+++ b/utils/layers/index.js
@@ -1,4 +1,7 @@
-import groupBy from 'lodash/groupBy';
+import {
+  isNumber,
+  groupBy,
+} from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
 // utils
@@ -45,7 +48,7 @@ export const getLayerGroups = (layers = [], layerParams = {}) => {
       .map((_layer) => ({
         ..._layer,
         active: _layer.default,
-        opacity: layerParams?.[_layer.id]?.opacity || 1,
+        opacity: isNumber(layerParams?.[_layer.id]?.opacity) ? layerParams[_layer.id].opacity : 1,
         ..._layer?.layerConfig?.type === 'gee' && {
           layerConfig: {
             ..._layer.layerConfig,


### PR DESCRIPTION
## Overview
Fixes a condition where opacity `0` was treated as falsy value and not applied.

## Testing instructions
Apply opacity 0 to any layer inside the `layerParams` object in the widget configuration.

## Jira task
https://vizzuality.atlassian.net/browse/OW-94

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
