### PR TITLE
takes into account map widget config for embed routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - bump `next@12.1.6`.
 
 ### Fixed
+- `/embed/map/{widget_id}` and `/data/widget/{widget_id}` routes take into account latitude/longitude values set in widget configuration. [RW-3](https://gfw.atlassian.net/browse/RW-3)
 - map overlay style that prevented a user could draw on the map.
 - typo in published layers checkbox. [RW-146](https://vizzuality.atlassian.net/browse/RW-146)
 - Explore: fixes navigation when a user clicks on "All datasets" button after searching. Now the search results remain. [RW-87](https://vizzuality.atlassian.net/browse/RW-87)

--- a/components/map/constants.ts
+++ b/components/map/constants.ts
@@ -85,7 +85,6 @@ export const DEFAULT_VIEWPORT: ViewportProps = {
   longitude: 0,
   pitch: 0,
   bearing: 0,
-  transitionDuration: 250,
 };
 
 export const USER_AREA_LAYER_TEMPLATES = {

--- a/components/widgets/types/map/component.tsx
+++ b/components/widgets/types/map/component.tsx
@@ -82,6 +82,9 @@ const MapTypeWidget = ({
   });
   const [viewport, setViewport] = useState<ViewportProps>({
     ...DEFAULT_VIEWPORT,
+    ...(widget?.widgetConfig?.lat && { latitude: widget.widgetConfig.lat }),
+    ...(widget?.widgetConfig?.lng && { longitude: widget.widgetConfig.lng }),
+    ...(widget?.widgetConfig?.zoom && { zoom: widget.widgetConfig.zoom }),
     height: 400,
   });
   const [isInfoWidgetVisible, setInfoWidgetVisibility] = useState(false);
@@ -170,6 +173,15 @@ const MapTypeWidget = ({
   );
 
   const caption = useMemo(() => widget?.metadata?.[0]?.info?.caption, [widget]);
+
+  useEffect(() => {
+    setViewport((prevViewport) => ({
+      ...prevViewport,
+      ...(widget?.widgetConfig?.lat && { latitude: widget.widgetConfig.lat }),
+      ...(widget?.widgetConfig?.lng && { longitude: widget.widgetConfig.lng }),
+      ...(widget?.widgetConfig?.zoom && { zoom: widget.widgetConfig.zoom }),
+    }));
+  }, [widget]);
 
   useEffect(() => {
     dispatch(setMapLayerGroups(layerGroups));

--- a/types/widget.d.ts
+++ b/types/widget.d.ts
@@ -32,12 +32,15 @@ export interface WidgetConfig {
   basemapLayers?: WidgetBasemapLayers;
   bbox?: [number, number, number, number];
   bounds?: number[];
-  paramsConfig?: WidgetParamsConfig;
+  data?: Record<string, string | number | unknown>[];
+  lat?: number;
+  layer_id?: string;
   layerParams?: LayerParams;
+  lng?: number;
+  paramsConfig?: WidgetParamsConfig;
   type?: WidgetTypes;
   url?: string;
-  data?: Record<string, string | number | unknown>[];
-  layer_id?: string;
+  zoom?: number;
 }
 
 export interface WidgetLink {


### PR DESCRIPTION
## Overview
Now `/embed/map/{widget_id}` and `/data/widget/{widget_id}` routes take into account map paramesitration (`lat`, `lng` and `zoom` attributes) coming from widget configuration.

## Testing instructions
 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output

## Jira task / Github issue
https://gfw.atlassian.net/browse/RW-3

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
- [x] Add entry to CHANGELOG.md, if appropriate
