### PR TITLE
Add env columns to back office tables

### DIFF
--- a/components/admin/data/layers/table/component.js
+++ b/components/admin/data/layers/table/component.js
@@ -165,6 +165,7 @@ class LayersTable extends PureComponent {
               { label: 'Owner', value: 'owner', td: OwnerTD },
               { label: 'Role', value: 'role', td: RoleTD },
               { label: 'Updated at', value: 'updatedAt', td: UpdatedAtTD },
+              { label: 'Environment', value: 'env' },
             ]}
             actions={{
               show: true,

--- a/components/admin/data/widgets/table/component.js
+++ b/components/admin/data/widgets/table/component.js
@@ -161,6 +161,7 @@ class WidgetsTable extends PureComponent {
               { label: 'Published', value: 'published', td: PublishedTD },
               { label: 'Owner', value: 'owner', td: OwnerTD },
               { label: 'Role', value: 'role', td: RoleTD },
+              { label: 'Environment', value: 'env' },
             ]}
             actions={{
               show: true,

--- a/components/admin/pages/table/PagesTable.js
+++ b/components/admin/pages/table/PagesTable.js
@@ -125,6 +125,7 @@ class PagesTable extends PureComponent {
               { label: 'Name', value: 'title', td: NameTD },
               { label: 'Role', value: 'role', td: RoleTD },
               { label: 'Published', value: 'published', td: PublishedTD },
+              { label: 'Environment', value: 'env' },
             ]}
             actions={{
               show: true,

--- a/components/admin/partners/table/component.js
+++ b/components/admin/partners/table/component.js
@@ -114,6 +114,7 @@ class AdminPartnersTable extends PureComponent {
               { label: 'Partner type', value: 'partner-type' },
               { label: 'Featured', value: 'featured', td: FeaturedTD },
               { label: 'Published', value: 'published', td: PublishedTD },
+              { label: 'Environment', value: 'env' },
             ]}
             actions={{
               show: true,

--- a/components/admin/tools/table/ToolsTable.js
+++ b/components/admin/tools/table/ToolsTable.js
@@ -127,6 +127,7 @@ class ToolsTable extends PureComponent {
               { label: 'Name', value: 'title', td: TitleTD },
               { label: 'Role', value: 'role', td: RoleTD },
               { label: 'Published', value: 'published', td: PublishedTD },
+              { label: 'Environment', value: 'env' },
             ]}
             actions={{
               show: true,

--- a/components/dashboards/table/DashboardsTable.js
+++ b/components/dashboards/table/DashboardsTable.js
@@ -152,6 +152,7 @@ class DashboardsTable extends PureComponent {
             { label: 'Role', value: 'role', td: RoleTD },
             { label: 'Preview', value: 'slug', td: PreviewTD },
             { label: 'Published', value: 'published', td: PublishedTD },
+            { label: 'Environment', value: 'env' },
           ]}
           actions={{
             show: true,

--- a/components/datasets/table/component.js
+++ b/components/datasets/table/component.js
@@ -27,7 +27,7 @@ import DeleteAction from './actions/delete';
 import { INITIAL_PAGINATION } from './constants';
 
 class DatasetsTable extends PureComponent {
-  static propTypes = { user: PropTypes.object.isRequired }
+  static propTypes = { user: PropTypes.object.isRequired };
 
   state = {
     pagination: INITIAL_PAGINATION,
@@ -162,6 +162,7 @@ class DatasetsTable extends PureComponent {
             { label: 'Owner', value: 'owner', td: OwnerTD },
             { label: 'Role', value: 'role', td: RoleTD },
             { label: 'Updated at', value: 'updatedAt', td: UpdatedAtTD },
+            { label: 'Environment', value: 'env' },
             { label: 'Applications', value: 'application', td: ApplicationsTD },
             {
               label: 'Related content', value: 'status', td: RelatedContentTD, tdProps: { route: '/admin/data' },


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/545342/131465851-65146a5d-ee39-4d6a-a593-5dbbfde255ca.png)

## Overview

This PR adds a new `env` column to all the tables from the back office.

## Testing instructions
Check all different entity sections in the back office.

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/RER-42