### PR TITLE
explore: fixes navigation with search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - bump `next@12.1.6`.
 
 ### Fixed
+- Explore: fixes navigation when a user clicks on "All datasets" button after searching. Now the search results remain. [RW-87](https://vizzuality.atlassian.net/browse/RW-87)
 
 ### Removed
+- removes unused `resetFiltersSelected` action.
+- removes `isServer` state in redux and its action/reducer.
 - removes `react-input-autosize`.
 - removes `react-fast-compare`.
 - removes `react-dates`.

--- a/components/datasets/list/selectors.js
+++ b/components/datasets/list/selectors.js
@@ -4,18 +4,12 @@ import { createSelector } from 'reselect';
 import { getDateConsideringTimeZone } from 'utils/utils';
 
 const getDatasets = (state) => state.datasets.datasets.list;
-const getIsServer = (state) => state.common.isServer;
 
-export const getUpdatedDatasets = createSelector(
-  [getDatasets, getIsServer],
-  (_datasets, _isServer) => {
-    if (_isServer) return _datasets;
-
-    return _datasets.map((_dataset) => ({
-      ..._dataset,
-      dateLastUpdated: getDateConsideringTimeZone(_dataset.dataLastUpdated),
-    }));
-  },
-);
+export const getUpdatedDatasets = createSelector([getDatasets], (_datasets) => {
+  return _datasets.map((_dataset) => ({
+    ..._dataset,
+    dateLastUpdated: getDateConsideringTimeZone(_dataset.dataLastUpdated),
+  }));
+});
 
 export default { getUpdatedDatasets };

--- a/components/datasets/search/search-component.js
+++ b/components/datasets/search/search-component.js
@@ -24,7 +24,6 @@ class SearchComponent extends React.Component {
     onChangeTextSearch: PropTypes.func,
     onToggleSelected: PropTypes.func,
     onChangeSelected: PropTypes.func,
-    onResetSelected: PropTypes.func,
   };
 
   constructor(props) {
@@ -33,16 +32,20 @@ class SearchComponent extends React.Component {
     const { list } = props;
 
     this.fuse = new Fuse(list, {
-      keys: [{
-        name: 'label',
-        weight: 0.6,
-      }, {
-        name: 'synonyms',
-        weight: 0.3,
-      }, {
-        name: 'id',
-        weight: 0.1,
-      }],
+      keys: [
+        {
+          name: 'label',
+          weight: 0.6,
+        },
+        {
+          name: 'synonyms',
+          weight: 0.3,
+        },
+        {
+          name: 'id',
+          weight: 0.1,
+        },
+      ],
       threshold: 0.2,
       minMatchCharLength: 2,
     });
@@ -53,7 +56,7 @@ class SearchComponent extends React.Component {
     value: '',
     filteredList: [],
     groupedFilteredList: {},
-  }
+  };
 
   // UI EVENTS:
   // - onScreenClick
@@ -69,7 +72,7 @@ class SearchComponent extends React.Component {
     if (clickOutside) {
       this.onToggleOpen(false);
     }
-  }
+  };
 
   onScreenKeyup = (e) => {
     switch (e.keyCode) {
@@ -94,7 +97,7 @@ class SearchComponent extends React.Component {
       default:
         return true;
     }
-  }
+  };
 
   onToggleOpen = (to) => {
     requestAnimationFrame(() => {
@@ -115,24 +118,26 @@ class SearchComponent extends React.Component {
     });
 
     this.props.onChangeOpen(to);
-  }
+  };
 
   onKeyArrow = (direction) => {
     const { index, filteredList } = this.state;
     if (direction === 'up') {
-      this.setState({ index: (index !== 0) ? index - 1 : filteredList.length });
+      this.setState({ index: index !== 0 ? index - 1 : filteredList.length });
     }
 
     if (direction === 'down') {
-      this.setState({ index: (index !== filteredList.length) ? index + 1 : 0 });
+      this.setState({ index: index !== filteredList.length ? index + 1 : 0 });
     }
-  }
+  };
 
   onKeyEnter = () => {
     const { value, index, groupedFilteredList } = this.state;
 
     if (index !== 0) {
-      const filteredList = flatten(Object.keys(groupedFilteredList).map((g) => groupedFilteredList[g]));
+      const filteredList = flatten(
+        Object.keys(groupedFilteredList).map((g) => groupedFilteredList[g]),
+      );
 
       const tag = filteredList[index - 1];
 
@@ -142,11 +147,11 @@ class SearchComponent extends React.Component {
     }
 
     this.onToggleOpen(false);
-  }
+  };
 
   onListItemMouseOver = (index) => {
     this.setState({ index });
-  }
+  };
 
   onChangeSearch = (e) => {
     const { value } = e.currentTarget;
@@ -156,29 +161,36 @@ class SearchComponent extends React.Component {
       this.onToggleOpen(true);
     }
 
-    const filteredList = (value.length > 2) ? this.fuse.search(value).sort((a, b) => {
-      const index1 = a.label.toLowerCase().indexOf(value.toLowerCase());
-      const index2 = b.label.toLowerCase().indexOf(value.toLowerCase());
-      const exactMatch1 = a.label.toLowerCase() === value.toLowerCase();
-      const exactMatch2 = b.label.toLowerCase() === value.toLowerCase();
-      if (exactMatch1) {
-        return -1;
-      } if (exactMatch2) {
-        return 1;
-      }
-      return index1 > index2;
-    }) : [];
-    const newGroupFilteredList = omit(groupBy(filteredList, (l) => {
-      const group = l.labels && l.labels[1];
-      return group || 'undefined';
-    }), ['undefined', 'GEOGRAPHY']);
+    const filteredList =
+      value.length > 2
+        ? this.fuse.search(value).sort((a, b) => {
+            const index1 = a.label.toLowerCase().indexOf(value.toLowerCase());
+            const index2 = b.label.toLowerCase().indexOf(value.toLowerCase());
+            const exactMatch1 = a.label.toLowerCase() === value.toLowerCase();
+            const exactMatch2 = b.label.toLowerCase() === value.toLowerCase();
+            if (exactMatch1) {
+              return -1;
+            }
+            if (exactMatch2) {
+              return 1;
+            }
+            return index1 > index2;
+          })
+        : [];
+    const newGroupFilteredList = omit(
+      groupBy(filteredList, (l) => {
+        const group = l.labels && l.labels[1];
+        return group || 'undefined';
+      }),
+      ['undefined', 'GEOGRAPHY'],
+    );
     this.setState({
       index: Object.keys(newGroupFilteredList).length > 0 ? 1 : 0,
       value,
       filteredList,
       groupedFilteredList: newGroupFilteredList,
     });
-  }
+  };
 
   render() {
     const { open } = this.props;
@@ -199,7 +211,9 @@ class SearchComponent extends React.Component {
           </button>
 
           <input
-            ref={(c) => { this.input = c; }}
+            ref={(c) => {
+              this.input = c;
+            }}
             className={classnames({
               'search-input': true,
               '-open': open,
@@ -212,29 +226,24 @@ class SearchComponent extends React.Component {
         </div>
 
         {/* Dropdown search */}
-        {open && value
-          && (
+        {open && value && (
           <div className="search-dropdown">
             <div className="search-dropdown-list">
               {Object.keys(groupedFilteredList).map((g) => (
                 <div className="search-dropdown-list-item" key={g}>
-                  {!!g && g.toLowerCase
-                    && (
+                  {!!g && g.toLowerCase && (
                     <h4>
                       Filter by
-                      {g.toLowerCase()}
-                      :
+                      {g.toLowerCase()}:
                     </h4>
-                    )}
+                  )}
 
                   <ul className="list-item-results">
                     {groupedFilteredList[g].map((l) => {
                       const currentIndex = ++groupedFilteredListIndex;
 
                       return (
-                        <li
-                          key={l.id}
-                        >
+                        <li key={l.id}>
                           <button
                             type="button"
                             className={classnames({ '-active': index === currentIndex })}
@@ -273,9 +282,8 @@ class SearchComponent extends React.Component {
               </div>
             </div>
           </div>
-          )}
+        )}
       </div>
-
     );
   }
 }

--- a/layout/app/pulse/layer-card/selectors.js
+++ b/layout/app/pulse/layer-card/selectors.js
@@ -5,18 +5,14 @@ import { createSelector } from 'reselect';
 import { getDateConsideringTimeZone } from 'utils/utils';
 
 const getDataset = (state) => state.layerCardPulse.dataset;
-const getIsServer = (state) => state.common.isServer;
 
-export const getUpdatedDataset = createSelector(
-  [getDataset, getIsServer],
-  (_dataset, _isServer) => {
-    if (isEmpty(_dataset) || _isServer) return _dataset;
+export const getUpdatedDataset = createSelector([getDataset], (_dataset) => {
+  if (isEmpty(_dataset)) return _dataset;
 
-    return ({
-      ..._dataset,
-      dataLastUpdated: getDateConsideringTimeZone(_dataset.dataLastUpdated),
-    });
-  },
-);
+  return {
+    ..._dataset,
+    dataLastUpdated: getDateConsideringTimeZone(_dataset.dataLastUpdated),
+  };
+});
 
 export default { getUpdatedDataset };

--- a/layout/explore/actions.js
+++ b/layout/explore/actions.js
@@ -22,61 +22,70 @@ export const setDatasetsLimit = createAction('EXPLORE/setDatasetsLimit');
 export const setDatasetsMode = createAction('EXPLORE/setDatasetsMode');
 export const setSelectedDataset = createAction('EXPLORE/setSelectedDataset');
 
-export const fetchDatasets = createThunkAction('EXPLORE/fetchDatasets', () => (dispatch, getState) => {
-  const { explore, common } = getState();
+export const fetchDatasets = createThunkAction(
+  'EXPLORE/fetchDatasets',
+  () => (dispatch, getState) => {
+    const { explore, common } = getState();
 
-  const concepts = Object.keys(explore.filters.selected)
-    .map((s) => explore.filters.selected[s])
-    .filter((selected) => selected.length);
+    const concepts = Object.keys(explore.filters.selected)
+      .map((s) => explore.filters.selected[s])
+      .filter((selected) => selected.length);
 
-  const params = {
-    language: common.locale,
-    includes: 'layer,metadata,vocabulary,widget',
-    sort: `${explore.sort.direction < 0 ? '-' : ''}${explore.sort.selected}`,
-    status: 'saved',
-    published: true,
-    // Search
-    ...explore.filters.search && { search: explore.filters.search },
-    // Concepts
-    ...concepts.reduce((o, s, i) => ({
-      ...o,
-      ...s.reduce((o2, s2, j) => ({
-        ...o2,
-        [`concepts[${i}][${j}]`]: s2,
-      }), {}),
-    }), {}),
-    // Page
-    'page[number]': explore.datasets.page,
-    'page[size]': explore.datasets.limit,
-    // Environment(s)
-    env: process.env.NEXT_PUBLIC_ENVS_SHOW,
-  };
+    const params = {
+      language: common.locale,
+      includes: 'layer,metadata,vocabulary,widget',
+      sort: `${explore.sort.direction < 0 ? '-' : ''}${explore.sort.selected}`,
+      status: 'saved',
+      published: true,
+      // Search
+      ...(explore.filters.search && { search: explore.filters.search }),
+      // Concepts
+      ...concepts.reduce(
+        (o, s, i) => ({
+          ...o,
+          ...s.reduce(
+            (o2, s2, j) => ({
+              ...o2,
+              [`concepts[${i}][${j}]`]: s2,
+            }),
+            {},
+          ),
+        }),
+        {},
+      ),
+      // Page
+      'page[number]': explore.datasets.page,
+      'page[size]': explore.datasets.limit,
+      // Environment(s)
+      env: process.env.NEXT_PUBLIC_ENVS_SHOW,
+    };
 
-  dispatch(setDatasetsLoading(true));
-  dispatch(setDatasetsError(null));
+    dispatch(setDatasetsLoading(true));
+    dispatch(setDatasetsError(null));
 
-  return fetchDatasetsService(params, {}, true)
-    .then((response) => {
-      const { meta = {}, datasets } = response;
-      dispatch(setDatasetsTotal(meta['total-items'] || 0));
-      return datasets;
-    })
-    .then((data) => {
-      // Show only published layers
-      const datasets = data.map((d) => ({
-        ...d,
-        layer: d.layer.filter((l) => l.published),
-      }));
+    return fetchDatasetsService(params, {}, true)
+      .then((response) => {
+        const { meta = {}, datasets } = response;
+        dispatch(setDatasetsTotal(meta['total-items'] || 0));
+        return datasets;
+      })
+      .then((data) => {
+        // Show only published layers
+        const datasets = data.map((d) => ({
+          ...d,
+          layer: d.layer.filter((l) => l.published),
+        }));
 
-      dispatch(setDatasetsLoading(false));
-      dispatch(setDatasetsError(null));
-      dispatch(setDatasets(datasets));
-    })
-    .catch((err) => {
-      dispatch(setDatasetsLoading(false));
-      dispatch(setDatasetsError(err));
-    });
-});
+        dispatch(setDatasetsLoading(false));
+        dispatch(setDatasetsError(null));
+        dispatch(setDatasets(datasets));
+      })
+      .catch((err) => {
+        dispatch(setDatasetsLoading(false));
+        dispatch(setDatasetsError(err));
+      });
+  },
+);
 
 // MAP
 export const setViewport = createAction('EXPLORE-MAP__SET-VIEWPORT');
@@ -102,32 +111,43 @@ export const resetLayerParametrization = createAction('EXPLORE/resetLayerParamet
 
 // INTERACTION
 export const setMapLayerGroupsInteraction = createAction('EXPLORE/setMapLayerGroupsInteraction');
-export const setMapLayerGroupsInteractionSelected = createAction('EXPLORE/setMapLayerGroupsInteractionSelected');
-export const setMapLayerGroupsInteractionLatLng = createAction('EXPLORE/setMapLayerGroupsInteractionLatLng');
-export const resetMapLayerGroupsInteraction = createAction('EXPLORE/resetMapLayerGroupsInteraction');
+export const setMapLayerGroupsInteractionSelected = createAction(
+  'EXPLORE/setMapLayerGroupsInteractionSelected',
+);
+export const setMapLayerGroupsInteractionLatLng = createAction(
+  'EXPLORE/setMapLayerGroupsInteractionLatLng',
+);
+export const resetMapLayerGroupsInteraction = createAction(
+  'EXPLORE/resetMapLayerGroupsInteraction',
+);
 
 export const setMapLayerGroups = createAction('EXPLORE/setMapLayerGroups');
-export const fetchMapLayerGroups = createThunkAction('EXPLORE/fetchMapLayers', (payload) => (dispatch, getState) => {
-  const { common } = getState();
+export const fetchMapLayerGroups = createThunkAction(
+  'EXPLORE/fetchMapLayers',
+  (payload) => (dispatch, getState) => {
+    const { common } = getState();
 
-  const params = {
-    language: common.locale,
-    includes: 'layer',
-    ids: payload.map((lg) => lg.dataset).join(','),
-    'page[size]': 999,
-  };
+    const params = {
+      language: common.locale,
+      includes: 'layer',
+      ids: payload.map((lg) => lg.dataset).join(','),
+      'page[size]': 999,
+    };
 
-  return fetchDatasetsService(params)
-    .then((data) => {
-      dispatch(setMapLayerGroups({
-        datasets: data,
-        params: payload,
-      }));
-    })
-    .catch((err) => {
-      console.error(err);
-    });
-});
+    return fetchDatasetsService(params)
+      .then((data) => {
+        dispatch(
+          setMapLayerGroups({
+            datasets: data,
+            params: payload,
+          }),
+        );
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  },
+);
 
 // FILTERS
 export const setFiltersOpen = createAction('EXPLORE/setFiltersOpen');
@@ -136,21 +156,28 @@ export const setFiltersSearch = createAction('EXPLORE/setFiltersSearch');
 export const setFiltersTags = createAction('EXPLORE/setFiltersTags');
 export const setFiltersSelected = createAction('EXPLORE/setFiltersSelected');
 export const toggleFiltersSelected = createAction('EXPLORE/toggleFiltersSelected');
-export const resetFiltersSelected = createAction('EXPLORE/resetFiltersSelected');
 
-export const fetchFiltersTags = createThunkAction('EXPLORE/fetchFiltersTags', () => (dispatch) => fetchAllTags()
-  .then((data) => {
-    dispatch(setFiltersTags(data.filter((tag) => {
-      const isBlack = TAGS_BLACKLIST.includes(tag.id);
-      const isGeography = (!!tag.labels[1] && tag.labels[1] === 'GEOGRAPHY');
-      const hasDatasets = !!tag.numberOfDatasetsTagged;
+export const fetchFiltersTags = createThunkAction(
+  'EXPLORE/fetchFiltersTags',
+  () => (dispatch) =>
+    fetchAllTags()
+      .then((data) => {
+        dispatch(
+          setFiltersTags(
+            data.filter((tag) => {
+              const isBlack = TAGS_BLACKLIST.includes(tag.id);
+              const isGeography = !!tag.labels[1] && tag.labels[1] === 'GEOGRAPHY';
+              const hasDatasets = !!tag.numberOfDatasetsTagged;
 
-      return !isBlack && !isGeography && hasDatasets;
-    })));
-  })
-  .catch((err) => {
-    console.error(err);
-  }));
+              return !isBlack && !isGeography && hasDatasets;
+            }),
+          ),
+        );
+      })
+      .catch((err) => {
+        console.error(err);
+      }),
+);
 
 // SORT
 export const setSortSelected = createAction('EXPLORE/setSortSelected');
@@ -179,10 +206,19 @@ export const fetchTags = createThunkAction('EXPLORE/fetchTags', (tags) => (dispa
 
   return fetchInferredTags({ concepts: tags.join(',') })
     .then((data) => {
-      dispatch(setTags(sortBy(
-        data.filter((tag) => !TAGS_BLACKLIST.includes(tag.id) && !!tag.labels[1] && tag.labels[1] !== 'GEOGRAPHY'),
-        (t) => t.label,
-      )));
+      dispatch(
+        setTags(
+          sortBy(
+            data.filter(
+              (tag) =>
+                !TAGS_BLACKLIST.includes(tag.id) &&
+                !!tag.labels[1] &&
+                tag.labels[1] !== 'GEOGRAPHY',
+            ),
+            (t) => t.label,
+          ),
+        ),
+      );
       dispatch(setTagsLoading(false));
       dispatch(setTagsError(null));
     })

--- a/layout/explore/explore-datasets/component.jsx
+++ b/layout/explore/explore-datasets/component.jsx
@@ -1,8 +1,4 @@
-import {
-  useEffect,
-  useMemo,
-  useCallback,
-} from 'react';
+import { useEffect, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
 import classnames from 'classnames';
@@ -20,14 +16,7 @@ import ExploreDatasetsActions from './explore-datasets-actions';
 
 export default function ExploreDatasets(props) {
   const {
-    datasets: {
-      selected,
-      list,
-      total,
-      limit,
-      page,
-      loading,
-    },
+    datasets: { selected, list, total, limit, page, loading },
     selectedTags,
     search,
     setDatasetsPage,
@@ -35,20 +24,25 @@ export default function ExploreDatasets(props) {
   } = props;
 
   const relatedDashboards = useMemo(
-    () => TOPICS.filter((topic) => selectedTags.find((tag) => tag.id === topic.id))
-      .map((_dashboard) => ({
-        ..._dashboard,
-        ..._dashboard.slug === 'ocean-watch' && {
-          label: 'Ocean Watch',
-        },
-      })),
+    () =>
+      TOPICS.filter((topic) => selectedTags.find((tag) => tag.id === topic.id)).map(
+        (_dashboard) => ({
+          ..._dashboard,
+          ...(_dashboard.slug === 'ocean-watch' && {
+            label: 'Ocean Watch',
+          }),
+        }),
+      ),
     [selectedTags],
   );
 
-  const fetchDatasetsPerPage = useCallback((_page) => {
-    setDatasetsPage(_page);
-    fetchDatasets();
-  }, [setDatasetsPage, fetchDatasets]);
+  const fetchDatasetsPerPage = useCallback(
+    (_page) => {
+      setDatasetsPage(_page);
+      fetchDatasets();
+    },
+    [setDatasetsPage, fetchDatasets],
+  );
 
   useEffect(() => {
     fetchDatasetsPerPage(1);
@@ -65,8 +59,8 @@ export default function ExploreDatasets(props) {
         <div className="left-container">
           <ExploreDatasetsSort />
           <div className="tags-container">
-            {selectedTags.length > 0
-              && selectedTags.map((t) => (
+            {selectedTags.length > 0 &&
+              selectedTags.map((t) => (
                 <button
                   key={t.id}
                   className="c-button -primary -compressed"
@@ -75,16 +69,10 @@ export default function ExploreDatasets(props) {
                     fetchDatasetsPerPage(1);
                   }}
                 >
-                  <span
-                    className="button-text"
-                    title={t.label.toUpperCase()}
-                  >
+                  <span className="button-text" title={t.label.toUpperCase()}>
                     {t.label.toUpperCase()}
                   </span>
-                  <Icon
-                    name="icon-cross"
-                    className="-tiny"
-                  />
+                  <Icon name="icon-cross" className="-tiny" />
                 </button>
               ))}
             {search && (
@@ -97,16 +85,10 @@ export default function ExploreDatasets(props) {
                   fetchDatasetsPerPage(1);
                 }}
               >
-                <span
-                  className="button-text"
-                  title={`TEXT: ${search.toUpperCase()}`}
-                >
+                <span className="button-text" title={`TEXT: ${search.toUpperCase()}`}>
                   {`TEXT: ${search.toUpperCase()}`}
                 </span>
-                <Icon
-                  name="icon-cross"
-                  className="-tiny"
-                />
+                <Icon name="icon-cross" className="-tiny" />
               </button>
             )}
           </div>
@@ -116,19 +98,16 @@ export default function ExploreDatasets(props) {
         </div>
       </div>
 
-      {relatedDashboards.length > 0
-        && (
+      {relatedDashboards.length > 0 && (
         <div className="related-dashboards">
           <div className="header">
             <h4>Related dashboards</h4>
             <Link href="/dashboards">
-              <a className="header-button">
-                SEE ALL
-              </a>
+              <a className="header-button">SEE ALL</a>
             </Link>
           </div>
           {relatedDashboards.map((dashboard) => (
-            <Link href={`/dashboards/${dashboard.slug}`}>
+            <Link key={dashboard.id} href={`/dashboards/${dashboard.slug}`} passHref>
               <div
                 className="dashboard-button"
                 style={{
@@ -139,19 +118,15 @@ export default function ExploreDatasets(props) {
                 onClick={() => logEvent('Explore Menu', 'Select Dashboard', dashboard.label)}
                 role="button"
                 tabIndex={0}
-                onKeyPress={() => {}}
               >
-                <div className="dashboard-title">
-                  {dashboard.label}
-                </div>
+                <div className="dashboard-title">{dashboard.label}</div>
               </div>
             </Link>
           ))}
         </div>
-        )}
+      )}
 
-      {!list.length && !loading
-        && (
+      {!list.length && !loading && (
         <div className="request-data-container">
           <div className="request-data-text">
             Oops! We couldn&#39;t find data for your search...
@@ -165,19 +140,16 @@ export default function ExploreDatasets(props) {
             Request data
           </a>
         </div>
-        )}
+      )}
 
       <DatasetList
         loading={loading}
         numberOfPlaceholders={20}
         list={list}
-        actions={(
-          <ExploreDatasetsActions />
-        )}
+        actions={<ExploreDatasetsActions />}
       />
 
-      {!!list.length && total > limit
-        && (
+      {!!list.length && total > limit && (
         <Paginator
           options={{
             page,
@@ -198,15 +170,14 @@ export default function ExploreDatasets(props) {
             fetchDatasetsPerPage(p);
           }}
         />
-        )}
-
+      )}
     </div>
   );
 }
 
 ExploreDatasets.propTypes = {
   datasets: PropTypes.shape({
-    selected: PropTypes.string.isRequired,
+    selected: PropTypes.string,
     list: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string.isRequired,
@@ -217,9 +188,7 @@ ExploreDatasets.propTypes = {
     page: PropTypes.number.isRequired,
     loading: PropTypes.bool.isRequired,
   }).isRequired,
-  selectedTags: PropTypes.arrayOf(
-    PropTypes.shape(),
-  ).isRequired,
+  selectedTags: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   search: PropTypes.string.isRequired,
   fetchDatasets: PropTypes.func.isRequired,
   setDatasetsPage: PropTypes.func.isRequired,

--- a/layout/explore/explore-datasets/list/list-item/component.js
+++ b/layout/explore/explore-datasets/list/list-item/component.js
@@ -81,7 +81,7 @@ class DatasetListItem extends React.Component {
   };
 
   render() {
-    const { dataset, metadata, actions, active } = this.props;
+    const { dataset, metadata, actions, active, filters, sort } = this.props;
 
     const dateLastUpdated = getDateConsideringTimeZone(dataset.dataLastUpdated, true);
     const classNameValue = classnames({
@@ -111,7 +111,16 @@ class DatasetListItem extends React.Component {
           {/* Title */}
           <div className="title-actions">
             <h4>
-              <Link href={`/data/explore/${dataset.slug}`}>
+              <Link
+                href={{
+                  pathname: `/data/explore/${dataset.slug}`,
+                  query: {
+                    ...(filters.search && { search: filters.search }),
+                    ...(sort.selected && { sort: sort.selected }),
+                    ...(sort.direction && { sortDirection: sort.direction }),
+                  },
+                }}
+              >
                 <a className="line-clamp-2">
                   {(metadata && metadata.info && metadata.info.name) || dataset.name}
                 </a>

--- a/layout/explore/explore-datasets/list/list-item/index.js
+++ b/layout/explore/explore-datasets/list/list-item/index.js
@@ -19,6 +19,8 @@ export default connect(
   (state, props) => ({
     user: state.user,
     active: isActive(state, props),
+    filters: state.explore.filters,
+    sort: state.explore.sort,
   }),
   {
     ...actions,

--- a/layout/explore/explore-datasets/list/selectors.js
+++ b/layout/explore/explore-datasets/list/selectors.js
@@ -4,18 +4,12 @@ import { createSelector } from 'reselect';
 import { getDateConsideringTimeZone } from 'utils/utils';
 
 const getDatasets = (state) => state.datasets.datasets.list;
-const getIsServer = (state) => state.common.isServer;
 
-export const getUpdatedDatasets = createSelector(
-  [getDatasets, getIsServer],
-  (_datasets, _isServer) => {
-    if (_isServer) return _datasets;
-
-    return _datasets.map((_dataset) => ({
-      ..._dataset,
-      dateLastUpdated: getDateConsideringTimeZone(_dataset.dataLastUpdated),
-    }));
-  },
-);
+export const getUpdatedDatasets = createSelector([getDatasets], (_datasets) => {
+  return _datasets.map((_dataset) => ({
+    ..._dataset,
+    dateLastUpdated: getDateConsideringTimeZone(_dataset.dataLastUpdated),
+  }));
+});
 
 export default { getUpdatedDatasets };

--- a/layout/explore/explore-datasets/selectors.js
+++ b/layout/explore/explore-datasets/selectors.js
@@ -4,28 +4,23 @@ import { createSelector } from 'reselect';
 import { getDateConsideringTimeZone } from 'utils/utils';
 
 const getDatasets = (state) => state.explore.datasets.list;
-const getIsServer = (state) => state.common.isServer;
 const getTags = (state) => state.explore.filters.tags;
 const getSelectedTags = (state) => state.explore.filters.selected.topics;
 
-export const getUpdatedDatasets = createSelector(
-  [getDatasets, getIsServer],
-  (_datasets, _isServer) => {
-    if (_isServer) return _datasets;
-
-    return _datasets.map((_dataset) => ({
-      ..._dataset,
-      dateLastUpdated: getDateConsideringTimeZone(_dataset.dataLastUpdated),
-    }));
-  },
-);
+export const getUpdatedDatasets = createSelector([getDatasets], (_datasets) => {
+  return _datasets.map((_dataset) => ({
+    ..._dataset,
+    dateLastUpdated: getDateConsideringTimeZone(_dataset.dataLastUpdated),
+  }));
+});
 
 export const getSelectedTagsWithData = createSelector(
   [getTags, getSelectedTags],
-  (_tags, _selectedTags) => _selectedTags.map((t) => ({
-    id: t,
-    label: _tags.find((e) => e.id === t).label,
-  })),
+  (_tags, _selectedTags) =>
+    _selectedTags.map((t) => ({
+      id: t,
+      label: _tags.find((e) => e.id === t).label,
+    })),
 );
 
 export default { getUpdatedDatasets, getSelectedTagsWithData };

--- a/layout/explore/explore-detail/explore-detail-header/component.jsx
+++ b/layout/explore/explore-detail/explore-detail-header/component.jsx
@@ -1,8 +1,6 @@
-import {
-  useState,
-  useCallback,
-} from 'react';
+import { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { useRouter } from 'next/router';
 
 // components
 import Icon from 'components/ui/icon';
@@ -16,12 +14,18 @@ import { getTooltipContainer } from 'utils/tooltip';
 // utils
 import { logEvent } from 'utils/analytics';
 
+// constants
+import { EXPLORE_SECTIONS } from 'layout/explore/constants';
+
 export default function ExploreDetailHeader({
   dataset,
   setSelectedDataset,
   userIsLoggedIn,
   isSidebarOpen,
+  setSidebarSection,
+  setFiltersSearch,
 }) {
+  const { query } = useRouter();
   const [showShareModal, setShowShareModal] = useState(false);
   const handleToggleFavorite = useCallback((isFavorite, resource) => {
     const datasetName = resource?.metadata[0]?.info?.name;
@@ -41,20 +45,35 @@ export default function ExploreDetailHeader({
     }
   }, []);
 
+  const handleGoBack = useCallback(() => {
+    const { search } = query;
+    setSelectedDataset(null);
+
+    if (search) {
+      setSidebarSection(EXPLORE_SECTIONS.ALL_DATA);
+      setFiltersSearch(search);
+    }
+  }, [query, setSelectedDataset, setSidebarSection, setFiltersSearch]);
+
   const location = typeof window !== 'undefined' && window.location;
-  const datasetName = dataset && dataset.metadata && dataset.metadata[0]
-      && dataset.metadata[0].info && dataset.metadata[0].info.name;
+  const datasetName =
+    dataset &&
+    dataset.metadata &&
+    dataset.metadata[0] &&
+    dataset.metadata[0].info &&
+    dataset.metadata[0].info.name;
 
   return (
     <div
       className="c-explore-detail-header"
       style={{
-        ...!isSidebarOpen && { position: 'absolute' },
+        ...(!isSidebarOpen && { position: 'absolute' }),
       }}
     >
       <button
+        type="button"
+        onClick={handleGoBack}
         className="c-btn -primary -compressed -fs-tiny all-datasets-button"
-        onClick={() => setSelectedDataset(null)}
       >
         <Icon className="-small" name="icon-arrow-left-2" />
         <span>ALL DATASETS</span>
@@ -69,14 +88,14 @@ export default function ExploreDetailHeader({
           }}
         >
           <Tooltip
-            overlay={(
+            overlay={
               <CollectionsPanel
                 resource={dataset}
                 resourceType="dataset"
                 onToggleFavorite={handleToggleFavorite}
                 onToggleCollection={handleToggleCollection}
               />
-            )}
+            }
             overlayClassName="c-rc-tooltip"
             placement="bottomRight"
             trigger="click"

--- a/layout/explore/explore-menu/component.jsx
+++ b/layout/explore/explore-menu/component.jsx
@@ -1,7 +1,4 @@
-import {
-  useCallback,
-  useMemo,
-} from 'react';
+import { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -42,11 +39,8 @@ const ExploreMenu = ({
   setFiltersSearch,
   toggleFiltersSelected,
   setFiltersSelected,
-  resetFiltersSelected,
 }) => {
-  const {
-    data: collections,
-  } = useFetchCollections(
+  const { data: collections } = useFetchCollections(
     token,
     {
       sort: 'name',
@@ -63,64 +57,65 @@ const ExploreMenu = ({
     fetchDatasets();
   }, [setDatasetsPage, fetchDatasets]);
 
-  const onChangeTextSearch = useCallback((_search) => {
-    if (!_search && sortSelected === 'relevance') {
-      resetFiltersSort();
-    }
-    setFiltersSearch(_search);
-    if (_search && shouldAutoUpdateSortDirection) {
-      setSortSelected('relevance');
-      setSortDirection(-1);
-    }
+  const onChangeTextSearch = useCallback(
+    (_search) => {
+      if (!_search && sortSelected === 'relevance') {
+        resetFiltersSort();
+      }
+      setFiltersSearch(_search);
+      if (_search && shouldAutoUpdateSortDirection) {
+        setSortSelected('relevance');
+        setSortDirection(-1);
+      }
 
-    setSidebarSection(EXPLORE_SECTIONS.ALL_DATA);
-    loadDatasets();
-    logEvent('Explore Menu', 'search', _search);
-  }, [
-    resetFiltersSort,
-    setFiltersSearch,
-    setSortSelected,
-    setSortDirection,
-    setSidebarSection,
-    loadDatasets,
-    shouldAutoUpdateSortDirection,
-    sortSelected,
-  ]);
-
-  const onToggleSelected = useCallback((payload) => {
-    if (section !== EXPLORE_SECTIONS.ALL_DATA) {
       setSidebarSection(EXPLORE_SECTIONS.ALL_DATA);
-    }
-    toggleFiltersSelected({ tag: payload, tab: 'topics' });
-    loadDatasets();
-  }, [section, setSidebarSection, toggleFiltersSelected, loadDatasets]);
+      loadDatasets();
+      logEvent('Explore Menu', 'search', _search);
+    },
+    [
+      resetFiltersSort,
+      setFiltersSearch,
+      setSortSelected,
+      setSortDirection,
+      setSidebarSection,
+      loadDatasets,
+      shouldAutoUpdateSortDirection,
+      sortSelected,
+    ],
+  );
 
-  const onChangeSelected = useCallback((payload = []) => {
-    setFiltersSelected({ key: tab, list: payload });
+  const onToggleSelected = useCallback(
+    (payload) => {
+      if (section !== EXPLORE_SECTIONS.ALL_DATA) {
+        setSidebarSection(EXPLORE_SECTIONS.ALL_DATA);
+      }
+      toggleFiltersSelected({ tag: payload, tab: 'topics' });
+      loadDatasets();
+    },
+    [section, setSidebarSection, toggleFiltersSelected, loadDatasets],
+  );
 
-    loadDatasets();
-    logEvent('Explore Menu', `filter ${tab}`, payload.join(','));
-  }, [setFiltersSelected, tab, loadDatasets]);
+  const onChangeSelected = useCallback(
+    (payload = []) => {
+      setFiltersSelected({ key: tab, list: payload });
 
-  const onResetSelected = useCallback(() => {
-    resetFiltersSelected();
+      loadDatasets();
+      logEvent('Explore Menu', `filter ${tab}`, payload.join(','));
+    },
+    [setFiltersSelected, tab, loadDatasets],
+  );
 
-    if (sortSelected === 'relevance') {
-      resetFiltersSort();
-    }
-
-    loadDatasets();
-    logEvent('Explore Menu', 'Clear filters', 'click');
-  }, [resetFiltersSelected, sortSelected, resetFiltersSort, loadDatasets]);
-
-  const collectionsWithDatasets = useMemo(() => collections
-    .filter(({ resources }) => resources.find(({ type }) => type === 'dataset')), [collections]);
+  const collectionsWithDatasets = useMemo(
+    () => collections.filter(({ resources }) => resources.find(({ type }) => type === 'dataset')),
+    [collections],
+  );
 
   return (
-    <div className={classnames({
-      'c-explore-menu': true,
-      '-hidden': selectedDataset,
-    })}
+    <div
+      className={classnames({
+        'c-explore-menu': true,
+        '-hidden': selectedDataset,
+      })}
     >
       <DatasetSearch
         open={open}
@@ -134,7 +129,6 @@ const ExploreMenu = ({
         onChangeTextSearch={onChangeTextSearch}
         onToggleSelected={onToggleSelected}
         onChangeSelected={onChangeSelected}
-        onResetSelected={onResetSelected}
       />
 
       <div className="menu-options">
@@ -192,7 +186,9 @@ const ExploreMenu = ({
             logEvent('Explore Menu', 'Clicks tab', EXPLORE_SECTIONS.NEAR_REAL_TIME);
           }}
         >
-          <Icon name={`icon-recent-${section === EXPLORE_SECTIONS.NEAR_REAL_TIME ? 'on' : 'off'}`} />
+          <Icon
+            name={`icon-recent-${section === EXPLORE_SECTIONS.NEAR_REAL_TIME ? 'on' : 'off'}`}
+          />
           Near Real-Time
         </div>
         <div
@@ -230,7 +226,9 @@ const ExploreMenu = ({
             logEvent('Explore Menu', 'Clicks tab', EXPLORE_SECTIONS.AREAS_OF_INTEREST);
           }}
         >
-          <Icon name={`icon-aoi-${section === EXPLORE_SECTIONS.AREAS_OF_INTEREST ? 'on' : 'off'}`} />
+          <Icon
+            name={`icon-aoi-${section === EXPLORE_SECTIONS.AREAS_OF_INTEREST ? 'on' : 'off'}`}
+          />
           Areas of Interest
         </div>
 
@@ -273,30 +271,32 @@ const ExploreMenu = ({
         >
           <span className="collection-name">My Favorites</span>
         </div>
-        {userIsLoggedIn && collectionsWithDatasets.map((collection) => (
-          <div
-            key={collection.id}
-            className={classnames({
-              'menu-option': true,
-              collection: true,
-              '-active': section === EXPLORE_SECTIONS.COLLECTIONS && selectedCollection === collection.id,
-            })}
-            role="button"
-            tabIndex={0}
-            onKeyPress={() => {
-              setSidebarSection(EXPLORE_SECTIONS.COLLECTIONS);
-              setSidebarSelectedCollection(collection.id);
-              logEvent('Explore Menu', 'Clicks tab', EXPLORE_SECTIONS.COLLECTIONS);
-            }}
-            onClick={() => {
-              setSidebarSection(EXPLORE_SECTIONS.COLLECTIONS);
-              setSidebarSelectedCollection(collection.id);
-              logEvent('Explore Menu', 'Clicks tab', EXPLORE_SECTIONS.COLLECTIONS);
-            }}
-          >
-            <span className="collection-name">{collection.name}</span>
-          </div>
-        ))}
+        {userIsLoggedIn &&
+          collectionsWithDatasets.map((collection) => (
+            <div
+              key={collection.id}
+              className={classnames({
+                'menu-option': true,
+                collection: true,
+                '-active':
+                  section === EXPLORE_SECTIONS.COLLECTIONS && selectedCollection === collection.id,
+              })}
+              role="button"
+              tabIndex={0}
+              onKeyPress={() => {
+                setSidebarSection(EXPLORE_SECTIONS.COLLECTIONS);
+                setSidebarSelectedCollection(collection.id);
+                logEvent('Explore Menu', 'Clicks tab', EXPLORE_SECTIONS.COLLECTIONS);
+              }}
+              onClick={() => {
+                setSidebarSection(EXPLORE_SECTIONS.COLLECTIONS);
+                setSidebarSelectedCollection(collection.id);
+                logEvent('Explore Menu', 'Clicks tab', EXPLORE_SECTIONS.COLLECTIONS);
+              }}
+            >
+              <span className="collection-name">{collection.name}</span>
+            </div>
+          ))}
       </div>
     </div>
   );
@@ -312,9 +312,7 @@ ExploreMenu.propTypes = {
   token: PropTypes.string,
   open: PropTypes.bool.isRequired,
   tab: PropTypes.string.isRequired,
-  tags: PropTypes.arrayOf(
-    PropTypes.shape({}),
-  ).isRequired,
+  tags: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   options: PropTypes.shape({}).isRequired,
   selected: PropTypes.shape({}).isRequired,
   search: PropTypes.string.isRequired,
@@ -333,7 +331,6 @@ ExploreMenu.propTypes = {
   setSortSelected: PropTypes.func.isRequired,
   setSortDirection: PropTypes.func.isRequired,
   toggleFiltersSelected: PropTypes.func.isRequired,
-  resetFiltersSelected: PropTypes.func.isRequired,
   resetFiltersSort: PropTypes.func.isRequired,
   setSidebarSection: PropTypes.func.isRequired,
   setSidebarSelectedCollection: PropTypes.func.isRequired,

--- a/layout/explore/reducers.js
+++ b/layout/explore/reducers.js
@@ -131,14 +131,6 @@ export default createReducer(initialState, (builder) => {
         filters,
       };
     })
-    .addCase(actions.resetFiltersSelected, (state) => ({
-      ...state,
-      filters: {
-        ...state.filters,
-        search: initialState.filters.search,
-        selected: initialState.filters.selected,
-      },
-    }))
     // sort
     .addCase(actions.setSortSelected, (state, { payload }) => ({
       ...state,

--- a/pages/data/explore/[[...dataset]].jsx
+++ b/pages/data/explore/[[...dataset]].jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { withRouter } from 'next/router';
 
 // actions
-import { setIsServer as setServerAction } from 'redactions/common';
 import * as actions from 'layout/explore/actions';
 
 // hoc
@@ -17,12 +16,6 @@ import { fetchDataset } from 'services/dataset';
 import Explore from 'layout/explore';
 
 class ExplorePage extends PureComponent {
-  componentDidMount() {
-    const { setIsServer } = this.props;
-
-    setIsServer(false);
-  }
-
   componentDidUpdate(prevProps) {
     if (this.shouldUpdateUrl(prevProps)) {
       this.setExploreURL();
@@ -95,18 +88,16 @@ class ExplorePage extends PureComponent {
       }),
     };
 
-    if (typeof window !== 'undefined') {
-      router.replace(
-        {
-          pathname: '/data/explore/[[...dataset]]',
-          query,
-        },
-        {},
-        {
-          shallow: true,
-        },
-      );
-    }
+    router.replace(
+      {
+        pathname: '/data/explore/[[...dataset]]',
+        query,
+      },
+      {},
+      {
+        shallow: true,
+      },
+    );
   }
 
   shouldUpdateUrl(prevProps) {
@@ -275,7 +266,9 @@ export const getServerSideProps = withRedux(
 
 ExplorePage.propTypes = {
   explore: PropTypes.shape({
-    datasets: PropTypes.arrayOf(PropTypes.shape({})),
+    datasets: PropTypes.shape({
+      selected: PropTypes.string,
+    }),
     filters: PropTypes.shape({
       search: PropTypes.string,
       selected: PropTypes.shape({
@@ -306,11 +299,10 @@ ExplorePage.propTypes = {
     }),
     sort: PropTypes.shape({
       selected: PropTypes.string,
-      direction: PropTypes.string,
+      direction: PropTypes.number,
     }),
   }).isRequired,
   resetExplore: PropTypes.func.isRequired,
-  setIsServer: PropTypes.func.isRequired,
   router: PropTypes.shape({
     replace: PropTypes.func.isRequired,
   }).isRequired,
@@ -318,5 +310,4 @@ ExplorePage.propTypes = {
 
 export default connect((state, pageProps) => ({ explore: state.explore, ...pageProps }), {
   ...actions,
-  setIsServer: setServerAction,
 })(withRouter(ExplorePage));

--- a/redactions/common.js
+++ b/redactions/common.js
@@ -1,26 +1,22 @@
-import {
-  HYDRATE,
-} from 'next-redux-wrapper';
+import { HYDRATE } from 'next-redux-wrapper';
 
 const SET_LOCALE = 'common/SET_LOCALE';
 const SET_EMBED = 'common/SET_EMBED';
 const SET_WEBSHOT = 'common/SET_WEBSHOT';
-const SET_IS_SERVER = 'common/SET_IS_SERVER';
 
 const initialState = {
   locale: 'en',
   embed: false,
   webshot: false,
-  isServer: true,
 };
 
 export default function commonReducer(state = initialState, action) {
   switch (action.type) {
     case HYDRATE:
-      return ({
+      return {
         ...state,
         ...action.payload.common,
-      });
+      };
     case SET_LOCALE:
       return { ...state, locale: action.payload };
 
@@ -29,10 +25,6 @@ export default function commonReducer(state = initialState, action) {
 
     case SET_WEBSHOT:
       return { ...state, webshot: action.payload };
-
-    case SET_IS_SERVER:
-      return { ...state, isServer: action.payload };
-
     default:
       return state;
   }
@@ -74,16 +66,5 @@ export function setWebshotMode(webshot) {
   return {
     type: SET_WEBSHOT,
     payload: webshot,
-  };
-}
-
-/**
- * Set if we are on the server side or not
- * @param {boolean} isServer boolean
- */
-export function setIsServer(isServer) {
-  return {
-    type: SET_IS_SERVER,
-    payload: isServer,
   };
 }


### PR DESCRIPTION
## Overview
![image](https://user-images.githubusercontent.com/999124/167403842-893abade-cd7e-485e-8491-c6ac043d1723.png)

Fixes navigation when a user searches for datasets. Before, after clicking on the "All Datasets" button, the page lost the search parametrization displaying the list of datasets without the user's filters. Now, the page keeps this parameterization allowing the user to keep looking at his/her search.

## Testing instructions
 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output

## Jira task / Github issue
https://vizzuality.atlassian.net/browse/RW-87

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
