### PR TITLE
enforces layer activeness regardless configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ability to remove border styles of Area of Interest layer. [OW-91](https://vizzuality.atlassian.net/browse/OW-91)
 
 ### Changed
+- enforces layer activeness in map/map-swipe widgets regardless its configuration.
 - `@vizzuality/wysiwyg@3.1.4` [RW-74](https://vizzuality.atlassian.net/browse/RW-74)
 
 ### Fixed

--- a/components/widgets/types/map-swipe/index.jsx
+++ b/components/widgets/types/map-swipe/index.jsx
@@ -149,8 +149,8 @@ export default function SwipeTypeWidgetContainer({
     const { layerParams } = widget?.widgetConfig?.paramsConfig || {};
 
     return ({
-      left: getLayerGroups(layers.left, layerParams),
-      right: getLayerGroups(layers.right, layerParams),
+      left: getLayerGroups(layers.left, layerParams, true),
+      right: getLayerGroups(layers.right, layerParams, true),
     });
   }, [layers, widget]);
 

--- a/components/widgets/types/map/index.jsx
+++ b/components/widgets/types/map/index.jsx
@@ -133,7 +133,7 @@ export default function MapTypeWidgetContainer({
 
   const layerGroups = useMemo(() => {
     const { layerParams } = widget?.widgetConfig?.paramsConfig || {};
-    return getLayerGroups(layers, layerParams);
+    return getLayerGroups(layers, layerParams, true);
   }, [layers, widget]);
 
   const isError = useMemo(

--- a/utils/layers/index.js
+++ b/utils/layers/index.js
@@ -41,9 +41,10 @@ export const getTilerUrl = (layer) => {
  *
  * @param {Object[]} layers - array of layers to group by dataset
  * @param {Object} layerParams - additional layer params to modify the layer specification
+ * @param {boolean} forceActive - enforces the layer to be active regardless its configuration
  * @returns {Object[]} array of layers grouped by dataset
  */
-export const getLayerGroups = (layers = [], layerParams = {}) => {
+export const getLayerGroups = (layers = [], layerParams = {}, forceActive = false) => {
   const layersByDataset = groupBy(layers, 'dataset');
 
   return Object.keys(layersByDataset).map((datasetKey) => ({
@@ -52,7 +53,7 @@ export const getLayerGroups = (layers = [], layerParams = {}) => {
     layers: layersByDataset[datasetKey]
       .map((_layer) => ({
         ..._layer,
-        active: layerParams?.[_layer.id]?.default || Boolean(_layer.default),
+        active: forceActive || (layerParams?.[_layer.id]?.default || Boolean(_layer.default)),
         opacity: isNumber(layerParams?.[_layer.id]?.opacity) ? layerParams[_layer.id].opacity : 1,
         ..._layer?.layerConfig?.type === 'gee' && {
           layerConfig: {


### PR DESCRIPTION
## Overview

Enforces activeness of layers inside map/swipe map widgets to avoid dependency of their configuration in certain cases.

## Testing instructions
–

## Jira task / Github issue
–

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
