### PR TITLE
adds hidden field to newsletter to identify Ocean Watch visitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.X.X] - 2021-X-X
 ### Added
+- Hidden field to newsletter to identify users coming from Ocean Watch pages. [OW-181](https://vizzuality.atlassian.net/browse/OW-181)
 - Ability to remove border styles of Area of Interest layer. [OW-91](https://vizzuality.atlassian.net/browse/OW-91)
 
 ### Changed

--- a/layout/app/newsletter/component.jsx
+++ b/layout/app/newsletter/component.jsx
@@ -1,6 +1,7 @@
-import React, {
+import {
   useState,
 } from 'react';
+import PropTypes from 'prop-types';
 import Link from 'next/link';
 
 // components
@@ -20,7 +21,9 @@ import {
   PARDOT_NEWSLETTER_URL,
 } from './constants';
 
-export default function LayoutNewsletter() {
+export default function LayoutNewsletter({
+  isOceanWatch,
+}) {
   const [form, setForm] = useState({});
   const [modalVisibility, setModalVisibility] = useState(false);
 
@@ -196,6 +199,21 @@ export default function LayoutNewsletter() {
                   {Input}
                 </Field>
 
+                {isOceanWatch && (
+                  <Field
+                    className="-pi-hidden"
+                    properties={{
+                      name: 'ocean-watch',
+                      label: 'Ocean Watch',
+                      type: 'text',
+                      required: false,
+                      value: 'true',
+                    }}
+                  >
+                    {Input}
+                  </Field>
+                )}
+
                 <div className="c-button-container -j-end">
                   <button
                     type="submit"
@@ -239,3 +257,11 @@ export default function LayoutNewsletter() {
     </Layout>
   );
 }
+
+LayoutNewsletter.defaultProps = {
+  isOceanWatch: false,
+};
+
+LayoutNewsletter.propTypes = {
+  isOceanWatch: PropTypes.bool,
+};

--- a/layout/footer/component.jsx
+++ b/layout/footer/component.jsx
@@ -1,4 +1,8 @@
+import {
+  useMemo,
+} from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 // components
 import Icon from 'components/ui/icon';
@@ -6,6 +10,12 @@ import FooterLinks from './footer-links';
 import PartnersCarousel from './partners-carousel';
 
 export default function Footer() {
+  const {
+    asPath,
+  } = useRouter();
+
+  const isOceanWatch = useMemo(() => asPath.includes('ocean-watch'), [asPath]);
+
   return (
     <footer className="l-footer">
       <div className="footer-main">
@@ -32,7 +42,7 @@ export default function Footer() {
               <ul>
                 <li>
                   <Link
-                    href="/about/newsletter"
+                    href={`/about/newsletter${isOceanWatch ? '?origin=ocean-watch' : ''}`}
                   >
                     <a className="c-button -primary join-us-button">
                       Subscribe to our newsletter

--- a/pages/about/newsletter/index.jsx
+++ b/pages/about/newsletter/index.jsx
@@ -1,6 +1,16 @@
+import {
+  useMemo,
+} from 'react';
+import { useRouter } from 'next/router';
 // components
 import LayoutNewsletter from 'layout/app/newsletter';
 
 export default function NewsletterPage() {
-  return (<LayoutNewsletter />);
+  const {
+    query,
+  } = useRouter();
+
+  const isOceanWatch = useMemo(() => query.origin === 'ocean-watch', [query]);
+
+  return (<LayoutNewsletter isOceanWatch={isOceanWatch} />);
 }


### PR DESCRIPTION
## Overview

Adds hidden field to the Resource Watch newsletter form to identify users coming from Ocean Watch pages.

## Testing instructions
- Start on an Ocean Watch page, go to the newsletter. The URL should contain an `origin=resource-watch` query param. If you go to the newsletter from a different page, the query param won't appear.
- If the page has the param, the form will send a hidden field `ocean-watch: true` once the user submits. Otherwise, it will send the usual fields. 

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/OW-181

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
