### PR TITLE
wysiwyg: removes mini explore option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- `@vizzuality/wysiwyg@3.1.4` [RW-74](https://vizzuality.atlassian.net/browse/RW-74)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@next/env": "10.0.8",
     "@reduxjs/toolkit": "^1.5.1",
     "@vizzuality/layer-manager-utils": "^1.0.0-alpha.3",
-    "@vizzuality/wysiwyg": "^3.1.1",
+    "@vizzuality/wysiwyg": "^3.1.4",
     "@widget-editor/renderer": "^2.6.2",
     "@widget-editor/rw-adapter": "^2.6.2",
     "@widget-editor/widget-editor": "^2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3365,10 +3365,10 @@
     axios "^0.21.1"
     cancelable-promise "^3.2.3"
 
-"@vizzuality/wysiwyg@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@vizzuality/wysiwyg/-/wysiwyg-3.1.1.tgz#3d129031de8a298e964185e7bece574fc36f7b58"
-  integrity sha512-SwghhbesgAn00/4MSB/QzZKZa8jY6p4G+iNwim6N2vRM4PC1cRmBd0/OccH+CkHhi9twxWquo1GB2Sv3zAKU2w==
+"@vizzuality/wysiwyg@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@vizzuality/wysiwyg/-/wysiwyg-3.1.4.tgz#9cb97198a2c82c38fc1060c9e669e3d910a520d9"
+  integrity sha512-KmF9xAbhHbi5brSFsqVU/zxh6UBjNICJz83QbSpU7LPNcEMlCTiDq3YqQvNcEvpx4Yfb2DeJf45M1E8SfOvIKQ==
   dependencies:
     classnames "2.2.5"
     foundation-sites "^6.6.3"


### PR DESCRIPTION
## Overview

WYSIWYG: removes `mini-explore` option in the content list as this is not available.

Before
![image](https://user-images.githubusercontent.com/999124/136366565-617cdb48-f8d0-4c3b-83cd-d5dbcb3f2149.png)


After
![image](https://user-images.githubusercontent.com/999124/136366480-413cab30-3dd4-45c2-bb1f-41d9edee3490.png)

## Testing instructions
- run `yarn` first

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/RW-74


## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
