### PR TITLE
explore: fixes aoi layer handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- explore: area of interest handling. [RW-120](https://vizzuality.atlassian.net/browse/RW-120)
 
 ### Removed
 

--- a/components/map/constants.ts
+++ b/components/map/constants.ts
@@ -89,8 +89,9 @@ export const DEFAULT_VIEWPORT: ViewportProps = {
 };
 
 export const USER_AREA_LAYER_TEMPLATES = {
-  explore: ({ id, geojson, minZoom }): Partial<APILayerSpec> => ({
+  explore: ({ id, geojson, minZoom }): Partial<APILayerSpec & { isAreaOfInterest: boolean }> => ({
     id,
+    isAreaOfInterest: true,
     layerConfig: {
       type: 'geojson',
       source: {
@@ -129,8 +130,9 @@ export const USER_AREA_LAYER_TEMPLATES = {
       },
     },
   }),
-  'area-card': ({ id, geojson }): Partial<APILayerSpec> => ({
+  'area-card': ({ id, geojson }): Partial<APILayerSpec & { isAreaOfInterest: boolean }> => ({
     id,
+    isAreaOfInterest: true,
     layerConfig: {
       type: 'geojson',
       source: {

--- a/layout/explore/explore-map/component.jsx
+++ b/layout/explore/explore-map/component.jsx
@@ -348,7 +348,7 @@ const ExploreMap = (props) => {
 
   useEffect(() => {
     setDisplayedLayers((prevLayers) => [
-      ...prevLayers.filter(({ provider }) => provider === 'geojson'),
+      ...prevLayers.filter(({ isAreaOfInterest }) => isAreaOfInterest),
       ...activeLayers,
     ]);
   }, [activeLayers, aoi]);
@@ -382,7 +382,7 @@ const ExploreMap = (props) => {
 
         setDisplayedLayers((prevLayers) => [
           aoiLayer,
-          ...prevLayers.filter(({ provider }) => provider !== 'geojson'),
+          ...prevLayers.filter(({ isAreaOfInterest }) => !isAreaOfInterest),
         ]);
 
         setBounds({
@@ -408,7 +408,7 @@ const ExploreMap = (props) => {
 
       setDisplayedLayers((prevLayers) => [
         aoiLayer,
-        ...prevLayers.filter(({ provider }) => provider !== 'geojson'),
+        ...prevLayers.filter(({ isAreaOfInterest }) => !isAreaOfInterest),
       ]);
 
       setBounds({
@@ -424,7 +424,7 @@ const ExploreMap = (props) => {
     else {
       // if the user removes the AoI, filter it to avoid display it in the map
       setDisplayedLayers((prevLayers) => [
-        ...prevLayers.filter(({ provider }) => provider !== 'geojson'),
+        ...prevLayers.filter(({ isAreaOfInterest }) => !isAreaOfInterest),
       ]);
     }
   }, [aoi, token, userId, setBounds, previewAoi]);


### PR DESCRIPTION
## Overview
Fixes an error handling Area of Interest layers. The filtering criteria was based on the previous layer spec. Updating it solved the issue.

## Testing instructions
 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/RW-120

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
