### PR TITLE
updates default Pardot URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - rich schema script for specific datasets. [RW-141](https://vizzuality.atlassian.net/browse/RW-141)
 
 ### Changed
+- updates default Pardot URL to custom one.[RW-8](https://gfw.atlassian.net/browse/RW-8)
 - dataset fetching determined by `NEXT_PUBLIC_ENVS_SHOW` environmental variable.
 - bump `moment@2.29.3`.
 - Coral Reefs dashboard: text changes. [RW-137](https://vizzuality.atlassian.net/browse/RW-137)

--- a/constants/app.ts
+++ b/constants/app.ts
@@ -11,3 +11,5 @@ export const TRANSIFEX_BLACKLIST = [
 ];
 
 export const HOTJAR_ROUTES = ['/data/explore'];
+
+export const PARDOT_FORM_HANDLER = 'https://connect.wri.org/l/120942/2021-06-01/53bndz';

--- a/layout/app/newsletter/component.tsx
+++ b/layout/app/newsletter/component.tsx
@@ -1,7 +1,4 @@
-import {
-  useState,
-} from 'react';
-import PropTypes from 'prop-types';
+import { useState } from 'react';
 import Link from 'next/link';
 
 // components
@@ -16,20 +13,31 @@ import Modal from 'components/modal/modal-component';
 import NewsletterConfirmationModal from 'components/modal/newsletter-confirmation-modal';
 
 // constants
-import {
-  FORM_COUNTRIES,
-  PARDOT_NEWSLETTER_URL,
-} from './constants';
+import { PARDOT_FORM_HANDLER } from 'constants/app';
+import { FORM_COUNTRIES } from './constants';
 
-export default function LayoutNewsletter({
-  isOceanWatch,
-}) {
-  const [form, setForm] = useState({});
+import { LayoutNewsletterProps } from './types';
+
+const LayoutNewsletter = ({ isOceanWatch }: LayoutNewsletterProps): JSX.Element => {
+  const [form, setForm] = useState({
+    first_name: '',
+    last_name: '',
+    email: '',
+    city: '',
+    country: '',
+    company: '',
+    job_title: '',
+    resource_watch_feature_test_group: false,
+  });
   const [modalVisibility, setModalVisibility] = useState(false);
 
-  const onSubmit = () => { setModalVisibility(true); };
+  const onSubmit = () => {
+    setModalVisibility(true);
+  };
 
-  const onChange = (value) => { setForm({ ...form, ...value }); };
+  const onChange = (value: Partial<typeof form>) => {
+    setForm({ ...form, ...value });
+  };
 
   return (
     <Layout
@@ -43,9 +51,7 @@ export default function LayoutNewsletter({
           <div className="row">
             <div className="column small-12">
               <div className="page-header-content">
-                <Breadcrumbs
-                  items={[{ name: 'About', route: '/about' }]}
-                />
+                <Breadcrumbs items={[{ name: 'About', route: '/about' }]} />
                 <h1>Newsletter</h1>
               </div>
             </div>
@@ -56,23 +62,22 @@ export default function LayoutNewsletter({
         <div className="l-container">
           <div className="row align-center">
             <div className="column small-12 medium-8">
-              <h2>
-                Sign up for Resource Watch news
-              </h2>
+              <h2>Sign up for Resource Watch news</h2>
               <p>
-                Don’t miss out on training announcements, our monthly newsletter,
-                exclusive tips for using the platform,
-                and the latest stories on the pulse of the planet.
+                Don&apos;t miss out on training announcements, our monthly newsletter, exclusive
+                tips for using the platform, and the latest stories on the pulse of the planet.
               </p>
             </div>
           </div>
           <div className="row align-center">
             <div className="column small-12 medium-8">
               <form
-                action={PARDOT_NEWSLETTER_URL}
-                onSubmit={onSubmit}
-                className="c-form"
                 id="pardot-form"
+                className="c-form"
+                // ! Pardot doesn't support submitting data to form handlers via Ajax requests:
+                // ! https://help.salesforce.com/s/articleView?id=pardot_considerations_for_using_form_handlers.htm&type=5&language=en_US
+                action={PARDOT_FORM_HANDLER}
+                onSubmit={onSubmit}
               >
                 <div className="form-row">
                   <Field
@@ -174,9 +179,11 @@ export default function LayoutNewsletter({
 
                 <div className="form-row">
                   <Field
-                    onChange={(value) => onChange({
-                      resource_watch_feature_test_group: value.checked,
-                    })}
+                    onChange={(value) =>
+                      onChange({
+                        resource_watch_feature_test_group: value.checked,
+                      })
+                    }
                     properties={{
                       name: 'resource_watch_feature_test_group',
                       defaultChecked: false,
@@ -186,7 +193,7 @@ export default function LayoutNewsletter({
                     {Checkbox}
                   </Field>
                 </div>
-                { /* pardot honeypot field */}
+                {/* pardot honeypot field */}
                 <Field
                   className="-pi-hidden"
                   properties={{
@@ -215,10 +222,7 @@ export default function LayoutNewsletter({
                 )}
 
                 <div className="c-button-container -j-end">
-                  <button
-                    type="submit"
-                    className="c-btn -primary"
-                  >
+                  <button type="submit" className="c-btn -primary">
                     Sign up
                   </button>
                 </div>
@@ -232,12 +236,13 @@ export default function LayoutNewsletter({
         <div className="l-container">
           <div className="row align-center">
             <div className="column small-12">
-              <Banner className="-text-center" bgImage="/static/images/backgrounds/partners-02@2x.jpg">
+              <Banner
+                className="-text-center"
+                bgImage="/static/images/backgrounds/partners-02@2x.jpg"
+              >
                 <p className="-claim">
                   Let&rsquo;s build a more sustainable
-                  <br />
-                  {' '}
-                  world together.
+                  <br /> world together.
                 </p>
                 <Link href="/about/partners">
                   <a className="c-btn -primary">Partners</a>
@@ -248,20 +253,11 @@ export default function LayoutNewsletter({
         </div>
       </aside>
 
-      <Modal
-        isOpen={modalVisibility}
-        onRequestClose={() => setModalVisibility(false)}
-      >
+      <Modal isOpen={modalVisibility} onRequestClose={() => setModalVisibility(false)}>
         <NewsletterConfirmationModal />
       </Modal>
     </Layout>
   );
-}
-
-LayoutNewsletter.defaultProps = {
-  isOceanWatch: false,
 };
 
-LayoutNewsletter.propTypes = {
-  isOceanWatch: PropTypes.bool,
-};
+export default LayoutNewsletter;

--- a/layout/app/newsletter/constants.ts
+++ b/layout/app/newsletter/constants.ts
@@ -53,7 +53,7 @@ export const FORM_COUNTRIES = {
     { value: '817057', label: 'Congo, the Democratic Republic of the' },
     { value: '817059', label: 'Cook Islands' },
     { value: '817061', label: 'Costa Rica' },
-    { value: '817063', label: 'Côte d\'Ivoire' },
+    { value: '817063', label: "Côte d'Ivoire" },
     { value: '817065', label: 'Croatia' },
     { value: '817067', label: 'Cuba' },
     { value: '817069', label: 'Curaçao' },
@@ -116,11 +116,11 @@ export const FORM_COUNTRIES = {
     { value: '817183', label: 'Kazakhstan' },
     { value: '817185', label: 'Kenya' },
     { value: '817187', label: 'Kiribati' },
-    { value: '817189', label: 'Korea, Democratic People\'s Republic of' },
+    { value: '817189', label: "Korea, Democratic People's Republic of" },
     { value: '817191', label: 'Korea, Republic of' },
     { value: '817193', label: 'Kuwait' },
     { value: '817195', label: 'Kyrgyzstan' },
-    { value: '817197', label: 'Lao People\'s Democratic Republic' },
+    { value: '817197', label: "Lao People's Democratic Republic" },
     { value: '817199', label: 'Latvia' },
     { value: '817201', label: 'Lebanon' },
     { value: '817203', label: 'Lesotho' },
@@ -250,5 +250,3 @@ export const FORM_COUNTRIES = {
     { value: '817451', label: 'Zimbabwe' },
   ],
 };
-
-export const PARDOT_NEWSLETTER_URL = 'https://go.pardot.com/l/120942/2018-01-25/3nzl13';

--- a/layout/app/newsletter/types.d.ts
+++ b/layout/app/newsletter/types.d.ts
@@ -1,0 +1,3 @@
+export interface LayoutNewsletterProps {
+  isOceanWatch?: boolean;
+}

--- a/layout/explore/explore-my-data/coming-soon/component.tsx
+++ b/layout/explore/explore-my-data/coming-soon/component.tsx
@@ -1,7 +1,4 @@
-import {
-  useState,
-  useCallback,
-} from 'react';
+import { useState, useCallback } from 'react';
 
 // components
 import CardPlaceholder from 'components/card-placeholder';
@@ -9,17 +6,16 @@ import Field from 'components/form/Field';
 import Input from 'components/form/Input';
 
 // hooks
-import {
-  useMe,
-} from 'hooks/user';
+import { useMe } from 'hooks/user';
 
 // utils
 import { logEvent } from 'utils/analytics';
 
-export default function MyDataComingSoon() {
-  const {
-    data: user,
-  } = useMe();
+// constants
+import { PARDOT_FORM_HANDLER } from 'constants/app';
+
+const MyDataComingSoon = (): JSX.Element => {
+  const { data: user } = useMe();
   const [form, setForm] = useState({
     email: user?.email || '',
   });
@@ -28,12 +24,15 @@ export default function MyDataComingSoon() {
     logEvent('Explore Menu', 'My Data', 'clicks on "I\'m interested" button');
   }, []);
 
-  const onChangeEmail = useCallback((value) => {
-    setForm({
-      ...form,
-      ...{ email: value },
-    });
-  }, [form]);
+  const onChangeEmail = useCallback(
+    (value: typeof form.email) => {
+      setForm({
+        ...form,
+        ...{ email: value },
+      });
+    },
+    [form],
+  );
 
   return (
     <div className="c-explore-my-data-coming-soon">
@@ -45,15 +44,16 @@ export default function MyDataComingSoon() {
           Resource Watch?
         </h4>
         <p>
-          We are exploring ways to let you bring your data to the platform.
-          Would you use this feature? Let us know.
+          We are exploring ways to let you bring your data to the platform. Would you use this
+          feature? Let us know.
         </p>
 
         <form
           id="my-data-sign-up"
           className="c-form my-data-form"
-          // Pardot doesn't support submitting data to form handlers via Ajax requests.
-          action="https://connect.wri.org/l/120942/2021-06-01/53bndz"
+          // ! Pardot doesn't support submitting data to form handlers via Ajax requests:
+          // ! https://help.salesforce.com/s/articleView?id=pardot_considerations_for_using_form_handlers.htm&type=5&language=en_US
+          action={PARDOT_FORM_HANDLER}
           onSubmit={onSubmit}
         >
           <Field
@@ -72,8 +72,7 @@ export default function MyDataComingSoon() {
           >
             {Input}
           </Field>
-
-          { /* pardot honeypot field – anti-spam protection */}
+          {/* pardot honeypot field – anti-spam protection */}
           <Field
             className="-pi-hidden"
             properties={{
@@ -85,11 +84,8 @@ export default function MyDataComingSoon() {
           >
             {Input}
           </Field>
-          <button
-            type="submit"
-            className="c-button -primary -compressed"
-          >
-            I’m interested
+          <button type="submit" className="c-button -primary -compressed">
+            I&apos;m interested
           </button>
         </form>
       </div>
@@ -97,4 +93,6 @@ export default function MyDataComingSoon() {
       <CardPlaceholder />
     </div>
   );
-}
+};
+
+export default MyDataComingSoon;


### PR DESCRIPTION
## Overview
As per [requested by Pardot](https://help.salesforce.com/s/articleView?id=000364239&type=1), Resource Watch stops using default _go.pardot.com_ URLs and uses a custom one provided by WRI.

## Testing instructions
 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output

## Jira task / Github issue
https://gfw.atlassian.net/browse/RW-8

## Checklist before submitting
- [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Add entry to CHANGELOG.md, if appropriate
