### PR TITLE
wysiwyg: removes mini-explore from toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Fixed
+- WYSIWYG: removes mini-explore button from toolbar. [RW-74](https://vizzuality.atlassian.net/browse/RW-74)
 - opacity 0 couldn't be applied to layer. [OW-94](https://vizzuality.atlassian.net/browse/OW-94)
 - data explore: areas of interest not loading.[RW-67](https://vizzuality.atlassian.net/browse/RW-67)
 - mini-explore: USA and World boundaries.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@next/env": "10.0.8",
     "@reduxjs/toolkit": "^1.5.1",
     "@vizzuality/layer-manager-utils": "^1.0.0-alpha.3",
-    "@vizzuality/wysiwyg": "^3.1.0",
+    "@vizzuality/wysiwyg": "^3.1.1",
     "@widget-editor/renderer": "^2.6.2",
     "@widget-editor/rw-adapter": "^2.6.2",
     "@widget-editor/widget-editor": "^2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4322,10 +4322,10 @@
     axios "^0.21.1"
     cancelable-promise "^3.2.3"
 
-"@vizzuality/wysiwyg@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@vizzuality/wysiwyg/-/wysiwyg-3.1.0.tgz#f50f74617523938ebd643fc4113ab6d265c6aec0"
-  integrity sha512-5dDB2YmS2TlOdTJ6H2sjuJ9vriKowH2fugOooOAD9WZt5LauL2JPd7y3e+pnY7atIiiiPCSXvbQP0L3nSzvdsA==
+"@vizzuality/wysiwyg@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@vizzuality/wysiwyg/-/wysiwyg-3.1.1.tgz#3d129031de8a298e964185e7bece574fc36f7b58"
+  integrity sha512-SwghhbesgAn00/4MSB/QzZKZa8jY6p4G+iNwim6N2vRM4PC1cRmBd0/OccH+CkHhi9twxWquo1GB2Sv3zAKU2w==
   dependencies:
     classnames "2.2.5"
     foundation-sites "^6.6.3"


### PR DESCRIPTION
## Overview
![image](https://user-images.githubusercontent.com/999124/128379848-98d509c1-659c-4f65-a509-6e55e75d3740.png)

In WYSIWG, removes "mini-explore" button from toolbar.

## Testing instructions
_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

## Jira task
https://vizzuality.atlassian.net/browse/RW-74

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
