### PR TITLE
UN compliant changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ability to remove border styles of Area of Interest layer. [OW-91](https://vizzuality.atlassian.net/browse/OW-91)
 
 ### Changed
+- hides boundaries of map selector in Ocean Watch homepage. [OW-192](https://vizzuality.atlassian.net/browse/OW-192)
+- ability to hide boundaries controls in maps. [OW-192](https://vizzuality.atlassian.net/browse/OW-192)
+- boundaries disabled by default in map slides. [OW-192](https://vizzuality.atlassian.net/browse/OW-192)
 - enforces layer activeness in map/map-swipe widgets regardless its configuration.
 - `@vizzuality/wysiwyg@3.1.4` [RW-74](https://vizzuality.atlassian.net/browse/RW-74)
 

--- a/components/map/layer-manager/component.js
+++ b/components/map/layer-manager/component.js
@@ -29,7 +29,7 @@ class LayerManager extends PureComponent {
           <Layer
             key={_layer.id}
             {..._layer}
-            {...(_layer.layerConfig.decoder && CANVAS_DECODERS[_layer.layerConfig.decoder])
+            {...(_layer?.layerConfig?.decoder && CANVAS_DECODERS[_layer.layerConfig.decoder])
               && { decodeFunction: CANVAS_DECODERS[_layer.layerConfig.decoder] }}
           />
         ))}

--- a/components/mini-explore/component.jsx
+++ b/components/mini-explore/component.jsx
@@ -24,11 +24,16 @@ export default function MiniExplore({
     title,
     datasetGroups,
     areaOfInterest,
+    boundaries,
+    disabledControls,
     aoiBorder,
     forcedBbox,
   },
 }) {
-  const [mapState, dispatch] = useReducer(miniExploreReducer, miniExploreState);
+  const [mapState, dispatch] = useReducer(miniExploreReducer, ({
+    ...miniExploreState,
+    ...boundaries && { boundaries },
+  }));
   const {
     layerGroups,
   } = mapState;
@@ -50,6 +55,7 @@ export default function MiniExplore({
         <MiniExploreMap
           dispatch={dispatch}
           mapState={mapState}
+          disabledControls={disabledControls}
           datasetGroups={datasetGroups}
           areaOfInterest={areaOfInterest}
           aoiBorder={aoiBorder}
@@ -70,6 +76,10 @@ MiniExplore.propTypes = {
         default: PropTypes.arrayOf(PropTypes.string),
       }),
     ).isRequired,
+    boundaries: PropTypes.bool,
+    disabledControls: PropTypes.arrayOf(
+      PropTypes.string,
+    ),
     areaOfInterest: PropTypes.string,
     aoiBorder: PropTypes.bool,
     forcedBbox: PropTypes.arrayOf(

--- a/components/mini-explore/component.stories.jsx
+++ b/components/mini-explore/component.stories.jsx
@@ -17,6 +17,8 @@ Template.propTypes = {
 };
 
 export const Default = Template.bind({});
+export const DisabledBoundariesControls = Template.bind({});
+
 Default.args = {
   config: {
     title: 'Lorem ipsum',
@@ -44,5 +46,36 @@ Default.args = {
         ],
       },
     ],
+  },
+};
+
+DisabledBoundariesControls.args = {
+  config: {
+    title: 'Lorem ipsum',
+    areaOfInterest: '972c24e1da2c2baacc7572ee9501abdc',
+    datasetGroups: [
+      {
+        title: 'Power Infrastructure',
+        datasets: [
+          'a86d906d-9862-4783-9e30-cdb68cd808b8',
+          'b75d8398-34f2-447d-832d-ea570451995a',
+          '4919be3a-c543-4964-a224-83ef801370de',
+        ],
+        default: [
+          'a86d906d-9862-4783-9e30-cdb68cd808b8',
+        ],
+      },
+      {
+        title: 'Natural hazards',
+        datasets: [
+          '484f10d3-a30b-4466-8052-c48d47cfb4a1',
+          'c5a62289-bdc8-4821-83f0-6f05e3d36bdc',
+        ],
+        default: [
+          '484f10d3-a30b-4466-8052-c48d47cfb4a1',
+        ],
+      },
+    ],
+    disabledControls: ['boundaries'],
   },
 };

--- a/components/mini-explore/map/component.jsx
+++ b/components/mini-explore/map/component.jsx
@@ -45,6 +45,7 @@ export default function MiniExploreMap({
   labelsId,
   bounds,
   boundaries,
+  disabledControls,
   activeLayers,
   activeInteractiveLayers,
   layerGroups,
@@ -164,6 +165,7 @@ export default function MiniExploreMap({
           basemap={basemap}
           labels={labels}
           boundaries={boundaries}
+          disabledControls={disabledControls}
           onChangeBasemap={handleBasemap}
           onChangeLabels={handleLabels}
           onChangeBoundaries={handleBoundaries}
@@ -234,6 +236,7 @@ MiniExploreMap.defaultProps = {
   layerModal: null,
   layerGroupsInteractionLatLng: null,
   layerGroupsInteractionSelected: null,
+  disabledControls: [],
   onLoad: null,
   onHover: null,
 };
@@ -245,6 +248,9 @@ MiniExploreMap.propTypes = {
   }).isRequired,
   bounds: PropTypes.shape({}).isRequired,
   boundaries: PropTypes.bool.isRequired,
+  disabledControls: PropTypes.arrayOf(
+    PropTypes.string,
+  ),
   basemapId: PropTypes.string.isRequired,
   labelsId: PropTypes.string.isRequired,
   layerModal: PropTypes.shape({}),

--- a/components/mini-explore/map/index.jsx
+++ b/components/mini-explore/map/index.jsx
@@ -78,6 +78,7 @@ export default function MiniExploreMapContainer({
   },
   datasetGroups,
   areaOfInterest,
+  disabledControls,
   aoiBorder,
   forcedBbox,
   dispatch,
@@ -378,6 +379,7 @@ export default function MiniExploreMapContainer({
       basemapId={basemapId}
       labelsId={labelsId}
       boundaries={boundaries}
+      disabledControls={disabledControls}
       layerGroups={layerGroups}
       activeLayers={activeLayers}
       activeInteractiveLayers={activeInteractiveLayers}
@@ -412,6 +414,7 @@ MiniExploreMapContainer.defaultProps = {
   areaOfInterest: null,
   aoiBorder: true,
   forcedBbox: null,
+  disabledControls: [],
 };
 
 MiniExploreMapContainer.propTypes = {
@@ -441,6 +444,9 @@ MiniExploreMapContainer.propTypes = {
     PropTypes.shape({}).isRequired,
   ).isRequired,
   areaOfInterest: PropTypes.string,
+  disabledControls: PropTypes.arrayOf(
+    PropTypes.string,
+  ),
   aoiBorder: PropTypes.bool,
   forcedBbox: PropTypes.arrayOf(
     PropTypes.number,

--- a/components/widgets/types/map-swipe/component.jsx
+++ b/components/widgets/types/map-swipe/component.jsx
@@ -117,6 +117,11 @@ export default function SwipeTypeWidget({
     ],
   }), [layerGroupsBySide, aoiLayer, maskLayer]);
 
+  const boundaries = useMemo(
+    () => Boolean(widget?.widgetConfig?.basemapLayers?.boundaries),
+    [widget],
+  );
+
   const caption = widget?.metadata?.[0]?.info?.caption;
 
   return (
@@ -168,7 +173,7 @@ export default function SwipeTypeWidget({
                 className="-compare"
                 basemap={basemap}
                 labels={labels}
-                boundaries
+                boundaries={boundaries}
                 scrollZoom={false}
                 viewport={viewport}
                 bounds={bounds}
@@ -230,7 +235,7 @@ export default function SwipeTypeWidget({
                 className="-compare"
                 basemap={basemap}
                 labels={labels}
-                boundaries
+                boundaries={boundaries}
                 scrollZoom={false}
                 viewport={viewport}
                 onViewportChange={handleViewport}
@@ -336,6 +341,7 @@ SwipeTypeWidget.propTypes = {
       basemapLayers: PropTypes.shape({
         basemap: PropTypes.string,
         labels: PropTypes.string,
+        boundaries: PropTypes.bool,
       }),
     }),
     metadata: PropTypes.arrayOf(

--- a/components/widgets/types/map/component.jsx
+++ b/components/widgets/types/map/component.jsx
@@ -165,7 +165,10 @@ export default function MapTypeWidget({
     });
   }, [widget, mapBounds]);
 
-  const boundaries = useMemo(() => !!widget?.widgetConfig?.basemapLayers?.boundaries, [widget]);
+  const boundaries = useMemo(
+    () => Boolean(widget?.widgetConfig?.basemapLayers?.boundaries),
+    [widget],
+  );
 
   const caption = widget?.metadata?.[0]?.info?.caption;
 

--- a/layout/layout/ocean-watch/hero/component.jsx
+++ b/layout/layout/ocean-watch/hero/component.jsx
@@ -24,7 +24,7 @@ const OCEAN_WATCH_TABS = [
     params: {},
   },
   {
-    label: 'Country Profile',
+    label: 'Coastal Profile',
     value: '/dashboards/ocean-watch/country/[iso]',
     route: '/dashboards/ocean-watch/country',
     params: {},

--- a/layout/layout/ocean-watch/map/component.jsx
+++ b/layout/layout/ocean-watch/map/component.jsx
@@ -260,7 +260,7 @@ export default function MapSelection() {
             lineHeight: 1.4,
           }}
         >
-          Select a coastal country to further explore
+          Select a coastline to further explore
           <br />
           land-based pressures upon the ocean
         </p>
@@ -404,7 +404,7 @@ export default function MapSelection() {
                 }}
                 onClick={() => { setVisibility(true); }}
               >
-                Select a country
+                Select a coastline
               </button>
             </Tooltip>
           </div>

--- a/layout/layout/ocean-watch/map/component.jsx
+++ b/layout/layout/ocean-watch/map/component.jsx
@@ -65,7 +65,6 @@ const layers = [
                 '#217098',
               ],
               'fill-opacity': 1,
-              'fill-outline-color': '#15527f',
             },
             'source-layer': 'layer0',
             type: 'fill',
@@ -96,7 +95,6 @@ const layers = [
             paint: {
               'fill-color': '#0f4573',
               'fill-opacity': 1,
-              'fill-outline-color': '#15527f',
             },
             'source-layer': 'layer0',
             type: 'fill',

--- a/pages/dashboards/ocean-watch/country/index.jsx
+++ b/pages/dashboards/ocean-watch/country/index.jsx
@@ -61,7 +61,7 @@ export default function OceanWatchCountryProfiles() {
                 onChange={handleAreaChange}
                 clearable={false}
                 value={countryValue}
-                placeholder="Select a country"
+                placeholder="Select a coastline"
               />
               <div
                 style={{
@@ -84,7 +84,7 @@ export default function OceanWatchCountryProfiles() {
                     textAlign: 'center',
                   }}
                 >
-                  Select a coastal country to further explore
+                  Select a coastline country to further explore
                   {' '}
                   <br />
                   land-based pressures upon the ocean.


### PR DESCRIPTION
## Overview
![image](https://user-images.githubusercontent.com/999124/141780048-5b3d3d68-b251-484c-a290-d722c58c82d0.png)


Set of changes in maps to compliant UN requirements:
- removes boundaries of slide maps.
- allows hiding boundaries controls.
- removes boundaries in map selector located in Ocean Watch homepage.

## Testing instructions
–

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/OW-192

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
