### PR TITLE
no robot crawling for staging, preproduction sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - custom "no data" for set of indicators. [OW-179](https://vizzuality.atlassian.net/browse/OW-179)
 
 ### Changed
+- disables robot crawling for staging and preproduction sites.
 - updates Coral Reefs calls to action. [OW-29](https://vizzuality.atlassian.net/browse/OW-29)
 - `next@12.0.10`
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import type { AppProps } from 'next/app';
 
 import { Provider as AuthenticationProvider } from 'next-auth/client';
+import Script from 'next/script';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Hydrate } from 'react-query/hydration';
 
@@ -21,21 +22,27 @@ const queryClient = new QueryClient();
 
 const ResourceWatchApp: FC<AppProps> = ({ Component, pageProps }: AppProps) => {
   return (
-    <QueryClientProvider client={queryClient}>
-      <MediaContextProvider>
-        <Hydrate state={pageProps.dehydratedState}>
-          <AuthenticationProvider
-            session={pageProps.session}
-            options={{
-              clientMaxAge: 5 * 60, // Re-fetch session if cache is older than 60 seconds
-              keepAlive: 10 * 60, // Send keepAlive message every 10 minutes
-            }}
-          >
-            <Component {...pageProps} />
-          </AuthenticationProvider>
-        </Hydrate>
-      </MediaContextProvider>
-    </QueryClientProvider>
+    <>
+      {/* Google Places API */}
+      <Script
+        src={`https://maps.googleapis.com/maps/api/js?v=weekly&key=${process.env.NEXT_PUBLIC_RW_GOGGLE_API_TOKEN_SHORTENER}&libraries=places`}
+      />
+      <QueryClientProvider client={queryClient}>
+        <MediaContextProvider>
+          <Hydrate state={pageProps.dehydratedState}>
+            <AuthenticationProvider
+              session={pageProps.session}
+              options={{
+                clientMaxAge: 5 * 60, // Re-fetch session if cache is older than 60 seconds
+                keepAlive: 10 * 60, // Send keepAlive message every 10 minutes
+              }}
+            >
+              <Component {...pageProps} />
+            </AuthenticationProvider>
+          </Hydrate>
+        </MediaContextProvider>
+      </QueryClientProvider>
+    </>
   );
 };
 

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,5 +1,4 @@
 import Document, { Html, Main, NextScript, Head } from 'next/document';
-import Script from 'next/script';
 
 // lib
 import { mediaStyles } from 'lib/media';
@@ -11,6 +10,10 @@ export default class MyDocument extends Document {
         <Head>
           <meta httpEquiv="x-ua-compatible" content="ie=edge" />
           <meta name="author" content="Vizzuality" />
+          {/* disables robots crawling for staging and preproduction sites */}
+          {process.env.NEXTAUTH_URL !== 'https://resourcewatch.org' && (
+            <meta name="robots" content="noindex, nofollow" />
+          )}
           <link rel="icon" href="/favicon.ico" />
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin />
@@ -34,11 +37,6 @@ export default class MyDocument extends Document {
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="twitter:site" content="@resource_watch" />
           <meta property="fb:app_id" content="Resource Watch" />
-
-          {/* Google API */}
-          <Script
-            src={`https://maps.googleapis.com/maps/api/js?v=weekly&key=${process.env.NEXT_PUBLIC_RW_GOGGLE_API_TOKEN_SHORTENER}&libraries=places`}
-          />
 
           <style
             type="text/css"


### PR DESCRIPTION
## Overview
Tell robots to not crawl pages from the subdomains: [https://preproduction.resourcewatch.org/](https://preproduction.resourcewatch.org/). and [https://staging.resourcewatch.org/](https://staging.resourcewatch.org/)

## Testing instructions
 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output

## Jira task / Github issue
–

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Add entry to CHANGELOG.md, if appropriate
