### PR TITLE
mini-explore: fixes layer interactivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.X.X] - 2021-X-X
 ### Added
+
+### Changed
+
+### Fixed
+- mini-explore: layer interactivity. [OW-185](https://vizzuality.atlassian.net/browse/OW-185)
+
+### Removed
+
+## [3.3.0] - 2021-11-11
+### Added
 - zoom controls to map-slide type widgets. [OW-101](https://vizzuality.atlassian.net/browse/OW-101)
 - Hidden field to newsletter to identify users coming from Ocean Watch pages. [OW-181](https://vizzuality.atlassian.net/browse/OW-181)
 - Ability to remove border styles of Area of Interest layer. [OW-91](https://vizzuality.atlassian.net/browse/OW-91)
@@ -20,7 +30,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - explore URL to embed (/embed/data/explore) now supports (optionally) selected dataset when sharing. [RW-88](https://vizzuality.atlassian.net/browse/RW-88)
 - restores old endpoint to render embed map-swipes without a widget. [RW-89](https://vizzuality.atlassian.net/browse/RW-89)
 
-### Removed
 
 ## [3.2.0] - 2021-10-06
 ### Added

--- a/components/mini-explore/map/index.jsx
+++ b/components/mini-explore/map/index.jsx
@@ -352,15 +352,14 @@ export default function MiniExploreMapContainer({
 
   const activeInteractiveLayers = useMemo(() => flatten(
     compact(activeLayers.map((_activeLayer) => {
-      const { layerConfig } = _activeLayer;
-      if (isEmpty(layerConfig)) return null;
+      const { id, layerConfig, interactionConfig } = _activeLayer;
+      if (isEmpty(layerConfig) || isEmpty(interactionConfig)) return null;
 
       const { body = {} } = layerConfig;
       const { vectorLayers } = body;
 
       if (vectorLayers) {
-        return vectorLayers.filter(({ id: vectorLayerId }) => Boolean(vectorLayerId))
-          .map(({ id: vectorLayerId }) => vectorLayerId);
+        return vectorLayers.map(({ id: vectorLayerId, type: vectorLayerType }, index) => vectorLayerId || `${id}-${vectorLayerType}-${index}`);
       }
 
       return null;


### PR DESCRIPTION
## Overview
![image](https://user-images.githubusercontent.com/999124/141288423-53d21ad2-1ff2-46f4-811f-1954b1cd9a3e.png)

Fixes layer interactivity that allows displaying the tooltip with layer data.

## Testing instructions
–

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/OW-185

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
