### PR TITLE
fixes explore route on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Fixed
+- wrong pathname route when the explore tries to reflect its state in the URL. [RW-82](https://vizzuality.atlassian.net/browse/RW-82)
 - WYSIWYG: removes mini-explore button from toolbar. [RW-74](https://vizzuality.atlassian.net/browse/RW-74)
 - opacity 0 couldn't be applied to layer. [OW-94](https://vizzuality.atlassian.net/browse/OW-94)
 - data explore: areas of interest not loading.[RW-67](https://vizzuality.atlassian.net/browse/RW-67)

--- a/pages/data/explore/[[...dataset]].jsx
+++ b/pages/data/explore/[[...dataset]].jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'next/router';
 
 // actions
-import { setIsServer } from 'redactions/common';
+import { setIsServer as setServerAction } from 'redactions/common';
 import * as actions from 'layout/explore/actions';
 
 // hoc
@@ -17,17 +17,12 @@ import {
 import Explore from 'layout/explore';
 
 class ExplorePage extends PureComponent {
-  static propTypes = {
-    explore: PropTypes.object.isRequired,
-    resetExplore: PropTypes.func.isRequired,
-    setIsServer: PropTypes.func.isRequired,
-    router: PropTypes.shape({
-      replace: PropTypes.func.isRequired,
-    }).isRequired,
-  };
-
   componentDidMount() {
-    this.props.setIsServer(false);
+    const {
+      setIsServer,
+    } = this.props;
+
+    setIsServer(false);
   }
 
   componentDidUpdate(prevProps) {
@@ -107,7 +102,7 @@ class ExplorePage extends PureComponent {
     if (typeof window !== 'undefined') {
       router.replace(
         {
-          pathname: 'explore',
+          pathname: '/data/explore/[[...dataset]]',
           query,
         },
         {},
@@ -248,10 +243,55 @@ export const getServerSideProps = withRedux(withUserServerSide(async ({ store, q
   });
 }));
 
+ExplorePage.propTypes = {
+  explore: PropTypes.shape({
+    datasets: PropTypes.arrayOf(PropTypes.shape({})),
+    filters: PropTypes.shape({
+      search: PropTypes.string,
+      selected: PropTypes.shape({
+        topics: PropTypes.arrayOf(PropTypes.shape({})),
+        data_types: PropTypes.arrayOf(PropTypes.shape({})),
+        frequencies: PropTypes.arrayOf(PropTypes.shape({})),
+        time_periods: PropTypes.arrayOf(PropTypes.shape({})),
+      }),
+    }),
+    map: PropTypes.shape({
+      viewport: PropTypes.shape({
+        zoom: PropTypes.number,
+        latitude: PropTypes.number,
+        longitude: PropTypes.number,
+        pitch: PropTypes.number,
+        bearing: PropTypes.number,
+      }),
+      basemap: PropTypes.string,
+      labels: PropTypes.string,
+      boundaries: PropTypes.bool,
+      layerGroups: PropTypes.arrayOf(
+        PropTypes.shape({}),
+      ),
+      aoi: PropTypes.string,
+    }),
+    sidebar: PropTypes.shape({
+      section: PropTypes.string,
+      anchor: PropTypes.string,
+      selectedCollection: PropTypes.string,
+    }),
+    sort: PropTypes.shape({
+      selected: PropTypes.string,
+      direction: PropTypes.string,
+    }),
+  }).isRequired,
+  resetExplore: PropTypes.func.isRequired,
+  setIsServer: PropTypes.func.isRequired,
+  router: PropTypes.shape({
+    replace: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
 export default connect(
   (state) => ({ explore: state.explore }),
   {
     ...actions,
-    setIsServer,
+    setIsServer: setServerAction,
   },
 )(withRouter(ExplorePage));


### PR DESCRIPTION
## Overview

Fixes a wrong update from the router when the explore page tried to update its state to be reflected in the URL.

## Testing instructions
 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/RW-82

### Demo
–

### Notes
–

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
