### PR TITLE
Add missing env selects

### DIFF
--- a/components/admin/data/layers/form/steps/Step1.js
+++ b/components/admin/data/layers/form/steps/Step1.js
@@ -106,14 +106,18 @@ class Step1 extends PureComponent {
             ref={(c) => { if (c) FORM_ELEMENTS.elements.env = c; }}
             hint={'Choose "preproduction" to see this dataset only as admin, "production" option will show it in the public site.'}
             className="-fluid"
-            options={[{ label: 'Pre-production', value: 'preproduction' }, { label: 'Production', value: 'production' }]}
+            options={[
+              { label: 'Staging', value: 'staging' },
+              { label: 'Preproduction', value: 'preproduction' },
+              { label: 'Production', value: 'production' },
+            ]}
             onChange={(value) => this.props.onChange({ env: value })}
             properties={{
               name: 'env',
               label: 'Environment',
               placeholder: 'Choose an environment...',
               noResultsText: 'Please, choose an environment for this layer',
-              default: 'preproduction',
+              default: process.env.NEXT_PUBLIC_API_ENV,
               value: this.props.form.env,
             }}
           >

--- a/components/admin/data/widgets/form/steps/component.jsx
+++ b/components/admin/data/widgets/form/steps/component.jsx
@@ -77,15 +77,17 @@ class AdminWidgetForm extends Component {
               ref={(c) => { if (c) FORM_ELEMENTS.elements.env = c; }}
               hint={'Choose "preproduction" to see this dataset it only as admin, "production" option will show it in public site.'}
               className="-fluid"
-              options={[{ label: 'Pre-production', value: 'preproduction' }, { label: 'Production', value: 'production' }]}
+              options={[
+                { label: 'Staging', value: 'staging' },
+                { label: 'Preproduction', value: 'preproduction' },
+                { label: 'Production', value: 'production' },
+              ]}
               onChange={(value) => onChange({ env: value })}
               properties={{
                 name: 'env',
                 label: 'Environment',
                 placeholder: 'Choose an environment...',
-                noResultsText: 'Please, type the name of the columns and press enter',
-                promptTextCreator: (label) => `The name of the column is "${label}"`,
-                default: 'preproduction',
+                default: process.env.NEXT_PUBLIC_API_ENV,
                 value: form.env,
               }}
             >

--- a/components/admin/pages/form/steps/Step1.js
+++ b/components/admin/pages/form/steps/Step1.js
@@ -11,6 +11,7 @@ import TextArea from 'components/form/TextArea';
 import FileImage from 'components/form/FileImage';
 import Checkbox from 'components/form/Checkbox';
 import Wysiwyg from 'components/form/Wysiwyg';
+import Select from 'components/form/SelectInput';
 
 class Step1 extends React.Component {
   constructor(props) {
@@ -102,6 +103,28 @@ class Step1 extends React.Component {
               </div>
             </div>
           </div>
+
+          {/* ENVIRONMENT */}
+          <Field
+            ref={(c) => { if (c) FORM_ELEMENTS.elements.env = c; }}
+            className="-fluid"
+            options={[
+              { label: 'Staging', value: 'staging' },
+              { label: 'Preproduction', value: 'preproduction' },
+              { label: 'Production', value: 'production' },
+            ]}
+            onChange={(value) => this.props.onChange({ env: value })}
+            properties={{
+              name: 'env',
+              label: 'Environment',
+              placeholder: 'Choose an environment...',
+              noResultsText: 'Please, choose an environment for this page',
+              default: process.env.NEXT_PUBLIC_API_ENV,
+              value: this.props.form.env,
+            }}
+          >
+            {Select}
+          </Field>
 
           {/* PUBLISHED */}
           <Field

--- a/components/admin/partners/form/steps/Step1.js
+++ b/components/admin/partners/form/steps/Step1.js
@@ -222,6 +222,28 @@ class Step1 extends React.Component {
           </div>
         </div>
 
+        {/* ENVIRONMENT */}
+        <Field
+          ref={(c) => { if (c) FORM_ELEMENTS.elements.env = c; }}
+          className="-fluid"
+          options={[
+            { label: 'Staging', value: 'staging' },
+            { label: 'Preproduction', value: 'preproduction' },
+            { label: 'Production', value: 'production' },
+          ]}
+          onChange={(value) => this.props.onChange({ env: value })}
+          properties={{
+            name: 'env',
+            label: 'Environment',
+            placeholder: 'Choose an environment...',
+            noResultsText: 'Please, choose an environment for this partner',
+            default: process.env.NEXT_PUBLIC_API_ENV,
+            value: this.props.form.env,
+          }}
+        >
+          {Select}
+        </Field>
+
         {/* FEATURED */}
         <Field
           ref={(c) => { if (c) FORM_ELEMENTS.elements.featured = c; }}

--- a/components/admin/tools/form/steps/Step1.js
+++ b/components/admin/tools/form/steps/Step1.js
@@ -10,6 +10,7 @@ import Input from 'components/form/Input';
 import TextArea from 'components/form/TextArea';
 import FileImage from 'components/form/FileImage';
 import Checkbox from 'components/form/Checkbox';
+import Select from 'components/form/SelectInput';
 
 class Step1 extends React.Component {
   constructor(props) {
@@ -117,6 +118,28 @@ class Step1 extends React.Component {
               </div>
             </div>
           </div>
+
+          {/* ENVIRONMENT */}
+          <Field
+            ref={(c) => { if (c) FORM_ELEMENTS.elements.env = c; }}
+            className="-fluid"
+            options={[
+              { label: 'Staging', value: 'staging' },
+              { label: 'Preproduction', value: 'preproduction' },
+              { label: 'Production', value: 'production' },
+            ]}
+            onChange={(value) => this.props.onChange({ env: value })}
+            properties={{
+              name: 'env',
+              label: 'Environment',
+              placeholder: 'Choose an environment...',
+              noResultsText: 'Please, choose an environment for this tool',
+              default: process.env.NEXT_PUBLIC_API_ENV,
+              value: this.props.form.env,
+            }}
+          >
+            {Select}
+          </Field>
 
           {/* PUBLISHED */}
           <Field

--- a/components/dashboards/form/steps/step-1/component.jsx
+++ b/components/dashboards/form/steps/step-1/component.jsx
@@ -6,6 +6,7 @@ import isEmpty from 'lodash/isEmpty';
 // components
 import Field from 'components/form/Field';
 import Input from 'components/form/Input';
+import Select from 'components/form/SelectInput';
 import TextArea from 'components/form/TextArea';
 import FileImage from 'components/form/FileImage';
 import Checkbox from 'components/form/Checkbox';
@@ -176,40 +177,19 @@ class Step1 extends PureComponent {
           {!basic
           && (
             <Field
-              ref={(c) => {
-                if (c) FORM_ELEMENTS.elements.preproduction = c;
-              }}
-              onChange={(value) => onChange({ preproduction: value.checked })}
+              ref={(c) => { if (c) FORM_ELEMENTS.elements.env = c; }}
+              className="-fluid"
+              options={[{ label: 'Production', value: 'production' }, { label: 'Preproduction', value: 'preproduction' }, { label: 'Staging', value: 'staging' }]}
+              onChange={(value) => onChange({ env: value })}
               properties={{
-                name: 'preproduction',
-                label: 'Do you want to set this dashboard as pre-production?',
-                value: 'preproduction',
-                title: 'Pre-production',
-                defaultChecked: form.preproduction,
-                checked: form.preproduction,
+                name: 'env',
+                label: 'Environment',
+                placeholder: 'Choose an environment...',
+                default: process.env.NEXT_PUBLIC_API_ENV,
+                value: form.env,
               }}
             >
-              {Checkbox}
-            </Field>
-          )}
-
-          {!basic
-          && (
-            <Field
-              ref={(c) => {
-                if (c) FORM_ELEMENTS.elements.production = c;
-              }}
-              onChange={(value) => onChange({ production: value.checked })}
-              properties={{
-                name: 'production',
-                label: 'Do you want to set this dashboard as production?',
-                value: 'production',
-                title: 'Production',
-                defaultChecked: form.production,
-                checked: form.production,
-              }}
-            >
-              {Checkbox}
+              {Select}
             </Field>
           )}
 
@@ -325,8 +305,7 @@ Step1.propTypes = {
     content: PropTypes.string,
     'is-featured': PropTypes.bool,
     'is-highlighted': PropTypes.bool,
-    production: PropTypes.string,
-    preproduction: PropTypes.string,
+    env: PropTypes.string,
     published: PropTypes.bool,
     photo: PropTypes.string,
     description: PropTypes.string,

--- a/components/datasets/form/steps/component.js
+++ b/components/datasets/form/steps/component.js
@@ -192,17 +192,15 @@ class Step1 extends PureComponent {
               }
               className="-fluid"
               options={[
-                { label: 'Pre-production', value: 'preproduction' },
+                { label: 'Staging', value: 'staging' },
+                { label: 'Preproduction', value: 'preproduction' },
                 { label: 'Production', value: 'production' },
               ]}
               onChange={(value) => this.props.onChange({ env: value })}
               properties={{
                 name: 'env',
                 label: 'Environment',
-                placeholder: 'Type the columns...',
-                noResultsText: 'Please, type the name of the columns and press enter',
-                promptTextCreator: (label) => `The name of the column is "${label}"`,
-                default: 'preproduction',
+                default: process.env.NEXT_PUBLIC_API_ENV,
                 value: this.props.form.env,
               }}
             >


### PR DESCRIPTION
## Overview

This PR adds environment selectors to those forms where they are missing.

## Testing instructions
Verify that all entities from the back office have a working environment selector (dataset, widget, layer, dashboard, partner, tool, page...)

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/RER-44