### PR TITLE
updates Ocean links to point to Ocean Watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.2.0] - X
 ### Added
+- redirect from `/dashboards/ocean` to `/dashboards/ocean-watch`.
 - Ocean Watch: Ocean Watch beta. [OW-171](https://vizzuality.atlassian.net/browse/OW-171)
 - Ocean Watch: analytics events. [OW-76](https://vizzuality.atlassian.net/browse/OW-76)
 - Ocean Watch: added OW partners carousel to several pages.
@@ -55,6 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ### Changed
+- updates links pointing to old Ocean dashboard to point to new Ocean Watch dashboard.
 - Ocean Watch: changed texts and links of "Suggest a Story" banner. [OW-129](https://vizzuality.atlassian.net/browse/OW-129)
 - Ocean Watch storytelling: increases map zoom one level. [OW-113](https://vizzuality.atlassian.net/browse/OW-113)
 - `redux@4.1.0`

--- a/layout/app/dashboards/component.jsx
+++ b/layout/app/dashboards/component.jsx
@@ -40,8 +40,8 @@ export default function LayoutDashboards({
       photo,
       user,
     }) => ({
-      name,
-      slug,
+      name: slug === 'ocean' ? 'Ocean Watch' : name,
+      slug: slug === 'ocean' ? 'ocean-watch' : slug,
       photo,
       user,
     })),

--- a/layout/app/home/component.jsx
+++ b/layout/app/home/component.jsx
@@ -62,8 +62,8 @@ export default function LayoutHome() {
       photo,
       user,
     }) => ({
-      name,
-      slug,
+      name: slug === 'ocean' ? 'Ocean Watch' : name,
+      slug: slug === 'ocean' ? 'ocean-watch' : slug,
       photo,
       user,
     })),

--- a/layout/explore/explore-topics/constants.js
+++ b/layout/explore/explore-topics/constants.js
@@ -43,10 +43,10 @@ export const TOPICS = [
   },
   {
     id: 'ocean',
-    label: 'Ocean',
+    label: 'Ocean Watch',
     backgroundURL: '/static/images/components/layout/explore/topics/topics-oceans.jpg',
     backgroundColor: 'rgba(44,117,176,0.7)',
-    slug: 'ocean',
+    slug: 'ocean-watch',
   },
   {
     id: 'urban',

--- a/layout/footer/footer-links/component.jsx
+++ b/layout/footer/footer-links/component.jsx
@@ -24,9 +24,9 @@ export default function FooterLinks() {
     isError,
   } = useFeaturedDashboards({ env: process.env.NEXT_PUBLIC_ENVS_SHOW }, {
     select: (_dashboards) => _dashboards.map(({ id, name, slug }) => ({
-      id,
-      label: name,
-      href: `/dashboards/${slug}`,
+      id: slug === 'ocean' ? 'ocean-watch' : id,
+      label: slug === 'ocean' ? 'Ocean Watch' : name,
+      href: slug === 'ocean' ? '/dashboards/ocean-watch' : `/dashboards/${slug}`,
     })),
     placeholderData: [],
     refetchOnWindowFocus: false,

--- a/layout/header/header-dashboards/component.jsx
+++ b/layout/header/header-dashboards/component.jsx
@@ -20,9 +20,9 @@ export default function HeaderDashboards() {
     data: featuredDashboards,
   } = useFeaturedDashboards({ env: process.env.NEXT_PUBLIC_ENVS_SHOW }, {
     select: (_dashboards) => _dashboards.map(({ id, name, slug }) => ({
-      id,
-      label: name,
-      href: `/dashboards/${slug}`,
+      id: slug === 'ocean' ? 'ocean-watch' : id,
+      label: slug === 'ocean' ? 'Ocean Watch' : name,
+      href: slug === 'ocean' ? '/dashboards/ocean-watch' : `/dashboards/${slug}`,
     })),
     placeholderData: [],
     refetchOnWindowFocus: false,

--- a/next.config.js
+++ b/next.config.js
@@ -40,6 +40,11 @@ module.exports = withBundleAnalyzer(withCSS(withSass({
         destination: '/myrw/widgets/my_widgets',
         permanent: true,
       },
+      {
+        source: '/dashboards/ocean',
+        destination: '/dashboards/ocean-watch',
+        permanent: true,
+      },
     ];
   },
 


### PR DESCRIPTION
## Overview

- Replaces Ocean dashboard links with Ocean Watch dashboard link.
- Adds redirect from `/dashboards/ocean` to `/dashboards/ocean-watch`.

## Testing instructions
–

## Jira task / Github issue
–

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
