### PR TITLE
zoom controls to map-slide type widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.X.X] - 2021-X-X
 ### Added
+- zoom controls to map-slide type widgets. [OW-101](https://vizzuality.atlassian.net/browse/OW-101)
 - Hidden field to newsletter to identify users coming from Ocean Watch pages. [OW-181](https://vizzuality.atlassian.net/browse/OW-181)
 - Ability to remove border styles of Area of Interest layer. [OW-91](https://vizzuality.atlassian.net/browse/OW-91)
 

--- a/components/map/plugins/compare/mapbox-compare.js
+++ b/components/map/plugins/compare/mapbox-compare.js
@@ -1,6 +1,5 @@
 import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import syncMove from '@mapbox/mapbox-gl-sync-move';
 import EventEmitter from 'events';
 
 class MapboxCompare extends PureComponent {
@@ -47,7 +46,6 @@ class MapboxCompare extends PureComponent {
     const { options: { swiper } } = this.props;
     const swiperPosition = (this._horizontal ? this._bounds.height : this._bounds.width) / 2;
     this._setPosition(swiperPosition);
-    syncMove(this._leftRef, this._rightRef);
 
     this._rightRef.on('resize', this._onResize);
 

--- a/layout/embed/map-swipe/component.jsx
+++ b/layout/embed/map-swipe/component.jsx
@@ -8,7 +8,6 @@ import Spinner from 'components/ui/Spinner';
 const LayoutEmbedMapSwipe = ({
   isFetching,
   layers,
-  mapOptions,
   bbox,
 }) => (
   <LayoutEmbed
@@ -26,7 +25,6 @@ const LayoutEmbedMapSwipe = ({
       <CompareMaps
         layers={layers}
         bbox={bbox}
-        mapOptions={mapOptions}
       />
     )}
   </LayoutEmbed>
@@ -41,11 +39,9 @@ LayoutEmbedMapSwipe.propTypes = {
     PropTypes.shape({}),
   ).isRequired,
   isFetching: PropTypes.bool.isRequired,
-  mapOptions: PropTypes.shape({
-    viewport: PropTypes.shape({}),
-  }).isRequired,
   bbox: PropTypes.arrayOf(
     PropTypes.number,
   ),
 };
+
 export default LayoutEmbedMapSwipe;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@artsy/fresnel": "^1.5.0",
     "@mapbox/mapbox-gl-draw": "^1.1.2",
-    "@mapbox/mapbox-gl-sync-move": "^0.3.0",
     "@math.gl/web-mercator": "^3.3.1",
     "@next/bundle-analyzer": "^10.0.7",
     "@next/env": "10.0.8",
@@ -45,7 +44,6 @@
     "lodash": "^4.17.21",
     "lodash.isnumber": "^3.0.3",
     "luma.gl": "^7.1.1",
-    "mapbox-gl-compare": "^0.2.1",
     "moment": "^2.24.0",
     "next": "^11.1.0",
     "next-auth": "^3.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,16 +1859,6 @@
   resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz#f60b6a55a5d8e5ee908347d2ce4250b15103dc8e"
   integrity sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==
 
-"@mapbox/mapbox-gl-sync-move@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-sync-move/-/mapbox-gl-sync-move-0.2.0.tgz#011835ba0bab9d26c310b0330f512058b2c0957d"
-  integrity sha1-ARg1ugurnSbDELAzD1EgWLLAlX0=
-
-"@mapbox/mapbox-gl-sync-move@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-sync-move/-/mapbox-gl-sync-move-0.3.0.tgz#5a1d9b7cbd531702c4ab9d49f2b6c80977420d90"
-  integrity sha512-ecApNLDoOdKVTZEKI/Wb5ZPinegHH1KyrEM5T6Q5QcNPDEoOFC/Gn8bK5iv4sD2akfNJacDtqqTaa1f2Oz6m+w==
-
 "@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
@@ -11703,13 +11693,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-mapbox-gl-compare@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/mapbox-gl-compare/-/mapbox-gl-compare-0.2.1.tgz#989edfdf9b42a3b45cc16849e2b6dd484e14dea7"
-  integrity sha512-SSoNFJCtODuT8AIUXQrY3Pu9y1mAJFgEjRF6yJt7q6R2T9JvzVU6MAta3wxXyyu1yDDrtU7l/IXAs+b1cYQfvw==
-  dependencies:
-    "@mapbox/mapbox-gl-sync-move" "^0.2.0"
 
 mapbox-gl@^1.0.0:
   version "1.13.1"


### PR DESCRIPTION
## Overview

![image](https://user-images.githubusercontent.com/999124/139307384-b533e98a-26da-4ca9-addd-02a656ebfb3c.png)

- Adds zoom controls to map-slide type widgets.
- Removes dependences: `@mapbox/mapbox-gl-sync-move`, `mapbox-gl-compare`
- The maps stop relying on `@mapbox/mapbox-gl-sync-move` to sync and rely now the local viewport start to sync.

## Testing instructions
As we have 2 inputs to display embedded map slides, the 2 routes must be tested:
- [http://localhost:3000/embed/map-swipe?zoom=3&lat=5&lng=60&layers=6a531ac5-7146-4105-ba78-8a54ae45837f,eb2a70d6-81b1-43e6-acc3-148af11c5a3b](http://localhost:3000/embed/map-swipe?zoom=3&lat=5&lng=60&layers=6a531ac5-7146-4105-ba78-8a54ae45837f,eb2a70d6-81b1-43e6-acc3-148af11c5a3b) 
- [http://localhost:3000/embed/map-swipe/2d80df96-f93e-4a1b-95fc-4f1241139c0e?geostore_env=geostore_prod&geostore_id=804b97bc661ae04c2b899d71ecaeb858&aoi=804b97bc661ae04c2b899d71ecaeb858](http://localhost:3000/embed/map-swipe/2d80df96-f93e-4a1b-95fc-4f1241139c0e?geostore_env=geostore_prod&geostore_id=804b97bc661ae04c2b899d71ecaeb858&aoi=804b97bc661ae04c2b899d71ecaeb858)

For both cases, the zoom controls must appear at the top right corner of the right map and work as expected.

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/OW-101

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
