### PR TITLE
Layer Manager v4 - Ocean Watch-related changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `tailwindcss` framework.
 
 ### Changed
+- updates standalone Area of Interest layer specs to match new layer specification. [RW-99](https://vizzuality.atlassian.net/browse/RW-99)[RW-97](https://vizzuality.atlassian.net/browse/RW-97)[RW-102](https://vizzuality.atlassian.net/browse/RW-102)
+- makes map's `onMapViewportChange` function optional.	
 - `webpack 5` and `next@12`
 - improved styles for widget captions. [OW-164](https://vizzuality.atlassian.net/browse/OW-164)
 

--- a/components/app/myrw/areas/tabs/index/component.jsx
+++ b/components/app/myrw/areas/tabs/index/component.jsx
@@ -11,9 +11,7 @@ import Paginator from 'components/ui/Paginator';
 // hooks
 import usePaginatedUserAreas from 'hooks/user-areas/paginated-user-areas';
 
-const AreasIndex = ({
-  token,
-}) => {
+const AreasIndex = ({ token }) => {
   const router = useRouter();
   const [pagination, setPagination] = useState({
     page: 1,
@@ -21,10 +19,7 @@ const AreasIndex = ({
     size: 0,
   });
   const {
-    data: {
-      areas: userAreas,
-      meta,
-    },
+    data: { areas: userAreas, meta },
     isFetching,
     isSuccess,
     isFetchedAfterMount,
@@ -35,17 +30,21 @@ const AreasIndex = ({
     sort: 'name',
   });
 
-  const handlePagination = useCallback((_nextPage) => {
-    setPagination({
-      ...pagination,
-      page: _nextPage,
-    });
-  }, [pagination]);
+  const handlePagination = useCallback(
+    (_nextPage) => {
+      setPagination({
+        ...pagination,
+        page: _nextPage,
+      });
+    },
+    [pagination],
+  );
 
   const handleMapView = useCallback(
     ({ id }) => {
       router.push(`/data/explore?aoi=${id}`);
-    }, [router],
+    },
+    [router],
   );
 
   const handleDeletionArea = useCallback(() => {
@@ -70,22 +69,15 @@ const AreasIndex = ({
           <ul>
             <li>
               <Link href="/myrw-detail/areas/new">
-                <a className="c-button -secondary">
-                  New area
-                </a>
+                <a className="c-button -secondary">New area</a>
               </Link>
             </li>
           </ul>
         </div>
-        {isFetching && (
-          <Spinner
-            isLoading
-            className="spinner -small -right -transparent"
-          />
-        )}
+        {isFetching && <Spinner isLoading className="spinner -small -right -transparent" />}
       </div>
 
-      {(isSuccess && isFetchedAfterMount) && (
+      {isSuccess && isFetchedAfterMount && (
         <>
           <AreaCardList
             areas={userAreas}
@@ -95,11 +87,8 @@ const AreasIndex = ({
             onDeletionArea={handleDeletionArea}
           />
 
-          {(pagination.size > pagination.limit) && (
-            <Paginator
-              options={pagination}
-              onChange={handlePagination}
-            />
+          {pagination.size > pagination.limit && (
+            <Paginator options={pagination} onChange={handlePagination} />
           )}
         </>
       )}

--- a/components/areas/card/component.jsx
+++ b/components/areas/card/component.jsx
@@ -1,10 +1,4 @@
-import {
-  useState,
-  useEffect,
-  useCallback,
-  useRef,
-  useMemo,
-} from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { toastr } from 'react-redux-toastr';
@@ -16,10 +10,7 @@ import { fetchGeostore } from 'services/geostore';
 import { updateArea } from 'services/areas';
 
 // constants
-import {
-  DEFAULT_VIEWPORT,
-  MAPSTYLES,
-} from 'components/map/constants';
+import { DEFAULT_VIEWPORT, MAPSTYLES } from 'components/map/constants';
 
 // components
 import Map from 'components/map';
@@ -46,14 +37,7 @@ const AreaCard = (props) => {
     onChangedVisibility,
     onDeletionArea,
   } = props;
-  const {
-    id,
-    geostore,
-    subscription,
-    name,
-    geostore: geostoreId,
-    isVisible,
-  } = area;
+  const { id, geostore, subscription, name, geostore: geostoreId, isVisible } = area;
   const tooltipRef = useRef(null);
   const formRef = useRef(null);
   const nameRef = useRef(null);
@@ -64,39 +48,39 @@ const AreaCard = (props) => {
   const [loading, setLoadingState] = useState(true);
   const [layer, setLayerState] = useState({ bounds: {}, geojson: null });
 
-  const {
-    data: subscriptionsByArea,
-    refetch,
-  } = useSubscriptionsByArea(id, token);
+  const { data: subscriptionsByArea, refetch } = useSubscriptionsByArea(id, token);
 
   const handleMapView = useCallback(() => onMapView(area), [onMapView, area]);
 
-  const handleEditSubscription = useCallback((modalState = true) => {
-    setModalState({
-      open: modalState,
-      mode: subscription ? 'edit' : 'new',
-    });
-  }, [subscription]);
+  const handleEditSubscription = useCallback(
+    (modalState = true) => {
+      setModalState({
+        open: modalState,
+        mode: subscription ? 'edit' : 'new',
+      });
+    },
+    [subscription],
+  );
 
   const handleDeleteArea = useCallback(() => {
-    toastr.confirm(`Are you sure you want to delete the area ${area.name}?
+    toastr.confirm(
+      `Are you sure you want to delete the area ${area.name}?
       Deleting an area will delete all the subscriptions associated to it`,
-    {
-      onOk: async () => {
-        try {
-          await removeUserArea(area);
-          onDeletionArea();
-        } catch (e) {
-          toastr.error(e.message);
-        }
+      {
+        onOk: async () => {
+          try {
+            await removeUserArea(area);
+            onDeletionArea();
+          } catch (e) {
+            toastr.error(e.message);
+          }
+        },
       },
-    });
+    );
   }, [removeUserArea, onDeletionArea, area]);
 
   const handleChangeVisibility = useCallback(async () => {
-    const {
-      public: isAreaPublic,
-    } = area;
+    const { public: isAreaPublic } = area;
     try {
       await updateArea(
         id,
@@ -130,32 +114,38 @@ const AreaCard = (props) => {
     setAreaName(evt.target.value);
   }, []);
 
-  const handleKeyDown = useCallback(async (evt) => {
-    if (evt.key === 'Escape') {
-      setAreaName(name);
-      nameRef.current.blur();
-    }
-  }, [name]);
+  const handleKeyDown = useCallback(
+    async (evt) => {
+      if (evt.key === 'Escape') {
+        setAreaName(name);
+        nameRef.current.blur();
+      }
+    },
+    [name],
+  );
 
-  const handleSubmit = useCallback(async (evt) => {
-    evt.preventDefault();
-    evt.stopPropagation();
+  const handleSubmit = useCallback(
+    async (evt) => {
+      evt.preventDefault();
+      evt.stopPropagation();
 
-    try {
-      await updateArea(
-        id,
-        {
-          name: areaName,
-          geostore,
-        },
-        token,
-      );
-      nameRef.current.blur();
-      if (onEditArea) onEditArea(id);
-    } catch (e) {
-      toastr.error('Something went wrong updating the area.');
-    }
-  }, [id, areaName, geostore, token, onEditArea]);
+      try {
+        await updateArea(
+          id,
+          {
+            name: areaName,
+            geostore,
+          },
+          token,
+        );
+        nameRef.current.blur();
+        if (onEditArea) onEditArea(id);
+      } catch (e) {
+        toastr.error('Something went wrong updating the area.');
+      }
+    },
+    [id, areaName, geostore, token, onEditArea],
+  );
 
   const openSubscriptionsModal = useCallback(() => {
     handleEditSubscription(true);
@@ -175,6 +165,8 @@ const AreaCard = (props) => {
           bounds: { bbox, options: { padding: 30 } },
           geojson,
         });
+
+        setLoadingState(false);
       })
       .catch((_error) => {
         if (axios.isCancel(_error)) {
@@ -183,6 +175,8 @@ const AreaCard = (props) => {
         } else {
           toastr.error(`Something went wrong loading your area "${name}"`);
         }
+
+        setLoadingState(false);
       });
   }, [area, geostoreId, name]);
 
@@ -198,19 +192,20 @@ const AreaCard = (props) => {
     '-ready': !loading,
   });
 
-  const userAreaLayer = useMemo(() => (geojson ? [getUserAreaLayer({ id: 'user-area', geojson })] : []), [geojson]);
+  const userAreaLayer = useMemo(
+    () => (geojson ? [getUserAreaLayer({ id: 'user-area', geojson })] : []),
+    [geojson],
+  );
 
-  const subscriptionsToConfirm = useMemo(() => subscriptionsByArea
-    .filter(({ confirmed }) => !confirmed),
-  [subscriptionsByArea]);
+  const subscriptionsToConfirm = useMemo(
+    () => subscriptionsByArea.filter(({ confirmed }) => !confirmed),
+    [subscriptionsByArea],
+  );
 
   return (
     <div className="c-area-card">
       <div className={mapContainerClass}>
-        <Spinner
-          isLoading={loading}
-          className="-transparent"
-        />
+        <Spinner isLoading={loading} className="-transparent" />
         <Map
           mapStyle={MAPSTYLES}
           viewport={DEFAULT_VIEWPORT}
@@ -226,28 +221,17 @@ const AreaCard = (props) => {
           dragRotate={false}
           dragPan={false}
           visible={!loading}
-          onLoad={({ map }) => {
-            map.on('render', () => {
-              if (map.areTilesLoaded()) {
-                setLoadingState(false);
-                map.off('render');
-              }
-            });
-          }}
         >
-          {(_map) => (
-            <LayerManager
-              map={_map}
-              layers={userAreaLayer}
-            />
-          )}
+          {(_map) => <LayerManager map={_map} layers={userAreaLayer} />}
         </Map>
       </div>
       <div className="text-container">
         <div className="basic-info">
           <div className="name-visibility">
             <form
-              ref={(ref) => { formRef.current = ref; }}
+              ref={(ref) => {
+                formRef.current = ref;
+              }}
               onSubmit={handleSubmit}
             >
               <input
@@ -256,7 +240,9 @@ const AreaCard = (props) => {
                 name="area-name"
                 required
                 minLength={3}
-                ref={(ref) => { nameRef.current = ref; }}
+                ref={(ref) => {
+                  nameRef.current = ref;
+                }}
                 onChange={handleChange}
                 onClick={handleClick}
                 onKeyDown={handleKeyDown}
@@ -268,21 +254,14 @@ const AreaCard = (props) => {
           </div>
           <div className="subscriptions">
             {subscriptionsByArea.length > 0 && (
-              <button
-                type="button"
-                className="c-btn -clean"
-                onClick={openSubscriptionsModal}
-              >
+              <button type="button" className="c-btn -clean" onClick={openSubscriptionsModal}>
                 {`${subscriptionsByArea.length} subscription`}
                 {subscriptionsByArea.length > 1 && 's'}
-                {subscriptionsToConfirm.length > 0 && ` (${subscriptionsToConfirm.length} to confirm)`}
+                {subscriptionsToConfirm.length > 0 &&
+                  ` (${subscriptionsToConfirm.length} to confirm)`}
               </button>
             )}
-            {!subscriptionsByArea.length && (
-              <span>
-                No subscriptions
-              </span>
-            )}
+            {!subscriptionsByArea.length && <span>No subscriptions</span>}
           </div>
         </div>
         <div className="actions-container">
@@ -301,24 +280,30 @@ const AreaCard = (props) => {
             overlayClassName="c-rc-tooltip -default"
             placement="top"
             destroyTooltipOnHide
-            onPopupAlign={(ref) => { tooltipRef.current = ref; }}
-            overlay={(
+            onPopupAlign={(ref) => {
+              tooltipRef.current = ref;
+            }}
+            overlay={
               <AreaActionsTooltip
                 area={area}
                 tooltipRef={tooltipRef}
                 showSubscriptions={showSubscriptions}
-                onMouseDown={() => { handleTooltip(false); }}
+                onMouseDown={() => {
+                  handleTooltip(false);
+                }}
                 onRenameArea={handleRenameArea}
                 onChangeVisibility={handleChangeVisibility}
                 onEditSubscriptions={openSubscriptionsModal}
                 onDeleteArea={handleDeleteArea}
               />
-            )}
+            }
           >
             <button
               type="button"
               className="c-btn -tertiary -compressed -fs-medium"
-              onClick={() => { handleTooltip(true); }}
+              onClick={() => {
+                handleTooltip(true);
+              }}
             >
               Edit
             </button>
@@ -327,14 +312,8 @@ const AreaCard = (props) => {
       </div>
 
       {isModalOpen && (
-        <Modal
-          isOpen
-          onRequestClose={closeSubscriptionsModal}
-        >
-          <SubscriptionsModal
-            area={area.id}
-            onRequestClose={closeSubscriptionsModal}
-          />
+        <Modal isOpen onRequestClose={closeSubscriptionsModal}>
+          <SubscriptionsModal area={area.id} onRequestClose={closeSubscriptionsModal} />
         </Modal>
       )}
     </div>
@@ -351,9 +330,7 @@ AreaCard.propTypes = {
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     geostore: PropTypes.string.isRequired,
-    subscriptions: PropTypes.arrayOf(
-      PropTypes.shape({}).isRequired,
-    ),
+    subscriptions: PropTypes.arrayOf(PropTypes.shape({}).isRequired),
     subscription: PropTypes.shape({}),
     isVisible: PropTypes.bool,
     public: PropTypes.bool.isRequired,

--- a/components/map/component.tsx
+++ b/components/map/component.tsx
@@ -48,7 +48,7 @@ export interface MapProps extends InteractiveMapProps {
   onMapLoad?: ({ map, mapContainer }) => void;
 
   /** A function that exposes the viewport */
-  onMapViewportChange: (viewport: Partial<ViewportProps>) => void;
+  onMapViewportChange?: (viewport: Partial<ViewportProps>) => void;
 }
 
 export const Map = ({
@@ -90,7 +90,7 @@ export const Map = ({
   }, [onMapLoad]);
 
   const debouncedOnMapViewportChange = useDebouncedCallback((v) => {
-    onMapViewportChange(v);
+    if (onMapViewportChange) onMapViewportChange(v);
   }, 250);
 
   const handleViewportChange = useCallback(

--- a/components/map/constants.ts
+++ b/components/map/constants.ts
@@ -1,5 +1,6 @@
 import isNumber from 'lodash/isNumber';
 import { ViewportProps } from 'react-map-gl';
+import { APILayerSpec } from 'types/layer';
 
 export const MAPSTYLES = 'mapbox://styles/resourcewatch/cjzmw480d00z41cp2x81gm90h';
 
@@ -87,14 +88,16 @@ export const DEFAULT_VIEWPORT: ViewportProps = {
 };
 
 export const USER_AREA_LAYER_TEMPLATES = {
-  explore: ({ id, geojson, minZoom }) => ({
+  explore: ({ id, geojson, minZoom }): Partial<APILayerSpec> => ({
     id,
-    provider: 'geojson',
+    type: 'geojson',
     layerConfig: {
-      parse: false,
-      data: geojson,
-      body: {
-        vectorLayers: [
+      source: {
+        type: 'geojson',
+        data: geojson,
+      },
+      render: {
+        layers: [
           {
             type: 'line',
             source: id,
@@ -125,14 +128,16 @@ export const USER_AREA_LAYER_TEMPLATES = {
       },
     },
   }),
-  'area-card': ({ id, geojson }) => ({
+  'area-card': ({ id, geojson }): Partial<APILayerSpec> => ({
     id,
-    provider: 'geojson',
+    type: 'geojson',
     layerConfig: {
-      parse: false,
-      data: geojson,
-      body: {
-        vectorLayers: [
+      source: {
+        type: 'geojson',
+        data: geojson,
+      },
+      render: {
+        layers: [
           {
             type: 'line',
             source: id,

--- a/components/map/utils.js
+++ b/components/map/utils.js
@@ -1,52 +1,39 @@
-import {
-  flatten,
-  compact,
-  isEmpty,
-} from 'lodash';
+import { flatten, compact, isEmpty } from 'lodash';
 
-import {
-  USER_AREA_LAYER_TEMPLATES,
-} from 'components/map/constants';
+import { USER_AREA_LAYER_TEMPLATES } from 'components/map/constants';
 
-export const getUserAreaLayer = ({
-  id = 'user-area',
-  geojson,
-  minZoom,
-},
-template = USER_AREA_LAYER_TEMPLATES['area-card']) => template({ id, geojson, minZoom });
+export const getUserAreaLayer = (
+  { id = 'user-area', geojson, minZoom },
+  template = USER_AREA_LAYER_TEMPLATES['area-card'],
+) => template({ id, geojson, minZoom });
 
 // use it to parse a bbox coming from widget-editor
 // and want to render in a Mapbox map
-export const parseBbox = (bbox) => [
-  bbox[1],
-  bbox[0],
-  bbox[3],
-  bbox[2],
-];
+export const parseBbox = (bbox) => [bbox[1], bbox[0], bbox[3], bbox[2]];
 
 /**
  *
  * @param {object[]} activeLayers Array of layers that mean to be interactive
  * @returns {string[]} Array of Mapbox layers ids that mean to be interactive
  */
-export const getInteractiveLayers = (activeLayers) => flatten(
-  compact(activeLayers.map((_activeLayer) => {
-    const { id, layerConfig } = _activeLayer;
-    if (isEmpty(layerConfig)) return null;
+export const getInteractiveLayers = (activeLayers) =>
+  flatten(
+    compact(
+      activeLayers.map((_activeLayer) => {
+        const { id, layerConfig } = _activeLayer;
+        if (isEmpty(layerConfig)) return null;
 
-    const { body = {} } = layerConfig;
-    const { vectorLayers } = body;
+        const { body = {} } = layerConfig;
+        const { vectorLayers } = body;
 
-    if (vectorLayers) {
-      return vectorLayers.map((l, i) => {
-        const {
-          id: vectorLayerId,
-          type: vectorLayerType,
-        } = l;
-        return vectorLayerId || `${id}-${vectorLayerType}-${i}`;
-      });
-    }
+        if (vectorLayers) {
+          return vectorLayers.map((l, i) => {
+            const { id: vectorLayerId, type: vectorLayerType } = l;
+            return vectorLayerId || `${id}-${vectorLayerType}-${i}`;
+          });
+        }
 
-    return null;
-  })),
-);
+        return null;
+      }),
+    ),
+  );

--- a/components/mini-explore-widgets/component.jsx
+++ b/components/mini-explore-widgets/component.jsx
@@ -1,8 +1,4 @@
-import {
-  useReducer,
-  useCallback,
-  useEffect,
-} from 'react';
+import { useReducer, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 // components
@@ -10,24 +6,13 @@ import WidgetSidebar from './widget-sidebar';
 import MiniExploreMap from './map';
 
 // reducers
-import {
-  miniExploreWidgetState,
-  miniExploreWidgetSlice,
-} from './reducer';
+import { miniExploreWidgetState, miniExploreWidgetSlice } from './reducer';
 
 const miniExploreWidgetReducer = miniExploreWidgetSlice.reducer;
-const {
-  setGeostoreBasin,
-} = miniExploreWidgetSlice.actions;
+const { setGeostoreBasin } = miniExploreWidgetSlice.actions;
 let clickState = null;
 export default function MiniExploreWidgets({
-  config: {
-    title,
-    layers,
-    mask,
-    widgets,
-    areaOfInterest,
-  },
+  config: { title, layers, mask, widgets, areaOfInterest },
   params,
   adapter,
 }) {
@@ -35,12 +20,9 @@ export default function MiniExploreWidgets({
 
   const onClickLayer = useCallback(({ features }, map) => {
     if (clickState) {
-      map.setFeatureState(
-        clickState,
-        {
-          active: false,
-        },
-      );
+      map.setFeatureState(clickState, {
+        active: false,
+      });
     }
 
     if (!features.length) return false;
@@ -48,11 +30,7 @@ export default function MiniExploreWidgets({
     const dataFeature = features.find(({ id }) => Boolean(id));
 
     if (!dataFeature) return false;
-    const {
-      source,
-      sourceLayer,
-      properties,
-    } = dataFeature;
+    const { source, sourceLayer, properties } = dataFeature;
 
     clickState = {
       source,
@@ -60,12 +38,9 @@ export default function MiniExploreWidgets({
       id: properties.cartodb_id,
     };
 
-    map.setFeatureState(
-      clickState,
-      {
-        active: true,
-      },
-    );
+    map.setFeatureState(clickState, {
+      active: true,
+    });
 
     return dispatch(setGeostoreBasin(properties.geostore_prod));
   }, []);
@@ -77,9 +52,7 @@ export default function MiniExploreWidgets({
   return (
     <div className="c-mini-explore-widgets">
       <header>
-        <h4>
-          {title}
-        </h4>
+        <h4>{title}</h4>
       </header>
       <div className="main-container">
         <MiniExploreMap
@@ -109,13 +82,9 @@ MiniExploreWidgets.defaultProps = {
 MiniExploreWidgets.propTypes = {
   config: PropTypes.shape({
     title: PropTypes.string.isRequired,
-    layers: PropTypes.arrayOf(
-      PropTypes.string.isRequired,
-    ).isRequired,
+    layers: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
     mask: PropTypes.shape({}),
-    widgets: PropTypes.arrayOf(
-      PropTypes.string.isRequired,
-    ).isRequired,
+    widgets: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
     areaOfInterest: PropTypes.string,
   }).isRequired,
   params: PropTypes.shape({}),

--- a/components/mini-explore-widgets/map/index.jsx
+++ b/components/mini-explore-widgets/map/index.jsx
@@ -362,8 +362,13 @@ export default function MiniExploreMapContainer({
     if (mask) {
       maskLayer = {
         id: maskLayerId,
-        ...mask,
-        params,
+        ...{
+          ...mask,
+          layerConfig: {
+            ...mask.layerConfig,
+            params,
+          },
+        },
       };
     }
 

--- a/components/widgets/types/map/index.jsx
+++ b/components/widgets/types/map/index.jsx
@@ -1,38 +1,20 @@
-import {
-  useMemo,
-  useCallback,
-  useState,
-} from 'react';
+import { useMemo, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
-import {
-  useQueries,
-} from 'react-query';
-import {
-  ErrorBoundary,
-} from 'react-error-boundary';
+import { useQueries } from 'react-query';
+import { ErrorBoundary } from 'react-error-boundary';
 import { v4 as uuidv4 } from 'uuid';
 
 // services
-import {
-  fetchLayer,
-} from 'services/layer';
+import { fetchLayer } from 'services/layer';
 
 // hooks
 import { useFetchWidget } from 'hooks/widget';
 import useBelongsToCollection from 'hooks/collection/belongs-to-collection';
-import {
-  useGeostore,
-} from 'hooks/geostore';
-import {
-  useMe,
-} from 'hooks/user';
+import { useGeostore } from 'hooks/geostore';
+import { useMe } from 'hooks/user';
 
 // utils
-import {
-  getAoiLayer,
-  getMaskLayer,
-  getLayerGroups,
-} from 'utils/layers';
+import { getAoiLayer, getMaskLayer, getLayerGroups } from 'utils/layers';
 
 // components
 import ErrorFallback from 'components/error-fallback';
@@ -40,12 +22,9 @@ import MapTypeWidget from './component';
 
 const mapKey = uuidv4();
 
-const CustomErrorFallback = ((_props) => (
-  <ErrorFallback
-    {..._props}
-    title="Something went wrong loading the widget"
-  />
-));
+const CustomErrorFallback = (_props) => (
+  <ErrorFallback {..._props} title="Something went wrong loading the widget" />
+);
 
 export default function MapTypeWidgetContainer({
   widgetId,
@@ -57,12 +36,8 @@ export default function MapTypeWidgetContainer({
   onToggleShare,
 }) {
   const [minZoom, setMinZoom] = useState(null);
-  const {
-    data: user,
-  } = useMe();
-  const {
-    isInACollection,
-  } = useBelongsToCollection(widgetId, user?.token);
+  const { data: user } = useMe();
+  const { isInACollection } = useBelongsToCollection(widgetId, user?.token);
 
   const {
     data: widget,
@@ -105,28 +80,30 @@ export default function MapTypeWidgetContainer({
       queryKey: ['fetch-layer', layerId],
       queryFn: () => fetchLayer(layerId),
       placeholderData: null,
-      select: (_layer) => (_layer ? ({
-        ..._layer,
-        params,
-      }) : null),
+      select: (_layer) =>
+        _layer
+          ? {
+              ..._layer,
+              params,
+            }
+          : null,
     })),
   );
 
-  const layers = useMemo(() => layerStates
-    .filter(({ data }) => !!data)
-    .map(({ data }) => data),
-  [layerStates]);
+  const layers = useMemo(
+    () => layerStates.filter(({ data }) => !!data).map(({ data }) => data),
+    [layerStates],
+  );
 
   const onFitBoundsChange = useCallback((viewport) => {
-    const {
-      zoom,
-    } = viewport;
+    const { zoom } = viewport;
 
     setMinZoom(zoom);
   }, []);
 
   const aoiLayer = useMemo(
-    () => getAoiLayer(widget, geostore, { minZoom }), [geostore, widget, minZoom],
+    () => getAoiLayer(widget, geostore, { minZoom }),
+    [geostore, widget, minZoom],
   );
 
   const maskLayer = useMemo(() => getMaskLayer(widget, params), [widget, params]);
@@ -136,10 +113,7 @@ export default function MapTypeWidgetContainer({
     return getLayerGroups(layers, layerParams, true);
   }, [layers, widget]);
 
-  const isError = useMemo(
-    () => (isErrorWidget || isErrorGeostore),
-    [isErrorWidget, isErrorGeostore],
-  );
+  const isError = useMemo(() => isErrorWidget || isErrorGeostore, [isErrorWidget, isErrorGeostore]);
 
   return (
     <ErrorBoundary
@@ -155,14 +129,14 @@ export default function MapTypeWidgetContainer({
         // todo: try to remove the key when the layer manager version is updated.
         key={minZoom || mapKey}
         layerGroups={layerGroups}
-        {...geostore?.bbox && {
+        {...(geostore?.bbox && {
           mapBounds: {
             bbox: geostore.bbox,
             options: {
               padding: 50,
             },
           },
-        }}
+        })}
         aoiLayer={aoiLayer}
         maskLayer={maskLayer}
         widget={widget}

--- a/pages/layer-manager.tsx
+++ b/pages/layer-manager.tsx
@@ -48,6 +48,16 @@ const layers: APILayerSpec[] = [
         type: 'geojson',
         maxzoom: 12,
       },
+      render: {
+        layers: [
+          {
+            type: 'fill',
+            paint: {
+              'fill-color': '#F00',
+            },
+          },
+        ],
+      },
     },
     legendConfig: {
       items: [

--- a/public/static/data/ocean-watch.json
+++ b/public/static/data/ocean-watch.json
@@ -595,20 +595,25 @@
                 "config": {
                   "title": "Water Quality Pressure",
                   "mask": {
-                    "provider": "cartodb",
-                    "promoteId": "cartodb_id",
+                    "type": "vector",
                     "layerConfig": {
-                      "account": "wri-rw",
-                      "body": {
-                        "layers": [
-                          {
-                            "type": "mapnik",
-                            "options": {
-                              "sql": "SELECT cartodb_id, the_geom_webmercator, coast, st_intersects(the_geom, (select the_geom from gadm36_0 where {{geostore_env}} = '{{geostore_id}}')) as intersect, geostore_staging, geostore_prod FROM wat_068_rw0_watersheds_edit WHERE level = 5"
+                      "source": {
+                        "promoteId": "cartodb_id",
+                        "provider": {
+                          "type": "carto",
+                          "account": "wri-rw",
+                          "layers": [
+                            {
+                              "options": {
+                                "sql": "SELECT cartodb_id, the_geom_webmercator, coast, st_intersects(the_geom, (select the_geom from gadm36_0 where {{geostore_env}} = '{{geostore_id}}')) as intersect, geostore_staging, geostore_prod FROM wat_068_rw0_watersheds_edit WHERE level = 5"
+                              },
+                              "type": "mapnik"
                             }
-                          }
-                        ],
-                        "vectorLayers": [
+                          ]
+                        }
+                      },
+                      "render": {
+                        "layers": [
                           {
                             "filter": [
                               "all",
@@ -645,7 +650,7 @@
                               ],
                               "fill-outline-color": "#FAB72E"
                             },
-                            "source-layer": "layer0",
+                            "source": "layer0",
                             "id": "coastal-interactivity",
                             "type": "fill"
                           },
@@ -659,7 +664,7 @@
                               "line-color": "#FAB72E",
                               "line-width": 2
                             },
-                            "source-layer": "layer0",
+                            "source": "layer0",
                             "type": "line"
                           },
                           {
@@ -676,7 +681,7 @@
                                 3
                               ]
                             },
-                            "source-layer": "layer0",
+                            "source": "layer0",
                             "type": "line"
                           },
                           {
@@ -690,11 +695,10 @@
                               "fill-opacity": 1,
                               "fill-outline-color": "#616161"
                             },
-                            "source-layer": "layer0",
+                            "source": "layer0",
                             "type": "fill"
                           }
-                        ],
-                        "layerType": "vector"
+                        ]
                       }
                     }
                   },
@@ -1598,20 +1602,25 @@
                 "config": {
                   "title": "Water Quality Pressure",
                   "mask": {
-                    "provider": "cartodb",
-                    "promoteId": "cartodb_id",
+                    "type": "vector",
                     "layerConfig": {
-                      "account": "wri-rw",
-                      "body": {
-                        "layers": [
-                          {
-                            "type": "mapnik",
-                            "options": {
-                              "sql": "SELECT cartodb_id, the_geom_webmercator, coast, st_intersects(the_geom, (select the_geom from gadm36_0 where {{geostore_env}} = '{{geostore_id}}')) as intersect, geostore_staging, geostore_prod FROM wat_068_rw0_watersheds_edit WHERE level = 5"
+                      "source": {
+                        "promoteId": "cartodb_id",
+                        "provider": {
+                          "type": "carto",
+                          "account": "wri-rw",
+                          "layers": [
+                            {
+                              "options": {
+                                "sql": "SELECT cartodb_id, the_geom_webmercator, coast, st_intersects(the_geom, (select the_geom from gadm36_0 where {{geostore_env}} = '{{geostore_id}}')) as intersect, geostore_staging, geostore_prod FROM wat_068_rw0_watersheds_edit WHERE level = 5"
+                              },
+                              "type": "mapnik"
                             }
-                          }
-                        ],
-                        "vectorLayers": [
+                          ]
+                        }
+                      },
+                      "render": {
+                        "layers": [
                           {
                             "filter": [
                               "all",
@@ -1648,7 +1657,7 @@
                               ],
                               "fill-outline-color": "#FAB72E"
                             },
-                            "source-layer": "layer0",
+                            "source": "layer0",
                             "id": "coastal-interactivity",
                             "type": "fill"
                           },
@@ -1662,7 +1671,7 @@
                               "line-color": "#FAB72E",
                               "line-width": 2
                             },
-                            "source-layer": "layer0",
+                            "source": "layer0",
                             "type": "line"
                           },
                           {
@@ -1679,7 +1688,7 @@
                                 3
                               ]
                             },
-                            "source-layer": "layer0",
+                            "source": "layer0",
                             "type": "line"
                           },
                           {
@@ -1693,11 +1702,10 @@
                               "fill-opacity": 1,
                               "fill-outline-color": "#616161"
                             },
-                            "source-layer": "layer0",
+                            "source": "layer0",
                             "type": "fill"
                           }
-                        ],
-                        "layerType": "vector"
+                        ]
                       }
                     }
                   },

--- a/types/layer.d.ts
+++ b/types/layer.d.ts
@@ -1,4 +1,8 @@
-import { Render, Source } from '@vizzuality/layer-manager';
+import { Source } from '@vizzuality/layer-manager';
+
+export interface Render {
+  layers?: Record<string, string | number | boolean | unknown>[];
+}
 
 export interface layerConfigSpec {
   render?: Render;

--- a/utils/layers/index.js
+++ b/utils/layers/index.js
@@ -1,18 +1,11 @@
-import {
-  isNumber,
-  groupBy,
-} from 'lodash';
+import { isNumber, groupBy } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
 // utils
-import {
-  getUserAreaLayer,
-} from 'components/map/utils';
+import { getUserAreaLayer } from 'components/map/utils';
 
 // constants
-import {
-  USER_AREA_LAYER_TEMPLATES,
-} from 'components/map/constants';
+import { USER_AREA_LAYER_TEMPLATES } from 'components/map/constants';
 
 // sorts layers based on an array of layer ids
 export const sortLayers = (_layers = [], _layerOrder = []) => {
@@ -50,42 +43,34 @@ export const getLayerGroups = (layers = [], layerParams = {}, forceActive = fals
   return Object.keys(layersByDataset).map((datasetKey) => ({
     id: datasetKey,
     visibility: true,
-    layers: layersByDataset[datasetKey]
-      .map((_layer) => ({
-        ..._layer,
-        active: forceActive || (layerParams?.[_layer.id]?.default || Boolean(_layer.default)),
-        opacity: isNumber(layerParams?.[_layer.id]?.opacity) ? layerParams[_layer.id].opacity : 1,
-        ..._layer?.layerConfig?.type === 'gee' && {
-          layerConfig: {
-            ..._layer.layerConfig,
-            body: {
-              ..._layer.layerConfig.body,
-              url: getTilerUrl(_layer),
-            },
+    layers: layersByDataset[datasetKey].map((_layer) => ({
+      ..._layer,
+      active: forceActive || layerParams?.[_layer.id]?.default || Boolean(_layer.default),
+      opacity: isNumber(layerParams?.[_layer.id]?.opacity) ? layerParams[_layer.id].opacity : 1,
+      // todo: remove this once layers have been migrated. This logic is replicated inside the GEE provider
+      ...(_layer?.layerConfig?.type === 'gee' && {
+        layerConfig: {
+          ..._layer.layerConfig,
+          body: {
+            ..._layer.layerConfig.body,
+            url: getTilerUrl(_layer),
           },
         },
-      })),
+      }),
+    })),
   }));
 };
 
 export const getAoiLayer = (widget = {}, geostore, options = {}) => {
   if (!geostore) return null;
 
-  const {
-    layerParams,
-  } = widget?.widgetConfig || {};
+  const { layerParams } = widget?.widgetConfig || {};
 
-  const {
-    minZoom,
-  } = options;
+  const { minZoom } = options;
 
-  const {
-    id,
-    geojson,
-    bbox,
-  } = geostore;
+  const { id, geojson, bbox } = geostore;
 
-  return ({
+  return {
     ...getUserAreaLayer(
       {
         id,
@@ -98,24 +83,21 @@ export const getAoiLayer = (widget = {}, geostore, options = {}) => {
     visibility: true,
     isAreaOfInterest: true,
     bbox,
-  });
+  };
 };
 
 export const getMaskLayer = (widget = {}, params = {}) => {
-  const {
-    mask,
-    layerParams,
-  } = widget?.widgetConfig?.paramsConfig || {};
+  const { mask, layerParams } = widget?.widgetConfig?.paramsConfig || {};
 
   if (!mask) return null;
 
-  return ({
+  return {
     id: mask?.id || `${uuidv4()}-mask`,
-    provider: 'cartodb',
+    type: 'vector',
     layerConfig: {
       ...mask,
+      params,
     },
-    params,
     opacity: layerParams?.mask?.opacity || 1,
-  });
+  };
 };


### PR DESCRIPTION
## Overview
- Updates `area of interest (AoI)` templates to achieve LMv4 compatibility. This affects: Explore AoI,  user AoIs (`/myrw/areas`) and Ocean Watch predefined AoIs.
- map component: makes `onMapViewportChange` function optional.

## Testing instructions
 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/RW-99
https://vizzuality.atlassian.net/browse/RW-97
https://vizzuality.atlassian.net/browse/RW-102


## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
